### PR TITLE
Hex AccAddress in order IDs

### DIFF
--- a/app/ordertx_test.go
+++ b/app/ordertx_test.go
@@ -44,7 +44,7 @@ func genOrderID(add sdk.AccAddress, seq int64, ctx sdk.Context, am auth.AccountM
 		}
 		am.SetAccount(ctx, acc)
 	}
-	oid := fmt.Sprintf("%s-%d", add.String(), seq)
+	oid := fmt.Sprintf("%X-%d", add, seq)
 	return oid
 }
 
@@ -111,7 +111,7 @@ func Test_handleNewOrder_DeliverTx(t *testing.T) {
 	testApp.DexKeeper.AddEngine(tradingPair)
 
 	add := Account(0).GetAddress()
-	oid := fmt.Sprintf("%s-0", add.String())
+	oid := fmt.Sprintf("%X-0", add)
 	msg := o.NewNewOrderMsg(add, oid, 1, "BTC_BNB", 355e8, 1e8)
 
 	res, e := testClient.DeliverTxSync(msg, testApp.Codec)
@@ -283,7 +283,7 @@ func Test_handleCancelOrder_CheckTx(t *testing.T) {
 
 	// setup accounts
 	add := Account(0).GetAddress()
-	oid := fmt.Sprintf("%s-0", add.String())
+	oid := fmt.Sprintf("%X-0", add)
 	add2 := Account(1).GetAddress()
 
 	msg := o.NewCancelOrderMsg(add, "BTC_BNB", oid, "doesnotexist")

--- a/plugins/dex/order/handler_test.go
+++ b/plugins/dex/order/handler_test.go
@@ -74,7 +74,7 @@ func TestHandler_ValidateOrder_OrderNotExist(t *testing.T) {
 		Sender:   acc.GetAddress(),
 		Price:    1e8,
 		Quantity: 1e8,
-		Id:       fmt.Sprintf("%s-0", acc.GetAddress()),
+		Id:       fmt.Sprintf("%X-0", acc.GetAddress()),
 	}
 
 	err = validateOrder(ctx, pairMapper, accMapper, msg)
@@ -124,7 +124,7 @@ func TestHandler_ValidateOrder_WrongPrice(t *testing.T) {
 		Sender:   acc.GetAddress(),
 		Price:    1e3 + 1e2,
 		Quantity: 1e6,
-		Id:       fmt.Sprintf("%s-0", acc.GetAddress()),
+		Id:       fmt.Sprintf("%X-0", acc.GetAddress()),
 	}
 
 	err = validateOrder(ctx, pairMapper, accMapper, msg)
@@ -145,7 +145,7 @@ func TestHandler_ValidateOrder_WrongQuantity(t *testing.T) {
 		Sender:   acc.GetAddress(),
 		Price:    1e3,
 		Quantity: 1e5 + 1e4,
-		Id:       fmt.Sprintf("%s-0", acc.GetAddress()),
+		Id:       fmt.Sprintf("%X-0", acc.GetAddress()),
 	}
 
 	err = validateOrder(ctx, pairMapper, accMapper, msg)
@@ -165,7 +165,7 @@ func TestHandler_ValidateOrder_Normal(t *testing.T) {
 		Sender:   acc.GetAddress(),
 		Price:    1e3,
 		Quantity: 1e5,
-		Id:       fmt.Sprintf("%s-0", acc.GetAddress()),
+		Id:       fmt.Sprintf("%X-0", acc.GetAddress()),
 	}
 
 	err = validateOrder(ctx, pairMapper, accMapper, msg)
@@ -184,7 +184,7 @@ func TestHandler_ValidateOrder_MaxNotional(t *testing.T) {
 		Sender:   acc.GetAddress(),
 		Price:    (math.MaxInt64 - 4) - ((int64)(math.MaxInt64-4) % 1e3),
 		Quantity: (math.MaxInt64 - 4) - ((int64)(math.MaxInt64-4) % 1e5),
-		Id:       fmt.Sprintf("%s-0", acc.GetAddress()),
+		Id:       fmt.Sprintf("%X-0", acc.GetAddress()),
 	}
 
 	err = validateOrder(ctx, pairMapper, accMapper, msg)

--- a/plugins/dex/order/msg.go
+++ b/plugins/dex/order/msg.go
@@ -42,8 +42,8 @@ func IToSide(side int8) string {
 }
 
 // GenerateOrderID generates an order ID
-func GenerateOrderID(sequence int64, from sdk.AccAddress) string {
-	id := fmt.Sprintf("%s-%d", from.String(), sequence)
+func GenerateOrderID(sequence int64, addr sdk.AccAddress) string {
+	id := fmt.Sprintf("%X-%d", addr, sequence)
 	return id
 }
 

--- a/plugins/dex/order/msg_test.go
+++ b/plugins/dex/order/msg_test.go
@@ -1,6 +1,7 @@
 package order
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -82,8 +83,11 @@ func TestGenerateOrderId(t *testing.T) {
 	cctx := newCoreContext(5)
 	viper.SetDefault(client.FlagSequence, "5")
 
-	saddr := "cosmosaccaddr1atcjghcs273lg95p2kcrn509gdyx2h2g83l0mj"
-	addr, err := sdk.AccAddressFromBech32(saddr)
+	sourceAddr := "cosmosaccaddr1atcjghcs273lg95p2kcrn509gdyx2h2g83l0mj"
+	expectedHexAddr := "EAF1245F1057A3F4168155B039D1E54348655D48"
+
+	addr, err := sdk.AccAddressFromBech32(sourceAddr)
+	hexAddr := fmt.Sprintf("%X", addr)
 	if err != nil {
 		panic(err)
 	}
@@ -97,5 +101,10 @@ func TestGenerateOrderId(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	assert.Equal(t, "cosmosaccaddr1atcjghcs273lg95p2kcrn509gdyx2h2g83l0mj-5", orderID)
+
+	// to ensure use of sprintf("%X", ...) is working.
+	assert.Equal(t, expectedHexAddr, hexAddr)
+
+	expectedID := fmt.Sprintf("%s-5", hexAddr)
+	assert.Equal(t, expectedID, orderID)
 }


### PR DESCRIPTION
### Description

Order IDs currently follow this format: `(addr)-(seq)`.

After this change, they will be migrated from using the string form of the bech32 address:
`cosmosaccaddr1atcjghcs273lg95p2kcrn509gdyx2h2g83l0mj-0` (sequence: 0)

to the following hex form:
`EAF1245F1057A3F4168155B039D1E54348655D48-0`

### Rationale

The prefix, checksum and user-friendly character encoding are not required in order IDs. Using the hex form reduces the space required in the message and saves some serialisation cost.

### Changes

Notable changes: 
* Changed msg and ordertx tests to expect the new form of order IDs.
* Changed ID generation (in order msg constructor and `validateOrder` in the handler).

### Warning

The current snapshot and blockchain will be invalidated after this change. **You must reset your local chain state `./bnbchaind unsafe_reset_all` before starting your nodes.**

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Related issues

#180 

