### PR TITLE
WIP: calculate and save tickSize and lotSize in Breathe Block

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -177,7 +177,7 @@ func (app *BinanceChain) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) a
 		// breathe block
 		icoDone := ico.EndBlockAsync(ctx)
 
-		dex.EndBlock(ctx, app.TradingPairMapper, app.OrderKeeper)
+		dex.EndBreatheBlock(ctx, app.TradingPairMapper, app.OrderKeeper)
 
 		// other end blockers
 		<-icoDone

--- a/plugins/dex/plugin.go
+++ b/plugins/dex/plugin.go
@@ -6,7 +6,7 @@ import (
 	"github.com/BiJie/BinanceChain/common/utils"
 )
 
-func EndBlock(ctx sdk.Context, tradingPairMapper TradingPairMapper, orderKeeper OrderKeeper) {
+func EndBreatheBlock(ctx sdk.Context, tradingPairMapper TradingPairMapper, orderKeeper OrderKeeper) {
 	updateTickSizeAndLotSize(ctx, tradingPairMapper, orderKeeper)
 }
 

--- a/plugins/dex/store/mapper.go
+++ b/plugins/dex/store/mapper.go
@@ -84,8 +84,7 @@ func (m mapper) ListAllTradingPairs(ctx sdk.Context) (res []types.TradingPair) {
 }
 
 func (m mapper) UpdateTickSizeAndLotSize(ctx sdk.Context, pair types.TradingPair, price int64) {
-	tickSize := dexUtils.CalcTickSize(price)
-	lotSize := dexUtils.CalcLotSize(price)
+	tickSize, lotSize := dexUtils.CalcTickSizeAndLotSize(price)
 
 	if tickSize != pair.TickSize || lotSize != pair.LotSize {
 		pair.TickSize = tickSize

--- a/plugins/dex/types/pair.go
+++ b/plugins/dex/types/pair.go
@@ -11,11 +11,13 @@ type TradingPair struct {
 }
 
 func NewTradingPair(tradeAsset, quoteAsset string, price int64) TradingPair {
+	tickSize, lotSize := utils.CalcTickSizeAndLotSize(price)
+
 	return TradingPair{
 		TradeAsset: tradeAsset,
 		QuoteAsset: quoteAsset,
 		Price:      price,
-		TickSize:   utils.CalcTickSize(price),
-		LotSize:    utils.CalcLotSize(price),
+		TickSize:   tickSize,
+		LotSize:    lotSize,
 	}
 }

--- a/plugins/dex/utils/pair.go
+++ b/plugins/dex/utils/pair.go
@@ -2,27 +2,15 @@ package utils
 
 import "math"
 
-// CalcTickSize calculate TickSize based on price
-func CalcTickSize(price int64) int64 {
+// CalcTickSizeAndLotSize calculate TickSize and LotSize
+func CalcTickSizeAndLotSize(price int64) (tickSize, lotSize int64) {
 	if price <= 0 {
-		return 1
-	}
-
-	priceDigits := int64(math.Floor(math.Log10(float64(price))))
-	tickSizeDigits := int64(math.Max(float64(priceDigits-5), 0))
-
-	return int64(math.Pow(10, float64(tickSizeDigits)))
-}
-
-// CalcLotSize calculate LotSize based on price
-func CalcLotSize(price int64) int64 {
-	if price <= 0 {
-		return 1e8
+		return 1, 1e8
 	}
 
 	priceDigits := int64(math.Floor(math.Log10(float64(price))))
 	tickSizeDigits := int64(math.Max(float64(priceDigits-5), 0))
 	lotSizeDigits := int64(math.Max(float64(8-tickSizeDigits), 0))
 
-	return int64(math.Pow(10, float64(lotSizeDigits)))
+	return int64(math.Pow(10, float64(tickSizeDigits))), int64(math.Pow(10, float64(lotSizeDigits)))
 }

--- a/plugins/dex/utils/pair_test.go
+++ b/plugins/dex/utils/pair_test.go
@@ -9,33 +9,21 @@ import (
 )
 
 func TestCalcLotSizeAndCalcTickSize(t *testing.T) {
-	var lotSizeTests = []struct {
-		in  int64
-		out int64
+	var tests = []struct {
+		price    int64
+		lotSize  int64
+		tickSize int64
 	}{
-		{-1, 1e8},
-		{0, 1e8},
-		{1e2, 1e8},
-		{1e8, 1e5},
-		{1e17, 1},
+		{-1, 1e8, 1},
+		{0, 1e8, 1},
+		{1e2, 1e8, 1},
+		{1e8, 1e5, 1e3},
+		{1e17, 1, 1e12},
 	}
 
-	var tickSizeTests = []struct {
-		in  int64
-		out int64
-	}{
-		{-1, 1},
-		{0, 1},
-		{1e2, 1},
-		{1e8, 1e3},
-		{1e17, 1e12},
-	}
-
-	for i := 0; i < len(lotSizeTests); i++ {
-		assert.Equal(t, utils.CalcLotSize(lotSizeTests[i].in), lotSizeTests[i].out)
-	}
-
-	for i := 0; i < len(tickSizeTests); i++ {
-		assert.Equal(t, utils.CalcTickSize(tickSizeTests[i].in), tickSizeTests[i].out)
+	for i := 0; i < len(tests); i++ {
+		tickSize, lotSize := utils.CalcTickSizeAndLotSize(tests[i].price)
+		assert.Equal(t, tests[i].tickSize, tickSize)
+		assert.Equal(t, tests[i].lotSize, lotSize)
 	}
 }


### PR DESCRIPTION
### Description

Calculate and save all trading pairs' `tickSize` and `lotSize` in Breathe Block

### Rationale

We need to update `tickSize` and `lotSize` periodically, like in every Breathe Block, because the price of one asset may change over time and  `tickSize` and `lotSize` are based on price.

### Changes

Notable changes: 
* add methods to calculate `tickSize` and `lotSize`
* update all trading pairs'  `tickSize` and `lotSize` in Breathe Block

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] manual transaction test passed (cli invoke)

###  Other concerns

* Do we need to update price of each trading pair as `tickSize` and `lotSize`?
* CheckTx should check order's price and quantity based on `tickSize` and `lotSize`