### PR TITLE
[R4R] #175 Fix orderbook restore doesn't recover last trade price correctly

### DIFF
--- a/plugins/dex/order/keeper_recovery.go
+++ b/plugins/dex/order/keeper_recovery.go
@@ -149,6 +149,7 @@ func (kp *Keeper) LoadOrderBookSnapshot(ctx sdk.Context, daysBack int) (int64, e
 		for _, pl := range ob.Sells {
 			eng.Book.InsertPriceLevel(&pl, me.SELLSIDE)
 		}
+		eng.LastTradePrice = ob.LastTradePrice
 		logger.Info("Successfully Loaded order snapshot", "pair", pair)
 	}
 	key := genActiveOrdersSnapshotKey(height)


### PR DESCRIPTION
Working on unit-test

### Description

add a description of your changes here...

### Rationale

#175 

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

