### PR TITLE
dex store: decoder edit for OrderBookLevel

### DIFF
--- a/plugins/dex/store/codec.go
+++ b/plugins/dex/store/codec.go
@@ -8,12 +8,23 @@ import (
 	"github.com/BiJie/BinanceChain/wire"
 )
 
+// queryOrderBook queries the store for the serialized order book for a given pair.
 func queryOrderBook(cdc *wire.Codec, ctx context.CoreContext, pair string) ([]byte, error) {
 	bz, err := ctx.Query(fmt.Sprintf("app/orderbook/%s", pair))
 	if err != nil {
 		return nil, err
 	}
 	return bz, nil
+}
+
+// decodeOrderBook decodes the order book to a set of OrderBookLevel structs
+func decodeOrderBook(cdc *wire.Codec, bz *[]byte) (*[]OrderBookLevel, error) {
+	levels := make([]OrderBookLevel, 0)
+	err := cdc.UnmarshalBinary(*bz, &levels)
+	if err != nil {
+		return nil, err
+	}
+	return &levels, nil
 }
 
 // GetOrderBook decodes the order book from the serialized store
@@ -25,16 +36,6 @@ func GetOrderBook(cdc *wire.Codec, ctx context.CoreContext, pair string) (*[]Ord
 	if bz == nil {
 		return nil, nil
 	}
-	book, err := DecodeOrderBook(cdc, &bz)
+	book, err := decodeOrderBook(cdc, &bz)
 	return book, err
-}
-
-// DecodeOrderBook decodes the order book to a set of OrderBookLevel structs
-func DecodeOrderBook(cdc *wire.Codec, bz *[]byte) (*[]OrderBookLevel, error) {
-	levels := make([]OrderBookLevel, 0)
-	err := cdc.UnmarshalBinary(*bz, &levels)
-	if err != nil {
-		return nil, err
-	}
-	return &levels, nil
 }


### PR DESCRIPTION
### Description

Fixes the following bug:

<img width="568" alt="screen shot 2018-08-22 at 12 18 00" src="https://user-images.githubusercontent.com/1255926/44442890-612b2700-a607-11e8-89c8-c5db04eb55f3.png">

### Changes

Notable changes: 
* `DecodeOrderBook` unmarshals `[]OrderBookLevel` instead of `[][]int64`.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...
