### PR TITLE
One Msg for One Tx

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/BiJie/BinanceChain/wire"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
@@ -23,6 +22,7 @@ import (
 	"github.com/BiJie/BinanceChain/plugins/ico"
 	"github.com/BiJie/BinanceChain/plugins/tokens"
 	tokenStore "github.com/BiJie/BinanceChain/plugins/tokens/store"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 const (
@@ -98,7 +98,7 @@ func (app *BinanceChain) SetCheckState(header abci.Header) {
 }
 
 func (app *BinanceChain) registerHandlers() {
-	app.Router().AddRoute("bank", bank.NewHandler(app.CoinKeeper))
+	// app.Router().AddRoute("bank", bank.NewHandler(app.CoinKeeper))
 	// AddRoute("ibc", ibc.NewHandler(ibcMapper, coinKeeper)).
 	// AddRoute("simplestake", simplestake.NewHandler(stakeKeeper))
 	for route, handler := range tokens.Routes(app.TokenMapper, app.AccountMapper, app.CoinKeeper) {
@@ -116,7 +116,7 @@ func MakeCodec() *wire.Codec {
 
 	wire.RegisterCrypto(cdc) // Register crypto.
 	bank.RegisterWire(cdc)
-	sdk.RegisterWire(cdc) // Register Msgs
+	tx.RegisterWire(cdc) // Register Msgs
 	dex.RegisterWire(cdc)
 	tokens.RegisterWire(cdc)
 	types.RegisterWire(cdc)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -8,20 +8,18 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/abci/client"
+	"github.com/tendermint/tendermint/abci/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/libs/db"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
 
-	"github.com/BiJie/BinanceChain/wire"
-
-	"github.com/tendermint/tendermint/abci/client"
-	"github.com/tendermint/tendermint/abci/types"
-
-	"github.com/tendermint/tendermint/libs/db"
-
+	"github.com/BiJie/BinanceChain/common/tx"
 	common "github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/plugins/dex"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 type TestClient struct {
@@ -29,26 +27,26 @@ type TestClient struct {
 	cdc *wire.Codec
 }
 
-func (tc *TestClient) DeliverTxAsync(msg sdk.Msg, cdc *wire.Codec) *abcicli.ReqRes {
-	stdtx := auth.NewStdTx([]sdk.Msg{msg}, auth.NewStdFee(0), nil, "test")
+func (tc *TestClient) DeliverTxAsync(msg tx.Msg, cdc *wire.Codec) *abcicli.ReqRes {
+	stdtx := tx.NewStdTx(msg, tx.NewStdFee(0), nil, "test")
 	tx, _ := tc.cdc.MarshalBinary(stdtx)
 	return tc.cl.DeliverTxAsync(tx)
 }
 
-func (tc *TestClient) CheckTxAsync(msg sdk.Msg, cdc *wire.Codec) *abcicli.ReqRes {
-	stdtx := auth.NewStdTx([]sdk.Msg{msg}, auth.NewStdFee(0), nil, "test")
+func (tc *TestClient) CheckTxAsync(msg tx.Msg, cdc *wire.Codec) *abcicli.ReqRes {
+	stdtx := tx.NewStdTx(msg, tx.NewStdFee(0), nil, "test")
 	tx, _ := tc.cdc.MarshalBinary(stdtx)
 	return tc.cl.CheckTxAsync(tx)
 }
 
-func (tc *TestClient) DeliverTxSync(msg sdk.Msg, cdc *wire.Codec) (*types.ResponseDeliverTx, error) {
-	stdtx := auth.NewStdTx([]sdk.Msg{msg}, auth.NewStdFee(0), nil, "test")
+func (tc *TestClient) DeliverTxSync(msg tx.Msg, cdc *wire.Codec) (*types.ResponseDeliverTx, error) {
+	stdtx := tx.NewStdTx(msg, tx.NewStdFee(0), nil, "test")
 	tx, _ := tc.cdc.MarshalBinary(stdtx)
 	return tc.cl.DeliverTxSync(tx)
 }
 
-func (tc *TestClient) CheckTxSync(msg sdk.Msg, cdc *wire.Codec) (*types.ResponseCheckTx, error) {
-	stdtx := auth.NewStdTx([]sdk.Msg{msg}, auth.NewStdFee(0), nil, "test")
+func (tc *TestClient) CheckTxSync(msg tx.Msg, cdc *wire.Codec) (*types.ResponseCheckTx, error) {
+	stdtx := tx.NewStdTx(msg, tx.NewStdFee(0), nil, "test")
 	tx, _ := tc.cdc.MarshalBinary(stdtx)
 	return tc.cl.CheckTxSync(tx)
 }

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -5,20 +5,22 @@ import (
 	"github.com/tendermint/tendermint/abci/server"
 	abci "github.com/tendermint/tendermint/abci/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
+
+	"github.com/BiJie/BinanceChain/common/tx"
 )
 
 // nolint - Mostly for testing
-func (app *BaseApp) Check(tx sdk.Tx) (result sdk.Result) {
+func (app *BaseApp) Check(tx tx.Tx) (result sdk.Result) {
 	return app.runTx(runTxModeCheck, nil, tx)
 }
 
 // nolint - full tx execution
-func (app *BaseApp) Simulate(tx sdk.Tx) (result sdk.Result) {
+func (app *BaseApp) Simulate(tx tx.Tx) (result sdk.Result) {
 	return app.runTx(runTxModeSimulate, nil, tx)
 }
 
 // nolint
-func (app *BaseApp) Deliver(tx sdk.Tx) (result sdk.Result) {
+func (app *BaseApp) Deliver(tx tx.Tx) (result sdk.Result) {
 	return app.runTx(runTxModeDeliver, nil, tx)
 }
 

--- a/app/router.go
+++ b/app/router.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"regexp"
+
+	"github.com/BiJie/BinanceChain/common/tx"
+)
+
+// Router provides handlers for each transaction type.
+type Router interface {
+	AddRoute(r string, h tx.Handler) (rtr Router)
+	Route(path string) (h tx.Handler)
+}
+
+// map a transaction type to a handler and an initgenesis function
+type route struct {
+	r string
+	h tx.Handler
+}
+
+type router struct {
+	routes []route
+}
+
+// nolint
+// NewRouter - create new router
+// TODO either make Function unexported or make return type (router) Exported
+func NewRouter() *router {
+	return &router{
+		routes: make([]route, 0),
+	}
+}
+
+var isAlpha = regexp.MustCompile(`^[a-zA-Z]+$`).MatchString
+
+// AddRoute - TODO add description
+func (rtr *router) AddRoute(r string, h tx.Handler) Router {
+	if !isAlpha(r) {
+		panic("route expressions can only contain alphabet characters")
+	}
+	rtr.routes = append(rtr.routes, route{r, h})
+
+	return rtr
+}
+
+// Route - TODO add description
+// TODO handle expressive matches.
+func (rtr *router) Route(path string) (h tx.Handler) {
+	for _, route := range rtr.routes {
+		if route.r == path {
+			return route.h
+		}
+	}
+	return nil
+}

--- a/common/tx/ante.go
+++ b/common/tx/ante.go
@@ -19,9 +19,9 @@ const (
 // and increments sequence numbers, checks signatures & account numbers,
 // and deducts fees from the first signer.
 // nolint: gocyclo
-func NewAnteHandler(am auth.AccountMapper, fck FeeCollectionKeeper) sdk.AnteHandler {
+func NewAnteHandler(am auth.AccountMapper, fck FeeCollectionKeeper) AnteHandler {
 	return func(
-		ctx sdk.Context, tx sdk.Tx,
+		ctx sdk.Context, tx Tx,
 	) (newCtx sdk.Context, res sdk.Result, abort bool) {
 
 		// This AnteHandler requires Txs to be StdTxs
@@ -59,7 +59,7 @@ func NewAnteHandler(am auth.AccountMapper, fck FeeCollectionKeeper) sdk.AnteHand
 
 		sigs := stdTx.GetSignatures()
 		signerAddrs := stdTx.GetSigners()
-		msgs := tx.GetMsgs()
+		msg := tx.GetMsg()
 
 		// charge gas for the memo
 		newCtx.GasMeter().ConsumeGas(memoCostPerByte*sdk.Gas(len(stdTx.GetMemo())), "memo")
@@ -79,7 +79,7 @@ func NewAnteHandler(am auth.AccountMapper, fck FeeCollectionKeeper) sdk.AnteHand
 			signerAddr, sig := signerAddrs[i], sigs[i]
 
 			// check signature, return account with incremented nonce
-			signBytes := StdSignBytes(newCtx.ChainID(), accNums[i], sequences[i], fee, msgs, stdTx.GetMemo())
+			signBytes := StdSignBytes(newCtx.ChainID(), accNums[i], sequences[i], fee, msg, stdTx.GetMemo())
 			signerAcc, res := processSig(
 				newCtx, am,
 				signerAddr, sig, signBytes,

--- a/common/tx/ante_test.go
+++ b/common/tx/ante_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
@@ -12,14 +14,11 @@ import (
 
 	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/common/utils"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	wire "github.com/cosmos/cosmos-sdk/wire"
-	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
-func newTestMsg(addrs ...sdk.AccAddress) *sdk.TestMsg {
-	return sdk.NewTestMsg(addrs...)
+func newTestMsg(addrs ...sdk.AccAddress) *tx.TestMsg {
+	return tx.NewTestMsg(addrs...)
 }
 
 func newStdFee() tx.StdFee {
@@ -43,7 +42,7 @@ func privAndAddr() (crypto.PrivKey, sdk.AccAddress) {
 }
 
 // run the tx through the anteHandler and ensure its valid
-func checkValidTx(t *testing.T, anteHandler sdk.AnteHandler, ctx sdk.Context, tx sdk.Tx) {
+func checkValidTx(t *testing.T, anteHandler tx.AnteHandler, ctx sdk.Context, tx tx.Tx) {
 	_, result, abort := anteHandler(ctx, tx)
 	require.False(t, abort)
 	require.Equal(t, sdk.ABCICodeOK, result.Code)
@@ -51,7 +50,7 @@ func checkValidTx(t *testing.T, anteHandler sdk.AnteHandler, ctx sdk.Context, tx
 }
 
 // run the tx through the anteHandler and ensure it fails with the given code
-func checkInvalidTx(t *testing.T, anteHandler sdk.AnteHandler, ctx sdk.Context, tx sdk.Tx, code sdk.CodeType) {
+func checkInvalidTx(t *testing.T, anteHandler tx.AnteHandler, ctx sdk.Context, tx tx.Tx, code sdk.CodeType) {
 	defer func() {
 		if r := recover(); r != nil {
 			switch r.(type) {
@@ -69,36 +68,34 @@ func checkInvalidTx(t *testing.T, anteHandler sdk.AnteHandler, ctx sdk.Context, 
 		fmt.Sprintf("Expected %v, got %v", sdk.ToABCICode(sdk.CodespaceRoot, code), result))
 }
 
-func newTestTx(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums []int64, seqs []int64, fee tx.StdFee) sdk.Tx {
+func newTestTx(ctx sdk.Context, msg tx.Msg, privs []crypto.PrivKey, accNums []int64, seqs []int64, fee tx.StdFee) tx.Tx {
 	sigs := make([]tx.StdSignature, len(privs))
 	for i, priv := range privs {
-		signBytes := tx.StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], fee, msgs, "")
+		signBytes := tx.StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], fee, msg, "")
 		sig, err := priv.Sign(signBytes)
 		if err != nil {
 			panic(err)
 		}
 		sigs[i] = tx.StdSignature{PubKey: priv.PubKey(), Signature: sig, AccountNumber: accNums[i], Sequence: seqs[i]}
 	}
-	tx := tx.NewStdTx(msgs, fee, sigs, "")
-	return tx
+	return tx.NewStdTx(msg, fee, sigs, "")
 }
 
-func newTestTxWithMemo(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums []int64, seqs []int64, fee tx.StdFee, memo string) sdk.Tx {
+func newTestTxWithMemo(ctx sdk.Context, msg tx.Msg, privs []crypto.PrivKey, accNums []int64, seqs []int64, fee tx.StdFee, memo string) tx.Tx {
 	sigs := make([]tx.StdSignature, len(privs))
 	for i, priv := range privs {
-		signBytes := tx.StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], fee, msgs, memo)
+		signBytes := tx.StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], fee, msg, memo)
 		sig, err := priv.Sign(signBytes)
 		if err != nil {
 			panic(err)
 		}
 		sigs[i] = tx.StdSignature{PubKey: priv.PubKey(), Signature: sig, AccountNumber: accNums[i], Sequence: seqs[i]}
 	}
-	tx := tx.NewStdTx(msgs, fee, sigs, memo)
-	return tx
+	return tx.NewStdTx(msg, fee, sigs, memo)
 }
 
 // All signers sign over the same StdSignDoc. Should always create invalid signatures
-func newTestTxWithSignBytes(msgs []sdk.Msg, privs []crypto.PrivKey, accNums []int64, seqs []int64, fee tx.StdFee, signBytes []byte, memo string) sdk.Tx {
+func newTestTxWithSignBytes(msg tx.Msg, privs []crypto.PrivKey, accNums []int64, seqs []int64, fee tx.StdFee, signBytes []byte, memo string) tx.Tx {
 	sigs := make([]tx.StdSignature, len(privs))
 	for i, priv := range privs {
 		sig, err := priv.Sign(signBytes)
@@ -107,7 +104,7 @@ func newTestTxWithSignBytes(msgs []sdk.Msg, privs []crypto.PrivKey, accNums []in
 		}
 		sigs[i] = tx.StdSignature{PubKey: priv.PubKey(), Signature: sig, AccountNumber: accNums[i], Sequence: seqs[i]}
 	}
-	tx := tx.NewStdTx(msgs, fee, sigs, memo)
+	tx := tx.NewStdTx(msg, fee, sigs, memo)
 	return tx
 }
 
@@ -124,23 +121,20 @@ func TestAnteHandlerSigErrors(t *testing.T) {
 
 	// keys and addresses
 	priv1, addr1 := privAndAddr()
-	priv2, addr2 := privAndAddr()
-	priv3, addr3 := privAndAddr()
+	_, addr2 := privAndAddr()
+	priv3, _ := privAndAddr()
 
 	// msg and signatures
-	var txn sdk.Tx
-	msg1 := newTestMsg(addr1, addr2)
-	msg2 := newTestMsg(addr1, addr3)
+	var txn tx.Tx
+	msg := newTestMsg(addr1, addr2)
 	fee := newStdFee()
-
-	msgs := []sdk.Msg{msg1, msg2}
 
 	// test no signatures
 	privs, accNums, seqs := []crypto.PrivKey{}, []int64{}, []int64{}
-	txn = newTestTx(ctx, msgs, privs, accNums, seqs, fee)
+	txn = newTestTx(ctx, msg, privs, accNums, seqs, fee)
 
 	// tx.GetSigners returns addresses in correct order: addr1, addr2, addr3
-	expectedSigners := []sdk.AccAddress{addr1, addr2, addr3}
+	expectedSigners := []sdk.AccAddress{addr1, addr2}
 	stdTx := txn.(tx.StdTx)
 	require.Equal(t, expectedSigners, stdTx.GetSigners())
 
@@ -149,12 +143,12 @@ func TestAnteHandlerSigErrors(t *testing.T) {
 
 	// test num sigs dont match GetSigners
 	privs, accNums, seqs = []crypto.PrivKey{priv1}, []int64{0}, []int64{0}
-	txn = newTestTx(ctx, msgs, privs, accNums, seqs, fee)
+	txn = newTestTx(ctx, msg, privs, accNums, seqs, fee)
 	checkInvalidTx(t, anteHandler, ctx, txn, sdk.CodeUnauthorized)
 
 	// test an unrecognized account
-	privs, accNums, seqs = []crypto.PrivKey{priv1, priv2, priv3}, []int64{0, 1, 2}, []int64{0, 0, 0}
-	txn = newTestTx(ctx, msgs, privs, accNums, seqs, fee)
+	privs, accNums, seqs = []crypto.PrivKey{priv1, priv3}, []int64{0, 2}, []int64{0, 0}
+	txn = newTestTx(ctx, msg, privs, accNums, seqs, fee)
 	checkInvalidTx(t, anteHandler, ctx, txn, sdk.CodeUnknownAddress)
 
 	// save the first account, but second is still unrecognized
@@ -188,38 +182,34 @@ func TestAnteHandlerAccountNumbers(t *testing.T) {
 	mapper.SetAccount(ctx, acc2)
 
 	// msg and signatures
-	var tx sdk.Tx
+	var tx tx.Tx
 	msg := newTestMsg(addr1)
 	fee := newStdFee()
 
-	msgs := []sdk.Msg{msg}
-
 	// test good tx from one signer
 	privs, accnums, seqs := []crypto.PrivKey{priv1}, []int64{0}, []int64{0}
-	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	tx = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkValidTx(t, anteHandler, ctx, tx)
 
 	// new tx from wrong account number
 	seqs = []int64{1}
-	tx = newTestTx(ctx, msgs, privs, []int64{1}, seqs, fee)
+	tx = newTestTx(ctx, msg, privs, []int64{1}, seqs, fee)
 	checkInvalidTx(t, anteHandler, ctx, tx, sdk.CodeInvalidSequence)
 
 	// from correct account number
 	seqs = []int64{1}
-	tx = newTestTx(ctx, msgs, privs, []int64{0}, seqs, fee)
+	tx = newTestTx(ctx, msg, privs, []int64{0}, seqs, fee)
 	checkValidTx(t, anteHandler, ctx, tx)
 
 	// new tx with another signer and incorrect account numbers
-	msg1 := newTestMsg(addr1, addr2)
-	msg2 := newTestMsg(addr2, addr1)
-	msgs = []sdk.Msg{msg1, msg2}
+	msg = newTestMsg(addr1, addr2)
 	privs, accnums, seqs = []crypto.PrivKey{priv1, priv2}, []int64{1, 0}, []int64{2, 0}
-	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	tx = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkInvalidTx(t, anteHandler, ctx, tx, sdk.CodeInvalidSequence)
 
 	// correct account numbers
 	privs, accnums, seqs = []crypto.PrivKey{priv1, priv2}, []int64{0, 1}, []int64{2, 0}
-	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	tx = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkValidTx(t, anteHandler, ctx, tx)
 }
 
@@ -237,7 +227,6 @@ func TestAnteHandlerSequences(t *testing.T) {
 	// keys and addresses
 	priv1, addr1 := privAndAddr()
 	priv2, addr2 := privAndAddr()
-	priv3, addr3 := privAndAddr()
 
 	// set the accounts
 	acc1 := mapper.NewAccountWithAddress(ctx, addr1)
@@ -246,20 +235,15 @@ func TestAnteHandlerSequences(t *testing.T) {
 	acc2 := mapper.NewAccountWithAddress(ctx, addr2)
 	acc2.SetCoins(newCoins())
 	mapper.SetAccount(ctx, acc2)
-	acc3 := mapper.NewAccountWithAddress(ctx, addr3)
-	acc3.SetCoins(newCoins())
-	mapper.SetAccount(ctx, acc3)
 
 	// msg and signatures
-	var tx sdk.Tx
+	var tx tx.Tx
 	msg := newTestMsg(addr1)
 	fee := newStdFee()
 
-	msgs := []sdk.Msg{msg}
-
 	// test good tx from one signer
 	privs, accnums, seqs := []crypto.PrivKey{priv1}, []int64{0}, []int64{0}
-	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	tx = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkValidTx(t, anteHandler, ctx, tx)
 
 	// test sending it again fails (replay protection)
@@ -267,16 +251,14 @@ func TestAnteHandlerSequences(t *testing.T) {
 
 	// fix sequence, should pass
 	seqs = []int64{1}
-	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	tx = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkValidTx(t, anteHandler, ctx, tx)
 
 	// new tx with another signer and correct sequences
-	msg1 := newTestMsg(addr1, addr2)
-	msg2 := newTestMsg(addr3, addr1)
-	msgs = []sdk.Msg{msg1, msg2}
+	msg = newTestMsg(addr1, addr2)
 
-	privs, accnums, seqs = []crypto.PrivKey{priv1, priv2, priv3}, []int64{0, 1, 2}, []int64{2, 0, 0}
-	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	privs, accnums, seqs = []crypto.PrivKey{priv1, priv2}, []int64{0, 1}, []int64{2, 0}
+	tx = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkValidTx(t, anteHandler, ctx, tx)
 
 	// replay fails
@@ -284,20 +266,18 @@ func TestAnteHandlerSequences(t *testing.T) {
 
 	// tx from just second signer with incorrect sequence fails
 	msg = newTestMsg(addr2)
-	msgs = []sdk.Msg{msg}
 	privs, accnums, seqs = []crypto.PrivKey{priv2}, []int64{1}, []int64{0}
-	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	tx = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkInvalidTx(t, anteHandler, ctx, tx, sdk.CodeInvalidSequence)
 
 	// fix the sequence and it passes
-	tx = newTestTx(ctx, msgs, []crypto.PrivKey{priv2}, []int64{1}, []int64{1}, fee)
+	tx = newTestTx(ctx, msg, []crypto.PrivKey{priv2}, []int64{1}, []int64{1}, fee)
 	checkValidTx(t, anteHandler, ctx, tx)
 
 	// another tx from both of them that passes
 	msg = newTestMsg(addr1, addr2)
-	msgs = []sdk.Msg{msg}
 	privs, accnums, seqs = []crypto.PrivKey{priv1, priv2}, []int64{0, 1}, []int64{3, 2}
-	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	tx = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkValidTx(t, anteHandler, ctx, tx)
 }
 
@@ -320,14 +300,13 @@ func TestAnteHandlerFees(t *testing.T) {
 	mapper.SetAccount(ctx, acc1)
 
 	// msg and signatures
-	var tx sdk.Tx
+	var tx tx.Tx
 	msg := newTestMsg(addr1)
 	privs, accnums, seqs := []crypto.PrivKey{priv1}, []int64{0}, []int64{0}
 	fee := newStdFee()
-	msgs := []sdk.Msg{msg}
 
 	// signer does not have enough funds to pay the fee
-	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	tx = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkInvalidTx(t, anteHandler, ctx, tx, sdk.CodeInsufficientFunds)
 
 	acc1.SetCoins(sdk.Coins{sdk.NewCoin("atom", 149)})
@@ -362,28 +341,28 @@ func TestAnteHandlerMemoGas(t *testing.T) {
 	mapper.SetAccount(ctx, acc1)
 
 	// msg and signatures
-	var txn sdk.Tx
+	var txn tx.Tx
 	msg := newTestMsg(addr1)
 	privs, accnums, seqs := []crypto.PrivKey{priv1}, []int64{0}, []int64{0}
 	fee := tx.NewStdFee(0, sdk.NewCoin("atom", 0))
 
 	// tx does not have enough gas
-	txn = newTestTx(ctx, []sdk.Msg{msg}, privs, accnums, seqs, fee)
+	txn = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkInvalidTx(t, anteHandler, ctx, txn, sdk.CodeOutOfGas)
 
 	// tx with memo doesn't have enough gas
 	fee = tx.NewStdFee(801, sdk.NewCoin("atom", 0))
-	txn = newTestTxWithMemo(ctx, []sdk.Msg{msg}, privs, accnums, seqs, fee, "abcininasidniandsinasindiansdiansdinaisndiasndiadninsd")
+	txn = newTestTxWithMemo(ctx, msg, privs, accnums, seqs, fee, "abcininasidniandsinasindiansdiansdinaisndiasndiadninsd")
 	checkInvalidTx(t, anteHandler, ctx, txn, sdk.CodeOutOfGas)
 
 	// memo too large
 	fee = tx.NewStdFee(2001, sdk.NewCoin("atom", 0))
-	txn = newTestTxWithMemo(ctx, []sdk.Msg{msg}, privs, accnums, seqs, fee, "abcininasidniandsinasindiansdiansdinaisndiasndiadninsdabcininasidniandsinasindiansdiansdinaisndiasndiadninsdabcininasidniandsinasindiansdiansdinaisndiasndiadninsd")
+	txn = newTestTxWithMemo(ctx, msg, privs, accnums, seqs, fee, "abcininasidniandsinasindiansdiansdinaisndiasndiadninsdabcininasidniandsinasindiansdiansdinaisndiasndiadninsdabcininasidniandsinasindiansdiansdinaisndiasndiadninsd")
 	checkInvalidTx(t, anteHandler, ctx, txn, sdk.CodeMemoTooLarge)
 
 	// tx with memo has enough gas
 	fee = tx.NewStdFee(1100, sdk.NewCoin("atom", 0))
-	txn = newTestTxWithMemo(ctx, []sdk.Msg{msg}, privs, accnums, seqs, fee, "abcininasidniandsinasindiansdiansdinaisndiasndiadninsd")
+	txn = newTestTxWithMemo(ctx, msg, privs, accnums, seqs, fee, "abcininasidniandsinasindiansdiansdinaisndiasndiadninsd")
 	checkValidTx(t, anteHandler, ctx, txn)
 }
 
@@ -414,27 +393,24 @@ func TestAnteHandlerMultiSigner(t *testing.T) {
 	mapper.SetAccount(ctx, acc3)
 
 	// set up msgs and fee
-	var tx sdk.Tx
+	var tx tx.Tx
 	msg1 := newTestMsg(addr1, addr2)
 	msg2 := newTestMsg(addr3, addr1)
-	msg3 := newTestMsg(addr2, addr3)
-	msgs := []sdk.Msg{msg1, msg2, msg3}
+	msg3 := newTestMsg(addr1, addr2, addr3)
 	fee := newStdFee()
 
 	// signers in order
-	privs, accnums, seqs := []crypto.PrivKey{priv1, priv2, priv3}, []int64{0, 1, 2}, []int64{0, 0, 0}
-	tx = newTestTxWithMemo(ctx, msgs, privs, accnums, seqs, fee, "Check signers are in expected order and different account numbers works")
-
+	tx = newTestTxWithMemo(ctx, msg3, []crypto.PrivKey{priv1, priv2, priv3}, []int64{0, 1, 2}, []int64{0, 0, 0}, fee, "Check signers are in expected order and different account numbers works")
 	checkValidTx(t, anteHandler, ctx, tx)
 
 	// change sequence numbers
-	tx = newTestTx(ctx, []sdk.Msg{msg1}, []crypto.PrivKey{priv1, priv2}, []int64{0, 1}, []int64{1, 1}, fee)
+	tx = newTestTx(ctx, msg1, []crypto.PrivKey{priv1, priv2}, []int64{0, 1}, []int64{1, 1}, fee)
 	checkValidTx(t, anteHandler, ctx, tx)
-	tx = newTestTx(ctx, []sdk.Msg{msg2}, []crypto.PrivKey{priv3, priv1}, []int64{2, 0}, []int64{1, 2}, fee)
+	tx = newTestTx(ctx, msg2, []crypto.PrivKey{priv3, priv1}, []int64{2, 0}, []int64{1, 2}, fee)
 	checkValidTx(t, anteHandler, ctx, tx)
 
 	// expected seqs = [3, 2, 2]
-	tx = newTestTxWithMemo(ctx, msgs, privs, accnums, []int64{3, 2, 2}, fee, "Check signers are in expected order and different account numbers and sequence numbers works")
+	tx = newTestTxWithMemo(ctx, msg3, []crypto.PrivKey{priv1, priv2, priv3}, []int64{0, 1, 2}, []int64{3, 2, 2}, fee, "Check signers are in expected order and different account numbers and sequence numbers works")
 	checkValidTx(t, anteHandler, ctx, tx)
 }
 
@@ -460,9 +436,8 @@ func TestAnteHandlerBadSignBytes(t *testing.T) {
 	acc2.SetCoins(newCoins())
 	mapper.SetAccount(ctx, acc2)
 
-	var txn sdk.Tx
+	var txn tx.Tx
 	msg := newTestMsg(addr1)
-	msgs := []sdk.Msg{msg}
 	fee := newStdFee()
 	fee2 := newStdFee()
 	fee2.Gas += 100
@@ -471,7 +446,7 @@ func TestAnteHandlerBadSignBytes(t *testing.T) {
 
 	// test good tx and signBytes
 	privs, accnums, seqs := []crypto.PrivKey{priv1}, []int64{0}, []int64{0}
-	txn = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	txn = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkValidTx(t, anteHandler, ctx, txn)
 
 	chainID := ctx.ChainID()
@@ -483,23 +458,23 @@ func TestAnteHandlerBadSignBytes(t *testing.T) {
 		accnum  int64
 		seq     int64
 		fee     tx.StdFee
-		msgs    []sdk.Msg
+		msg     tx.Msg
 		code    sdk.CodeType
 	}{
-		{chainID2, 0, 1, fee, msgs, codeUnauth},                        // test wrong chain_id
-		{chainID, 0, 2, fee, msgs, codeUnauth},                         // test wrong seqs
-		{chainID, 1, 1, fee, msgs, codeUnauth},                         // test wrong accnum
-		{chainID, 0, 1, fee, []sdk.Msg{newTestMsg(addr2)}, codeUnauth}, // test wrong msg
-		{chainID, 0, 1, fee2, msgs, codeUnauth},                        // test wrong fee
-		{chainID, 0, 1, fee3, msgs, codeUnauth},                        // test wrong fee
+		{chainID2, 0, 1, fee, msg, codeUnauth},              // test wrong chain_id
+		{chainID, 0, 2, fee, msg, codeUnauth},               // test wrong seqs
+		{chainID, 1, 1, fee, msg, codeUnauth},               // test wrong accnum
+		{chainID, 0, 1, fee, newTestMsg(addr2), codeUnauth}, // test wrong msg
+		{chainID, 0, 1, fee2, msg, codeUnauth},              // test wrong fee
+		{chainID, 0, 1, fee3, msg, codeUnauth},              // test wrong fee
 	}
 
 	privs, seqs = []crypto.PrivKey{priv1}, []int64{1}
 	for _, cs := range cases {
 		txn := newTestTxWithSignBytes(
 
-			msgs, privs, accnums, seqs, fee,
-			tx.StdSignBytes(cs.chainID, cs.accnum, cs.seq, cs.fee, cs.msgs, ""),
+			msg, privs, accnums, seqs, fee,
+			tx.StdSignBytes(cs.chainID, cs.accnum, cs.seq, cs.fee, cs.msg, ""),
 			"",
 		)
 		checkInvalidTx(t, anteHandler, ctx, txn, cs.code)
@@ -507,14 +482,13 @@ func TestAnteHandlerBadSignBytes(t *testing.T) {
 
 	// test wrong signer if public key exist
 	privs, accnums, seqs = []crypto.PrivKey{priv2}, []int64{0}, []int64{1}
-	txn = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	txn = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkInvalidTx(t, anteHandler, ctx, txn, sdk.CodeUnauthorized)
 
 	// test wrong signer if public doesn't exist
 	msg = newTestMsg(addr2)
-	msgs = []sdk.Msg{msg}
 	privs, accnums, seqs = []crypto.PrivKey{priv1}, []int64{1}, []int64{0}
-	txn = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	txn = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkInvalidTx(t, anteHandler, ctx, txn, sdk.CodeInvalidPubKey)
 
 }
@@ -541,14 +515,13 @@ func TestAnteHandlerSetPubKey(t *testing.T) {
 	acc2.SetCoins(newCoins())
 	mapper.SetAccount(ctx, acc2)
 
-	var txn sdk.Tx
+	var txn tx.Tx
 
 	// test good tx and set public key
 	msg := newTestMsg(addr1)
-	msgs := []sdk.Msg{msg}
 	privs, accnums, seqs := []crypto.PrivKey{priv1}, []int64{0}, []int64{0}
 	fee := newStdFee()
-	txn = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	txn = newTestTx(ctx, msg, privs, accnums, seqs, fee)
 	checkValidTx(t, anteHandler, ctx, txn)
 
 	acc1 = mapper.GetAccount(ctx, addr1)
@@ -556,8 +529,7 @@ func TestAnteHandlerSetPubKey(t *testing.T) {
 
 	// test public key not found
 	msg = newTestMsg(addr2)
-	msgs = []sdk.Msg{msg}
-	txn = newTestTx(ctx, msgs, privs, []int64{1}, seqs, fee)
+	txn = newTestTx(ctx, msg, privs, []int64{1}, seqs, fee)
 	sigs := txn.(tx.StdTx).GetSignatures()
 	sigs[0].PubKey = nil
 	checkInvalidTx(t, anteHandler, ctx, txn, sdk.CodeInvalidPubKey)
@@ -566,7 +538,7 @@ func TestAnteHandlerSetPubKey(t *testing.T) {
 	require.Nil(t, acc2.GetPubKey())
 
 	// test invalid signature and public key
-	txn = newTestTx(ctx, msgs, privs, []int64{1}, seqs, fee)
+	txn = newTestTx(ctx, msg, privs, []int64{1}, seqs, fee)
 	checkInvalidTx(t, anteHandler, ctx, txn, sdk.CodeInvalidPubKey)
 
 	acc2 = mapper.GetAccount(ctx, addr2)

--- a/common/tx/handler.go
+++ b/common/tx/handler.go
@@ -1,0 +1,10 @@
+package tx
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+// Handler defines the core of the state transition function of an application.
+type Handler func(ctx sdk.Context, msg Msg) sdk.Result
+
+// AnteHandler authenticates transactions, before their internal messages are handled.
+// If newCtx.IsZero(), ctx is used instead.
+type AnteHandler func(ctx sdk.Context, tx Tx) (newCtx sdk.Context, result sdk.Result, abort bool)

--- a/common/tx/tx_msg.go
+++ b/common/tx/tx_msg.go
@@ -1,0 +1,71 @@
+package tx
+
+import (
+	"encoding/json"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// TODO: merge this type into Tx
+// Transactions messages must fulfill the Msg
+type Msg interface {
+
+	// Return the message type.
+	// Must be alphanumeric or empty.
+	Type() string
+
+	// ValidateBasic does a simple validation check that
+	// doesn't require access to any other information.
+	ValidateBasic() sdk.Error
+
+	// Get the canonical byte representation of the Msg.
+	GetSignBytes() []byte
+
+	// Signers returns the addrs of signers that must sign.
+	// CONTRACT: All signatures must be present to be valid.
+	// CONTRACT: Returns addrs in some deterministic order.
+	GetSigners() []sdk.AccAddress
+}
+
+//__________________________________________________________
+
+// Transactions objects must fulfill the Tx
+type Tx interface {
+
+	// Gets the Msg.
+	GetMsg() Msg
+}
+
+//__________________________________________________________
+
+// TxDecoder unmarshals transaction bytes
+type TxDecoder func(txBytes []byte) (Tx, sdk.Error)
+
+//__________________________________________________________
+
+var _ Msg = (*TestMsg)(nil)
+
+// msg type for testing
+type TestMsg struct {
+	signers []sdk.AccAddress
+}
+
+func NewTestMsg(addrs ...sdk.AccAddress) *TestMsg {
+	return &TestMsg{
+		signers: addrs,
+	}
+}
+
+//nolint
+func (msg *TestMsg) Type() string { return "TestMsg" }
+func (msg *TestMsg) GetSignBytes() []byte {
+	bz, err := json.Marshal(msg.signers)
+	if err != nil {
+		panic(err)
+	}
+	return sdk.MustSortJSON(bz)
+}
+func (msg *TestMsg) ValidateBasic() sdk.Error { return nil }
+func (msg *TestMsg) GetSigners() []sdk.AccAddress {
+	return msg.signers
+}

--- a/common/tx/tx_test.go
+++ b/common/tx/tx_test.go
@@ -15,12 +15,12 @@ import (
 func TestStdTx(t *testing.T) {
 	priv := ed25519.GenPrivKey()
 	addr := sdk.AccAddress(priv.PubKey().Address())
-	msgs := []sdk.Msg{sdk.NewTestMsg(addr)}
+	msg := txns.NewTestMsg(addr)
 	fee := newStdFee()
 	sigs := []txns.StdSignature{}
 
-	tx := txns.NewStdTx(msgs, fee, sigs, "")
-	require.Equal(t, msgs, tx.GetMsgs())
+	tx := txns.NewStdTx(msg, fee, sigs, "")
+	require.Equal(t, msg, tx.GetMsg())
 	require.Equal(t, sigs, tx.GetSignatures())
 
 	feePayer := txns.FeePayer(tx)
@@ -30,15 +30,15 @@ func TestStdTx(t *testing.T) {
 func TestStdSignBytes(t *testing.T) {
 	priv := ed25519.GenPrivKey()
 	addr := sdk.AccAddress(priv.PubKey().Address())
-	msgs := []sdk.Msg{sdk.NewTestMsg(addr)}
+	msg := txns.NewTestMsg(addr)
 	fee := newStdFee()
 	signMsg := txns.StdSignMsg{
 		"1234",
 		3,
 		6,
 		fee,
-		msgs,
+		msg,
 		"memo",
 	}
-	require.Equal(t, fmt.Sprintf("{\"account_number\":\"3\",\"chain_id\":\"1234\",\"fee\":{\"amount\":[{\"amount\":\"150\",\"denom\":\"atom\"}],\"gas\":\"5000\"},\"memo\":\"memo\",\"msgs\":[[\"%s\"]],\"sequence\":\"6\"}", addr), string(signMsg.Bytes()))
+	require.Equal(t, fmt.Sprintf("{\"account_number\":\"3\",\"chain_id\":\"1234\",\"fee\":{\"amount\":[{\"amount\":\"150\",\"denom\":\"atom\"}],\"gas\":\"5000\"},\"memo\":\"memo\",\"msg\":[\"%s\"],\"sequence\":\"6\"}", addr), string(signMsg.Bytes()))
 }

--- a/common/tx/wire.go
+++ b/common/tx/wire.go
@@ -1,0 +1,9 @@
+package tx
+
+import "github.com/BiJie/BinanceChain/wire"
+
+// Register the sdk message type
+func RegisterWire(cdc *wire.Codec) {
+	cdc.RegisterInterface((*Msg)(nil), nil)
+	cdc.RegisterInterface((*Tx)(nil), nil)
+}

--- a/plugins/dex/client/cli/commands.go
+++ b/plugins/dex/client/cli/commands.go
@@ -1,9 +1,10 @@
 package commands
 
 import (
-	"github.com/BiJie/BinanceChain/wire"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
+
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 const (

--- a/plugins/dex/client/cli/list.go
+++ b/plugins/dex/client/cli/list.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"strings"
 
-	"github.com/BiJie/BinanceChain/wire"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
@@ -12,6 +11,7 @@ import (
 	"github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/common/utils"
 	"github.com/BiJie/BinanceChain/plugins/dex/list"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 const flagQuoteSymbol = "quote-symbol"

--- a/plugins/dex/client/cli/tx.go
+++ b/plugins/dex/client/cli/tx.go
@@ -4,17 +4,16 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/BiJie/BinanceChain/wire"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/common/utils"
 	"github.com/BiJie/BinanceChain/plugins/dex/order"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 const (

--- a/plugins/dex/client/rest/orderbook.go
+++ b/plugins/dex/client/rest/orderbook.go
@@ -6,13 +6,12 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gorilla/mux"
-
-	"github.com/BiJie/BinanceChain/wire"
 	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/gorilla/mux"
 
 	"github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/common/utils"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 type order struct {

--- a/plugins/dex/client/rest/rest.go
+++ b/plugins/dex/client/rest/rest.go
@@ -1,11 +1,11 @@
 package rest
 
 import (
+	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/gorilla/mux"
 	cmn "github.com/tendermint/tendermint/libs/common"
 
 	"github.com/BiJie/BinanceChain/wire"
-	"github.com/cosmos/cosmos-sdk/client/context"
 )
 
 // https://github.com/tendermint/tendermint/blob/05a76fb517f50da27b4bfcdc7b4cf185fc61eff6/crypto/crypto.go#L14

--- a/plugins/dex/list/handler.go
+++ b/plugins/dex/list/handler.go
@@ -6,13 +6,14 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/plugins/dex/store"
 	"github.com/BiJie/BinanceChain/plugins/dex/types"
 	"github.com/BiJie/BinanceChain/plugins/tokens"
 )
 
-func NewHandler(pairMapper store.TradingPairMapper, tokenMapper tokens.Mapper) sdk.Handler {
-	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+func NewHandler(pairMapper store.TradingPairMapper, tokenMapper tokens.Mapper) tx.Handler {
+	return func(ctx sdk.Context, msg tx.Msg) sdk.Result {
 		switch msg := msg.(type) {
 		case Msg:
 			return handleList(ctx, pairMapper, tokenMapper, msg)

--- a/plugins/dex/order/handler.go
+++ b/plugins/dex/order/handler.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 
+	"github.com/BiJie/BinanceChain/common/tx"
 	common "github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/common/utils"
 	me "github.com/BiJie/BinanceChain/plugins/dex/matcheng"
@@ -15,8 +16,8 @@ import (
 )
 
 // NewHandler - returns a handler for dex type messages.
-func NewHandler(k Keeper, accountMapper auth.AccountMapper) sdk.Handler {
-	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+func NewHandler(k Keeper, accountMapper auth.AccountMapper) tx.Handler {
+	return func(ctx sdk.Context, msg tx.Msg) sdk.Result {
 		switch msg := msg.(type) {
 		case NewOrderMsg:
 			return handleNewOrder(ctx, k, accountMapper, msg)

--- a/plugins/dex/order/msg.go
+++ b/plugins/dex/order/msg.go
@@ -8,6 +8,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/common/utils"
 	"github.com/BiJie/BinanceChain/plugins/dex/types"
 )
@@ -129,7 +130,7 @@ func NewNewOrderMsg(sender sdk.AccAddress, id string, side int8,
 	}
 }
 
-var _ sdk.Msg = NewOrderMsg{}
+var _ tx.Msg = NewOrderMsg{}
 
 // nolint
 func (msg NewOrderMsg) Type() string                            { return Route }
@@ -148,7 +149,7 @@ func NewCancelOrderMsg(sender sdk.AccAddress, id, refId string) CancelOrderMsg {
 	}
 }
 
-var _ sdk.Msg = CancelOrderMsg{}
+var _ tx.Msg = CancelOrderMsg{}
 
 // nolint
 func (msg CancelOrderMsg) Type() string                            { return Route }

--- a/plugins/dex/route.go
+++ b/plugins/dex/route.go
@@ -1,17 +1,17 @@
 package dex
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 
+	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/plugins/dex/list"
 	"github.com/BiJie/BinanceChain/plugins/dex/order"
 	"github.com/BiJie/BinanceChain/plugins/tokens"
 )
 
-func Routes(tradingPairMapper TradingPairMapper, orderKeeper OrderKeeper, tokenMapper tokens.Mapper, accountMapper auth.AccountMapper, keeper bank.Keeper) map[string]sdk.Handler {
-	routes := make(map[string]sdk.Handler)
+func Routes(tradingPairMapper TradingPairMapper, orderKeeper OrderKeeper, tokenMapper tokens.Mapper, accountMapper auth.AccountMapper, keeper bank.Keeper) map[string]tx.Handler {
+	routes := make(map[string]tx.Handler)
 	routes[order.Route] = order.NewHandler(orderKeeper, accountMapper)
 	routes[list.Route] = list.NewHandler(tradingPairMapper, tokenMapper)
 	return routes

--- a/plugins/dex/store/mapper.go
+++ b/plugins/dex/store/mapper.go
@@ -3,12 +3,11 @@ package store
 import (
 	"errors"
 
-	"github.com/BiJie/BinanceChain/wire"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/BiJie/BinanceChain/common/utils"
-
 	"github.com/BiJie/BinanceChain/plugins/dex/types"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 type TradingPairMapper interface {

--- a/plugins/tokens/burn/handler.go
+++ b/plugins/tokens/burn/handler.go
@@ -7,11 +7,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 
+	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/plugins/tokens/store"
 )
 
-func NewHandler(tokenMapper store.Mapper, keeper bank.Keeper) sdk.Handler {
-	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+func NewHandler(tokenMapper store.Mapper, keeper bank.Keeper) tx.Handler {
+	return func(ctx sdk.Context, msg tx.Msg) sdk.Result {
 		if msg, ok := msg.(Msg); ok {
 			return handleBurnToken(ctx, tokenMapper, keeper, msg)
 		}

--- a/plugins/tokens/burn/msg.go
+++ b/plugins/tokens/burn/msg.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/plugins/tokens/base"
 )
 
@@ -12,7 +13,7 @@ import (
 // const Route = "tokens/burn"
 const Route = "tokensBurn"
 
-var _ sdk.Msg = (*Msg)(nil)
+var _ tx.Msg = (*Msg)(nil)
 
 type Msg struct {
 	base.MsgBase

--- a/plugins/tokens/client/cli/commands.go
+++ b/plugins/tokens/client/cli/commands.go
@@ -1,9 +1,10 @@
 package commands
 
 import (
-	"github.com/BiJie/BinanceChain/wire"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
+
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 const (

--- a/plugins/tokens/client/cli/helper.go
+++ b/plugins/tokens/client/cli/helper.go
@@ -5,13 +5,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/BiJie/BinanceChain/wire"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/BiJie/BinanceChain/common/types"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 type Commander struct {

--- a/plugins/tokens/client/cli/info.go
+++ b/plugins/tokens/client/cli/info.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/BiJie/BinanceChain/wire"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/BiJie/BinanceChain/common"
 	"github.com/BiJie/BinanceChain/common/types"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 func getTokenInfoCmd(cmdr Commander) *cobra.Command {

--- a/plugins/tokens/client/rest/balance.go
+++ b/plugins/tokens/client/rest/balance.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/BiJie/BinanceChain/wire"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/BiJie/BinanceChain/common/utils"
 	"github.com/BiJie/BinanceChain/plugins/tokens"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 // RegisterBalanceRoute registers this http route handler

--- a/plugins/tokens/client/rest/balances.go
+++ b/plugins/tokens/client/rest/balances.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/BiJie/BinanceChain/wire"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
@@ -15,6 +14,7 @@ import (
 	"github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/common/utils"
 	"github.com/BiJie/BinanceChain/plugins/tokens"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 type TokenBalance struct {

--- a/plugins/tokens/client/rest/rest.go
+++ b/plugins/tokens/client/rest/rest.go
@@ -1,14 +1,13 @@
 package rest
 
 import (
+	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/gorilla/mux"
 	cmn "github.com/tendermint/tendermint/libs/common"
 
-	"github.com/BiJie/BinanceChain/wire"
-	"github.com/cosmos/cosmos-sdk/client/context"
-
 	"github.com/BiJie/BinanceChain/common"
 	"github.com/BiJie/BinanceChain/plugins/tokens"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 // https://github.com/tendermint/tendermint/blob/05a76fb517f50da27b4bfcdc7b4cf185fc61eff6/crypto/crypto.go#L14

--- a/plugins/tokens/freeze/handler.go
+++ b/plugins/tokens/freeze/handler.go
@@ -8,12 +8,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 
+	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/plugins/tokens/store"
 )
 
-func NewHandler(tokenMapper store.Mapper, accountMapper auth.AccountMapper, keeper bank.Keeper) sdk.Handler {
-	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+func NewHandler(tokenMapper store.Mapper, accountMapper auth.AccountMapper, keeper bank.Keeper) tx.Handler {
+	return func(ctx sdk.Context, msg tx.Msg) sdk.Result {
 		switch msg := msg.(type) {
 		case FreezeMsg:
 			return handleFreezeToken(ctx, tokenMapper, accountMapper, keeper, msg)

--- a/plugins/tokens/freeze/msg.go
+++ b/plugins/tokens/freeze/msg.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/plugins/tokens/base"
 )
 
@@ -12,7 +13,7 @@ import (
 // const RouteFreeze = "tokens/freeze"
 const RouteFreeze = "tokensFreeze"
 
-var _ sdk.Msg = (*FreezeMsg)(nil)
+var _ tx.Msg = (*FreezeMsg)(nil)
 
 type FreezeMsg struct {
 	base.MsgBase
@@ -28,7 +29,7 @@ func (msg FreezeMsg) String() string {
 	return fmt.Sprintf("Freeze{%v#%v}", msg.From, msg.Symbol)
 }
 
-var _ sdk.Msg = (*UnfreezeMsg)(nil)
+var _ tx.Msg = (*UnfreezeMsg)(nil)
 
 type UnfreezeMsg struct {
 	base.MsgBase

--- a/plugins/tokens/issue/handler.go
+++ b/plugins/tokens/issue/handler.go
@@ -8,12 +8,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 
+	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/plugins/tokens/store"
 )
 
-func NewHandler(tokenMapper store.Mapper, keeper bank.Keeper) sdk.Handler {
-	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+func NewHandler(tokenMapper store.Mapper, keeper bank.Keeper) tx.Handler {
+	return func(ctx sdk.Context, msg tx.Msg) sdk.Result {
 		if msg, ok := msg.(Msg); ok {
 			return handleIssueToken(ctx, tokenMapper, keeper, msg)
 		}

--- a/plugins/tokens/issue/msg.go
+++ b/plugins/tokens/issue/msg.go
@@ -7,6 +7,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/common/types"
 )
 
@@ -14,7 +15,7 @@ import (
 // const Route  = "tokens/issue"
 const Route = "tokensIssue"
 
-var _ sdk.Msg = Msg{}
+var _ tx.Msg = Msg{}
 
 type Msg struct {
 	From        sdk.AccAddress `json:"from"`

--- a/plugins/tokens/route.go
+++ b/plugins/tokens/route.go
@@ -1,18 +1,18 @@
 package tokens
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 
+	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/plugins/tokens/burn"
 	"github.com/BiJie/BinanceChain/plugins/tokens/freeze"
 	"github.com/BiJie/BinanceChain/plugins/tokens/issue"
 	"github.com/BiJie/BinanceChain/plugins/tokens/store"
 )
 
-func Routes(tokenMapper store.Mapper, accountMapper auth.AccountMapper, keeper bank.Keeper) map[string]sdk.Handler {
-	routes := make(map[string]sdk.Handler)
+func Routes(tokenMapper store.Mapper, accountMapper auth.AccountMapper, keeper bank.Keeper) map[string]tx.Handler {
+	routes := make(map[string]tx.Handler)
 	routes[issue.Route] = issue.NewHandler(tokenMapper, keeper)
 	routes[burn.Route] = burn.NewHandler(tokenMapper, keeper)
 	routes[freeze.RouteFreeze] = freeze.NewHandler(tokenMapper, accountMapper, keeper)

--- a/plugins/tokens/store/mapper.go
+++ b/plugins/tokens/store/mapper.go
@@ -3,13 +3,13 @@ package store
 import (
 	"fmt"
 
-	"github.com/BiJie/BinanceChain/wire"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
 
 	"github.com/BiJie/BinanceChain/common"
 	"github.com/BiJie/BinanceChain/common/types"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 type Tokens []types.Token


### PR DESCRIPTION
### Description
Refactor the Tx type, making each Tx have only 1 msg.  
// TODO: merge type Tx and Msg. 

### Rationale
We do not really need multiple msgs in one tx. Instead, one Tx meaning one transaction makes us unambiguous when we talking about it.

If we want 1:N transfer, we just make the transfer transaction support it instead of having a Tx containing multiple messages.
Also,  many transactions **must not** be executed in batch, e.g. `Cancel Order`

### Changes

Notable changes: 
* copied and modified tx_msg and its' related files.
* fixed the test cases for Tx and Msg. 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] manual transaction test passed (cli invoke)