### PR TITLE
[R4R] #66 make the app config can be generated for testnet command 

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -94,7 +94,7 @@ type PublicationConfig struct {
 func defaultPublicationConfig() *PublicationConfig {
 	return &PublicationConfig{
 		PublishOrderUpdates: false,
-		OrderUpdatesTopic:   "test",
+		OrderUpdatesTopic:   "orders",
 		OrderUpdatesKafka:   "127.0.0.1:9092",
 
 		PublishAccountBalance: false,
@@ -102,7 +102,7 @@ func defaultPublicationConfig() *PublicationConfig {
 		AccountBalanceKafka:   "127.0.0.1:9092",
 
 		PublishOrderBook: false,
-		OrderBookTopic:   "books",
+		OrderBookTopic:   "orders",
 		OrderBookKafka:   "127.0.0.1:9092",
 	}
 }


### PR DESCRIPTION
make the app config can be generated for testnet command  and change default config for QA/PROD setting

### Description

The app.toml will always generated before we start any sub-command of bnbchaind (ensured by PresistentPreRun func) but for testnet subcommand, it create several config dirs for validators we want generated and app.toml is not placed there without this PR.

### Rationale

#66 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

