### PR TITLE
update match engine's lotSize when updating tickSize and lotSize

### DIFF
--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -101,6 +101,14 @@ func (kp *Keeper) AddEngine(pair dexTypes.TradingPair) *me.MatchEng {
 	return eng
 }
 
+func (kp *Keeper) UpdateLotSize(symbol string, lotSize int64) {
+	eng, ok := kp.engines[symbol]
+	if !ok {
+		panic(fmt.Sprintf("match engine of symbol %s doesn't exist", symbol))
+	}
+	eng.LotSize = lotSize
+}
+
 func (kp *Keeper) AddOrder(msg NewOrderMsg, height int64) (err error) {
 	//try update order book first
 	symbol := msg.Symbol

--- a/plugins/dex/order/keeper_test.go
+++ b/plugins/dex/order/keeper_test.go
@@ -326,3 +326,19 @@ func TestKeeper_ReplayOrdersFromBlock(t *testing.T) {
 	assert.Equal(int64(1000000), buys[0].Orders[0].CumQty)
 	assert.Equal(int64(96000), buys[1].Price)
 }
+
+func TestKeeper_UpdateLotSize(t *testing.T) {
+	assert := assert.New(t)
+	cdc := MakeCodec()
+	keeper := MakeKeeper(cdc)
+	logger := log.NewTMLogger(os.Stdout)
+	cms := MakeCMS()
+	ctx := sdk.NewContext(cms, abci.Header{}, true, logger)
+	tradingPair := dextypes.NewTradingPair("XYZ", "BNB", 1e8)
+	keeper.PairMapper.AddTradingPair(ctx, tradingPair)
+	keeper.AddEngine(tradingPair)
+
+	keeper.UpdateLotSize(tradingPair.GetSymbol(), 1e3)
+
+	assert.Equal(int64(1e3), keeper.engines[tradingPair.GetSymbol()].LotSize)
+}

--- a/plugins/dex/plugin.go
+++ b/plugins/dex/plugin.go
@@ -21,6 +21,7 @@ func updateTickSizeAndLotSize(ctx sdk.Context, dexKeeper DexKeeper) {
 			continue
 		}
 
-		dexKeeper.PairMapper.UpdateTickSizeAndLotSize(ctx, pair, lastPrice)
+		_, lotSize := dexKeeper.PairMapper.UpdateTickSizeAndLotSize(ctx, pair, lastPrice)
+		dexKeeper.UpdateLotSize(pair.GetSymbol(), lotSize)
 	}
 }

--- a/plugins/dex/store/mapper.go
+++ b/plugins/dex/store/mapper.go
@@ -16,7 +16,7 @@ type TradingPairMapper interface {
 	Exists(ctx sdk.Context, tradeAsset, quoteAsset string) bool
 	GetTradingPair(ctx sdk.Context, tradeAsset, quoteAsset string) (types.TradingPair, error)
 	ListAllTradingPairs(ctx sdk.Context) []types.TradingPair
-	UpdateTickSizeAndLotSize(ctx sdk.Context, pair types.TradingPair, price int64)
+	UpdateTickSizeAndLotSize(ctx sdk.Context, pair types.TradingPair, price int64) (tickSize, lotSize int64)
 }
 
 var _ TradingPairMapper = mapper{}
@@ -83,8 +83,8 @@ func (m mapper) ListAllTradingPairs(ctx sdk.Context) (res []types.TradingPair) {
 	return res
 }
 
-func (m mapper) UpdateTickSizeAndLotSize(ctx sdk.Context, pair types.TradingPair, price int64) {
-	tickSize, lotSize := dexUtils.CalcTickSizeAndLotSize(price)
+func (m mapper) UpdateTickSizeAndLotSize(ctx sdk.Context, pair types.TradingPair, price int64) (tickSize, lotSize int64) {
+	tickSize, lotSize = dexUtils.CalcTickSizeAndLotSize(price)
 
 	if tickSize != pair.TickSize || lotSize != pair.LotSize {
 		pair.TickSize = tickSize
@@ -92,6 +92,7 @@ func (m mapper) UpdateTickSizeAndLotSize(ctx sdk.Context, pair types.TradingPair
 
 		m.AddTradingPair(ctx, pair)
 	}
+	return tickSize, lotSize
 }
 
 func (m mapper) encodeTradingPair(pair types.TradingPair) []byte {


### PR DESCRIPTION
### Description

update match engine's lotSize when updating tickSize and lotSize

### Rationale

We need to update  match engine's lotSize in Breathe Block when updating tickSize and lotSize.

### Changes

Notable changes: 
* update match engine's lotSize in EndBreatheBlock


### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...
