### PR TITLE
#147 Fix after breathe block due to active order snapshot is not consistent

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -207,12 +207,14 @@ func (app *BinanceChain) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) a
 	blockTime := ctx.BlockHeader().Time
 	height := ctx.BlockHeight()
 
-	if utils.SameDayInUTC(lastBlockTime, blockTime) || height == 1 {
+	if utils.SameDayInUTC(lastBlockTime, blockTime) && (height%2500 != 0) {
+		//if utils.SameDayInUTC(lastBlockTime, blockTime) || height == 1 {
 		// only match in the normal block
 		// TODO: add postAllocateHandler
 		ctx, _, _ = app.DexKeeper.MatchAndAllocateAll(ctx, app.AccountMapper, nil)
 	} else {
 		// breathe block
+		app.Logger.Debug(fmt.Sprintf("breathe block: %d", height))
 		bnclog.Info("Start Breathe Block Handling",
 			"height", height, "lastBlockTime", lastBlockTime, "newBlockTime", blockTime)
 		icoDone := ico.EndBlockAsync(ctx)

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -461,6 +461,7 @@ func (kp *Keeper) MarkBreatheBlock(ctx sdk.Context, height, blockTime int64) {
 	if err != nil {
 		panic(err)
 	}
+	bnclog.Debug(fmt.Sprintf("mark breathe block for key: %v (blockTime: %d), value: %v\n", key, blockTime, bz))
 	store.Set([]byte(key), bz)
 }
 

--- a/plugins/dex/order/keeper_test.go
+++ b/plugins/dex/order/keeper_test.go
@@ -135,6 +135,15 @@ func MakeAddress() (sdk.AccAddress, secp256k1.PrivKeySecp256k1) {
 	return addr, privKey
 }
 
+func effectedStoredKVPairs(keeper *Keeper, ctx sdk.Context, keys []string) map[string][]byte {
+	res := make(map[string][]byte, len(keys))
+	store := ctx.KVStore(keeper.storeKey)
+	for _, key := range keys {
+		res[key] = store.Get([]byte(key))
+	}
+	return res
+}
+
 func TestKeeper_SnapShotOrderBook(t *testing.T) {
 	assert := assert.New(t)
 	cdc := MakeCodec()
@@ -163,7 +172,13 @@ func TestKeeper_SnapShotOrderBook(t *testing.T) {
 	keeper.AddOrder(msg, 42)
 	assert.Equal(7, len(keeper.allOrders))
 	assert.Equal(1, len(keeper.engines))
-	err := keeper.SnapShotOrderBook(ctx, 43)
+
+	effectedStoredKeys1, err := keeper.SnapShotOrderBook(ctx, 43)
+	storedKVPairs1 := effectedStoredKVPairs(keeper, ctx, effectedStoredKeys1)
+	effectedStoredKeys2, err := keeper.SnapShotOrderBook(ctx, 43)
+	storedKVPairs2 := effectedStoredKVPairs(keeper, ctx, effectedStoredKeys2)
+	assert.Equal(storedKVPairs1, storedKVPairs2)
+
 	assert.Nil(err)
 	keeper.MarkBreatheBlock(ctx, 43, time.Now().Unix())
 	keeper2 := MakeKeeper(cdc)
@@ -200,7 +215,7 @@ func TestKeeper_SnapShotOrderBookEmpty(t *testing.T) {
 	buys, sells := keeper.engines["XYZ_BNB"].Book.GetAllLevels()
 	assert.Equal(0, len(buys))
 	assert.Equal(0, len(sells))
-	err := keeper.SnapShotOrderBook(ctx, 43)
+	_, err := keeper.SnapShotOrderBook(ctx, 43)
 	assert.Nil(err)
 	keeper.MarkBreatheBlock(ctx, 43, time.Now().Unix())
 

--- a/plugins/dex/plugin.go
+++ b/plugins/dex/plugin.go
@@ -30,7 +30,9 @@ func EndBreatheBlock(ctx sdk.Context, accountMapper auth.AccountMapper, dexKeepe
 	logger.Info("Mark BreathBlock", "blockHeight", height)
 	dexKeeper.MarkBreatheBlock(ctx, height, blockTime)
 	logger.Info("Save Orderbook snapshot", "blockHeight", height)
-	dexKeeper.SnapShotOrderBook(ctx, height)
+	if _, err := dexKeeper.SnapShotOrderBook(ctx, height); err != nil {
+		logger.Error("Failed to snapshot order book", "blockHeight", height, "err", err)
+	}
 }
 
 func updateTickSizeAndLotSize(ctx sdk.Context, dexKeeper DexKeeper) {


### PR DESCRIPTION
### Description

sort active orders before we persist to state

### Rationale

#147 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...
