### PR TITLE
init checkState in initFromStore

### DIFF
--- a/app/baseapp.go
+++ b/app/baseapp.go
@@ -216,7 +216,6 @@ func (app *BaseApp) LastBlockHeight() int64 {
 
 // initializes the remaining logic from app.cms
 func (app *BaseApp) initFromStore(mainKey sdk.StoreKey) error {
-
 	// main store should exist.
 	// TODO: we don't actually need the main store here
 	main := app.cms.GetKVStore(mainKey)
@@ -224,6 +223,7 @@ func (app *BaseApp) initFromStore(mainKey sdk.StoreKey) error {
 		return errors.New("baseapp expects MultiStore with 'main' KVStore")
 	}
 
+	app.setCheckState(abci.Header{})
 	return nil
 }
 
@@ -286,7 +286,6 @@ func (app *BaseApp) SetOption(req abci.RequestSetOption) (res abci.ResponseSetOp
 func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitChain) {
 	// Initialize the deliver state and check state with ChainID and run initChain
 	app.setDeliverState(abci.Header{ChainID: req.ChainId})
-	app.setCheckState(abci.Header{ChainID: req.ChainId})
 
 	if app.initChainer == nil {
 		return


### PR DESCRIPTION
in cosmos-sdk 0.22.0, the init of checkState is moved to InitChain which results in node restart failure.