### PR TITLE
Added Version fields to all Msgs, Msg housekeeping

### DIFF
--- a/plugins/dex/list/handler.go
+++ b/plugins/dex/list/handler.go
@@ -17,7 +17,7 @@ import (
 func NewHandler(keeper *order.Keeper, tokenMapper tokens.Mapper) common.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg, simulate bool) sdk.Result {
 		switch msg := msg.(type) {
-		case Msg:
+		case ListMsg:
 			return handleList(ctx, keeper, tokenMapper, msg, simulate)
 		default:
 			errMsg := fmt.Sprintf("Unrecognized dex msg type: %v", reflect.TypeOf(msg).Name())
@@ -27,7 +27,7 @@ func NewHandler(keeper *order.Keeper, tokenMapper tokens.Mapper) common.Handler 
 }
 
 func handleList(
-	ctx sdk.Context, keeper *order.Keeper, tokenMapper tokens.Mapper, msg Msg, simulate bool,
+	ctx sdk.Context, keeper *order.Keeper, tokenMapper tokens.Mapper, msg ListMsg, simulate bool,
 ) sdk.Result {
 	if keeper.PairMapper.Exists(ctx, msg.BaseAssetSymbol, msg.QuoteAssetSymbol) || keeper.PairMapper.Exists(ctx, msg.QuoteAssetSymbol, msg.BaseAssetSymbol) {
 		return sdk.ErrInvalidCoins("trading pair exists").Result()

--- a/plugins/dex/list/msg.go
+++ b/plugins/dex/list/msg.go
@@ -11,15 +11,17 @@ import (
 
 const Route = "dexList"
 
-type Msg struct {
+type ListMsg struct {
+	Version          byte           `json:"version"`
 	From             sdk.AccAddress `json:"from"`
 	BaseAssetSymbol  string         `json:"base_asset_symbol"`
 	QuoteAssetSymbol string         `json:"quote_asset_symbol"`
 	InitPrice        int64          `json:"init_price"`
 }
 
-func NewMsg(from sdk.AccAddress, baseAssetSymbol string, quoteAssetSymbol string, initPrice int64) Msg {
-	return Msg{
+func NewMsg(from sdk.AccAddress, baseAssetSymbol string, quoteAssetSymbol string, initPrice int64) ListMsg {
+	return ListMsg{
+		Version:          0x01,
 		From:             from,
 		BaseAssetSymbol:  baseAssetSymbol,
 		QuoteAssetSymbol: quoteAssetSymbol,
@@ -27,30 +29,29 @@ func NewMsg(from sdk.AccAddress, baseAssetSymbol string, quoteAssetSymbol string
 	}
 }
 
-func (msg Msg) Type() string                            { return Route }
-func (msg Msg) String() string                          { return fmt.Sprintf("MsgList{%#v}", msg) }
-func (msg Msg) Get(key interface{}) (value interface{}) { return nil }
-func (msg Msg) GetSigners() []sdk.AccAddress            { return []sdk.AccAddress{msg.From} }
+func (msg ListMsg) Type() string                 { return Route }
+func (msg ListMsg) String() string               { return fmt.Sprintf("MsgList{%#v}", msg) }
+func (msg ListMsg) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.From} }
 
-func (msg Msg) ValidateBasic() sdk.Error {
+func (msg ListMsg) ValidateBasic() sdk.Error {
+	if msg.Version != 0x01 {
+		return sdk.ErrInternal("Invalid version. Expected 0x01")
+	}
 	err := types.ValidateSymbol(msg.BaseAssetSymbol)
 	if err != nil {
 		return sdk.ErrInvalidCoins("base token: " + err.Error())
 	}
-
 	err = types.ValidateSymbol(msg.QuoteAssetSymbol)
 	if err != nil {
 		return sdk.ErrInvalidCoins("quote token: " + err.Error())
 	}
-
 	if msg.InitPrice <= 0 {
 		return sdk.ErrInvalidCoins("price should be positive")
 	}
-
 	return nil
 }
 
-func (msg Msg) GetSignBytes() []byte {
+func (msg ListMsg) GetSignBytes() []byte {
 	b, err := json.Marshal(msg)
 	if err != nil {
 		panic(err)

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -7,12 +7,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	tmlog "github.com/tendermint/tendermint/libs/log"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
-	"github.com/pkg/errors"
 
 	bnclog "github.com/BiJie/BinanceChain/common/log"
 	"github.com/BiJie/BinanceChain/common/tx"

--- a/plugins/dex/wire.go
+++ b/plugins/dex/wire.go
@@ -1,11 +1,10 @@
 package dex
 
 import (
-	"github.com/BiJie/BinanceChain/wire"
-
 	"github.com/BiJie/BinanceChain/plugins/dex/list"
 	"github.com/BiJie/BinanceChain/plugins/dex/order"
 	"github.com/BiJie/BinanceChain/plugins/dex/types"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 // Register concrete types on wire codec
@@ -17,7 +16,7 @@ func RegisterWire(cdc *wire.Codec) {
 
 	cdc.RegisterConcrete(order.NewOrderResponse{}, "dex/NewOrderResponse", nil)
 
-	cdc.RegisterConcrete(list.Msg{}, "dex/ListMsg", nil)
+	cdc.RegisterConcrete(list.ListMsg{}, "dex/ListMsg", nil)
 	cdc.RegisterConcrete(types.TradingPair{}, "dex/TradingPair", nil)
 
 	cdc.RegisterConcrete(order.OrderBookSnapshot{}, "dex/OrderBookSnapshot", nil)

--- a/plugins/shared/msg/base.go
+++ b/plugins/shared/msg/base.go
@@ -1,4 +1,4 @@
-package base
+package msg
 
 import (
 	"encoding/json"
@@ -10,28 +10,31 @@ import (
 )
 
 type MsgBase struct {
-	From   sdk.AccAddress `json:"from"`
-	Symbol string         `json:"symbol"`
-	Amount int64          `json:"amount"`
+	Version byte           `json:"version"`
+	From    sdk.AccAddress `json:"from"`
+	Symbol  string         `json:"symbol"`
+	Amount  int64          `json:"amount"`
 }
 
 func (msg MsgBase) Type() string {
-	return ""
+	// TODO: panic here? - should not be accessed.
+	return "BASE"
 }
 
 // ValidateBasic does a simple validation check that
 // doesn't require access to any other information.
 func (msg MsgBase) ValidateBasic() sdk.Error {
+	if msg.Version != 0x01 {
+		return sdk.ErrInternal("Invalid version. Expected 0x01")
+	}
 	err := types.ValidateSymbol(msg.Symbol)
 	if err != nil {
 		return sdk.ErrInvalidCoins(err.Error())
 	}
-
 	if msg.Amount <= 0 {
 		// TODO: maybe we need to define our own errors
 		return sdk.ErrInsufficientFunds("amount should be more than 0")
 	}
-
 	return nil
 }
 

--- a/plugins/tokens/burn/handler.go
+++ b/plugins/tokens/burn/handler.go
@@ -14,7 +14,7 @@ import (
 
 func NewHandler(tokenMapper store.Mapper, keeper bank.Keeper) common.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg, simulate bool) sdk.Result {
-		if msg, ok := msg.(Msg); ok {
+		if msg, ok := msg.(BurnMsg); ok {
 			return handleBurnToken(ctx, tokenMapper, keeper, msg)
 		}
 
@@ -23,7 +23,7 @@ func NewHandler(tokenMapper store.Mapper, keeper bank.Keeper) common.Handler {
 	}
 }
 
-func handleBurnToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Keeper, msg Msg) sdk.Result {
+func handleBurnToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Keeper, msg BurnMsg) sdk.Result {
 	logger := log.With("module", "token", "symbol", msg.Symbol, "amount", msg.Amount)
 	burnAmount := msg.Amount
 	symbol := strings.ToUpper(msg.Symbol)

--- a/plugins/tokens/burn/msg.go
+++ b/plugins/tokens/burn/msg.go
@@ -5,27 +5,27 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/BiJie/BinanceChain/plugins/tokens/base"
+	shared "github.com/BiJie/BinanceChain/plugins/shared/msg"
 )
 
 // TODO: "route expressions can only contain alphanumeric characters", we need to change the cosmos sdk to support slash
-// const Route = "tokens/burn"
-const Route = "tokensBurn"
+// const BurnRoute = "tokens/burn"
+const BurnRoute = "tokensBurn"
 
-var _ sdk.Msg = (*Msg)(nil)
+var _ sdk.Msg = (*BurnMsg)(nil)
 
-type Msg struct {
-	base.MsgBase
+type BurnMsg struct {
+	shared.MsgBase
 }
 
-func NewMsg(from sdk.AccAddress, symbol string, amount int64) Msg {
-	return Msg{base.MsgBase{From: from, Symbol: symbol, Amount: amount}}
+func NewMsg(from sdk.AccAddress, symbol string, amount int64) BurnMsg {
+	return BurnMsg{shared.MsgBase{From: from, Symbol: symbol, Amount: amount}}
 }
 
-func (msg Msg) Type() string {
-	return Route
+func (msg BurnMsg) Type() string {
+	return BurnRoute
 }
 
-func (msg Msg) String() string {
+func (msg BurnMsg) String() string {
 	return fmt.Sprintf("BurnMsg{%v#%v%v}", msg.From, msg.Amount, msg.Symbol)
 }

--- a/plugins/tokens/fee.go
+++ b/plugins/tokens/fee.go
@@ -19,8 +19,8 @@ const (
 
 func init() {
 	tx.RegisterCalculator(issue.Route, tx.FixedFeeCalculator(IssueFee, types.FeeForAll))
-	tx.RegisterCalculator(burn.Route, tx.FixedFeeCalculator(BurnFee, types.FeeForProposer))
-	tx.RegisterCalculator(freeze.RouteFreeze, tx.FixedFeeCalculator(FreezeFee, types.FeeForProposer))
+	tx.RegisterCalculator(burn.BurnRoute, tx.FixedFeeCalculator(BurnFee, types.FeeForProposer))
+	tx.RegisterCalculator(freeze.FreezeRoute, tx.FixedFeeCalculator(FreezeFee, types.FeeForProposer))
 	// TODO: we will rewrite Transfer tx, so put it here temporarily
 	tx.RegisterCalculator(bank.MsgSend{}.Type(), tx.FixedFeeCalculator(TransferFee, types.FeeForProposer))
 }

--- a/plugins/tokens/freeze/msg.go
+++ b/plugins/tokens/freeze/msg.go
@@ -5,24 +5,26 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/BiJie/BinanceChain/plugins/tokens/base"
+	shared "github.com/BiJie/BinanceChain/plugins/shared/msg"
 )
 
 // TODO: "route expressions can only contain alphanumeric characters", we need to change the cosmos sdk to support slash
-// const RouteFreeze = "tokens/freeze"
-const RouteFreeze = "tokensFreeze"
+// const FreezeRoute = "tokens/freeze"
+const FreezeRoute = "tokensFreeze"
 
 var _ sdk.Msg = (*FreezeMsg)(nil)
 
 type FreezeMsg struct {
-	base.MsgBase
+	shared.MsgBase
 }
 
 func NewFreezeMsg(from sdk.AccAddress, symbol string, amount int64) FreezeMsg {
-	return FreezeMsg{base.MsgBase{From: from, Symbol: symbol, Amount: amount}}
+	return FreezeMsg{shared.MsgBase{From: from, Symbol: symbol, Amount: amount}}
 }
 
-func (msg FreezeMsg) Type() string { return RouteFreeze }
+func (msg FreezeMsg) Type() string {
+	return FreezeRoute
+}
 
 func (msg FreezeMsg) String() string {
 	return fmt.Sprintf("Freeze{%v#%v}", msg.From, msg.Symbol)
@@ -31,14 +33,14 @@ func (msg FreezeMsg) String() string {
 var _ sdk.Msg = (*UnfreezeMsg)(nil)
 
 type UnfreezeMsg struct {
-	base.MsgBase
+	shared.MsgBase
 }
 
 func NewUnfreezeMsg(from sdk.AccAddress, symbol string, amount int64) UnfreezeMsg {
-	return UnfreezeMsg{base.MsgBase{From: from, Symbol: symbol, Amount: amount}}
+	return UnfreezeMsg{shared.MsgBase{From: from, Symbol: symbol, Amount: amount}}
 }
 
-func (msg UnfreezeMsg) Type() string { return RouteFreeze }
+func (msg UnfreezeMsg) Type() string { return FreezeRoute }
 
 func (msg UnfreezeMsg) String() string {
 	return fmt.Sprintf("Unfreeze{%v#%v%v}", msg.From, msg.Amount, msg.Symbol)

--- a/plugins/tokens/issue/handler.go
+++ b/plugins/tokens/issue/handler.go
@@ -16,7 +16,7 @@ import (
 // NewHandler creates a new token issue message handler
 func NewHandler(tokenMapper store.Mapper, keeper bank.Keeper) common.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg, simulate bool) sdk.Result {
-		if msg, ok := msg.(Msg); ok {
+		if msg, ok := msg.(IssueMsg); ok {
 			return handleIssueToken(ctx, tokenMapper, keeper, msg)
 		}
 
@@ -25,7 +25,7 @@ func NewHandler(tokenMapper store.Mapper, keeper bank.Keeper) common.Handler {
 	}
 }
 
-func handleIssueToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Keeper, msg Msg) sdk.Result {
+func handleIssueToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Keeper, msg IssueMsg) sdk.Result {
 	symbol := strings.ToUpper(msg.Symbol)
 	exists := tokenMapper.Exists(ctx, symbol)
 	logger := log.With("module", "token", "symbol", symbol, "name", msg.Name, "total_supply", msg.TotalSupply, "issuer", msg.From)

--- a/plugins/tokens/issue/msg.go
+++ b/plugins/tokens/issue/msg.go
@@ -14,17 +14,19 @@ import (
 // const Route  = "tokens/issue"
 const Route = "tokensIssue"
 
-var _ sdk.Msg = Msg{}
+var _ sdk.Msg = IssueMsg{}
 
-type Msg struct {
+type IssueMsg struct {
+	Version     byte           `json:"version"`
 	From        sdk.AccAddress `json:"from"`
 	Name        string         `json:"name"`
 	Symbol      string         `json:"symbol"`
 	TotalSupply int64          `json:"total_supply"`
 }
 
-func NewMsg(from sdk.AccAddress, name, symbol string, supply int64) Msg {
-	return Msg{
+func NewMsg(from sdk.AccAddress, name, symbol string, supply int64) IssueMsg {
+	return IssueMsg{
+		Version:     0x01,
 		From:        from,
 		Name:        name,
 		Symbol:      symbol,
@@ -34,7 +36,10 @@ func NewMsg(from sdk.AccAddress, name, symbol string, supply int64) Msg {
 
 // ValidateBasic does a simple validation check that
 // doesn't require access to any other information.
-func (msg Msg) ValidateBasic() sdk.Error {
+func (msg IssueMsg) ValidateBasic() sdk.Error {
+	if msg.Version != 0x01 {
+		return sdk.ErrInternal("Invalid version. Expected 0x01")
+	}
 	if msg.From == nil {
 		return sdk.ErrInvalidAddress("sender address cannot be empty")
 	}
@@ -54,13 +59,12 @@ func (msg Msg) ValidateBasic() sdk.Error {
 	return nil
 }
 
-// Implements Msg.
-func (msg Msg) Type() string                            { return Route }
-func (msg Msg) String() string                          { return fmt.Sprintf("IssueMsg{%#v}", msg) }
-func (msg Msg) Get(key interface{}) (value interface{}) { return nil }
-func (msg Msg) GetSigners() []sdk.AccAddress            { return []sdk.AccAddress{msg.From} }
+// Implements IssueMsg.
+func (msg IssueMsg) Type() string                 { return Route }
+func (msg IssueMsg) String() string               { return fmt.Sprintf("IssueMsg{%#v}", msg) }
+func (msg IssueMsg) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.From} }
 
-func (msg Msg) GetSignBytes() []byte {
+func (msg IssueMsg) GetSignBytes() []byte {
 	b, err := json.Marshal(msg) // XXX: ensure some canonical form
 	if err != nil {
 		panic(err)

--- a/plugins/tokens/route.go
+++ b/plugins/tokens/route.go
@@ -14,7 +14,7 @@ import (
 func Routes(tokenMapper store.Mapper, accountMapper auth.AccountMapper, keeper bank.Keeper) map[string]common.Handler {
 	routes := make(map[string]common.Handler)
 	routes[issue.Route] = issue.NewHandler(tokenMapper, keeper)
-	routes[burn.Route] = burn.NewHandler(tokenMapper, keeper)
-	routes[freeze.RouteFreeze] = freeze.NewHandler(tokenMapper, accountMapper, keeper)
+	routes[burn.BurnRoute] = burn.NewHandler(tokenMapper, keeper)
+	routes[freeze.FreezeRoute] = freeze.NewHandler(tokenMapper, accountMapper, keeper)
 	return routes
 }

--- a/plugins/tokens/wire.go
+++ b/plugins/tokens/wire.go
@@ -1,17 +1,16 @@
 package tokens
 
 import (
-	"github.com/BiJie/BinanceChain/wire"
-
 	"github.com/BiJie/BinanceChain/plugins/tokens/burn"
 	"github.com/BiJie/BinanceChain/plugins/tokens/freeze"
 	"github.com/BiJie/BinanceChain/plugins/tokens/issue"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 // Register concrete types on wire codec
 func RegisterWire(cdc *wire.Codec) {
-	cdc.RegisterConcrete(issue.Msg{}, "tokens/IssueMsg", nil)
-	cdc.RegisterConcrete(burn.Msg{}, "tokens/BurnMsg", nil)
+	cdc.RegisterConcrete(issue.IssueMsg{}, "tokens/IssueMsg", nil)
+	cdc.RegisterConcrete(burn.BurnMsg{}, "tokens/BurnMsg", nil)
 	cdc.RegisterConcrete(freeze.FreezeMsg{}, "tokens/FreezeMsg", nil)
 	cdc.RegisterConcrete(freeze.UnfreezeMsg{}, "tokens/UnfreezeMsg", nil)
 }


### PR DESCRIPTION
### Description

Plugin `Msg` implementations have been changed to include and validate a `Version` field, which is set to `0x01` everywhere for now.

### Rationale

To future proof changes in `Msg` implementations. Rather than switch on a block height after a change or update, we can switch on the `Version` fields instead.

### Changes

Notable changes: 
* Added `Version` to concrete `Msg` structs.
* Updated `ValidateBasic` to include basic `Version` checks.
* Moved `MsgBase` to a new "shared" plugin directory.
* Fixed tests.

### Warning

The current snapshot and blockchain will be invalidated after this change. **You must reset your local chain state `./bnbchaind unsafe_reset_all` before starting your nodes.**

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Related issues

#187

