### PR TITLE
#114 Fix missing codec registration of auth.StdTx broke tx query

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -141,6 +141,7 @@ func MakeCodec() *wire.Codec {
 	dex.RegisterWire(cdc)
 	tokens.RegisterWire(cdc)
 	types.RegisterWire(cdc)
+	tx.RegisterWire(cdc)
 
 	return cdc
 }

--- a/common/tx/wire.go
+++ b/common/tx/wire.go
@@ -1,0 +1,12 @@
+package tx
+
+import (
+	"github.com/cosmos/cosmos-sdk/x/auth"
+
+	"github.com/BiJie/BinanceChain/wire"
+)
+
+
+func RegisterWire(cdc *wire.Codec) {
+	cdc.RegisterConcrete(&auth.StdTx{}, "auth/StdTx", nil)
+}


### PR DESCRIPTION
### Description

Fix missing codec registration of auth.StdTx broke tx query

```
$ ./bnbcli tx B7C036687A8FCBC5F5D8AF817ED58F120422650B
ERROR: Cannot encode unregistered concrete type auth.StdTx.
```

### Rationale

https://github.com/BiJie/BinanceChain/issues/114

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [ ] tests passed (`make test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...
