### PR TITLE
add pre_commit target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ test_unit:
 	@go test $(PACKAGES)
 
 ########################################
+### Pre Commit
+pre_commit: build test format
+
+########################################
 ### Local validator nodes using docker and docker-compose
 build-docker-node:
 	$(MAKE) -C networks/local


### PR DESCRIPTION
*PLS* ensure that you have run `make pre_commit` before checking in code, for we have to make sure that building and testing are passed.

We can add a pre-commit hook for git. Just put the below code into a hook file-".git/hooks/pre-commit":
``` shell
#!/bin/sh

PACKAGES=$(go list ./... | grep -v '/vendor/')
unformatted=$(cd ../../../ && gofmt -l $PACKAGES && goimports -l -local github.com/BiJie/BinanceChain $PACKAGES)

[ -n "$unformatted" ] && echo "Files are found unformatted, please execute 'make pre_commit' and then try again." && exit 1

exec make pre_commit
```
Before committing the code, the command `exec make pre_commit` will executed automatically.