### PR TITLE
account api: /api/v1/account/{address}

### DIFF
--- a/plugins/api/handlers.go
+++ b/plugins/api/handlers.go
@@ -84,8 +84,8 @@ func (s *server) handleNodeVersionReq() http.HandlerFunc {
 	return hnd.NodeVersionReqHandler(s.ctx)
 }
 
-func (s *server) handleAccountReq(cdc *wire.Codec, ctx context.CoreContext, accStoreName string) http.HandlerFunc {
-	return hnd.AccountReqHandler(cdc, ctx, accStoreName)
+func (s *server) handleAccountReq(cdc *wire.Codec, ctx context.CoreContext, tokens tkstore.Mapper, accStoreName string) http.HandlerFunc {
+	return hnd.AccountReqHandler(cdc, ctx, tokens, accStoreName)
 }
 
 func (s *server) handleSimulateReq(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFunc {

--- a/plugins/api/handlers/simulate.go
+++ b/plugins/api/handlers/simulate.go
@@ -66,6 +66,7 @@ func SimulateReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFu
 			return
 		}
 
+		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
 		w.Write(output)
 	}

--- a/plugins/api/routes.go
+++ b/plugins/api/routes.go
@@ -21,7 +21,7 @@ func (s *server) bindRoutes() *server {
 		Methods("GET")
 
 	// auth routes
-	r.HandleFunc(prefix+"/account/{address}", s.handleAccountReq(s.cdc, s.ctx, s.accStoreName)).
+	r.HandleFunc(prefix+"/account/{address}", s.handleAccountReq(s.cdc, s.ctx, s.tokens, s.accStoreName)).
 		Methods("GET")
 
 	// tx routes

--- a/plugins/dex/client/rest/getdepth.go
+++ b/plugins/dex/client/rest/getdepth.go
@@ -76,6 +76,7 @@ func DepthReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFunc 
 			return
 		}
 
+		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
 
 		err = rutils.StreamDepthResponse(w, ob, limit)

--- a/plugins/dex/client/rest/getpairs.go
+++ b/plugins/dex/client/rest/getpairs.go
@@ -91,6 +91,7 @@ func GetPairsReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFu
 			return
 		}
 
+		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
 		w.Write(output)
 	}

--- a/plugins/dex/client/rest/putorder.go
+++ b/plugins/dex/client/rest/putorder.go
@@ -166,6 +166,7 @@ func PutOrderReqHandler(cdc *wire.Codec, ctx context.CoreContext, accStoreName s
 			return
 		}
 
+		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
 		w.Write(output)
 	}

--- a/plugins/tokens/client/rest/getbalance.go
+++ b/plugins/tokens/client/rest/getbalance.go
@@ -23,7 +23,7 @@ func BalanceReqHandler(cdc *wire.Codec, ctx context.CoreContext, tokens tokens.M
 	}
 	type response struct {
 		Address string       `json:"address"`
-		Balance tokenBalance `json:"balance"`
+		Balance TokenBalance `json:"balance"`
 	}
 	throw := func(w http.ResponseWriter, status int, err error) {
 		w.WriteHeader(status)
@@ -76,7 +76,7 @@ func BalanceReqHandler(cdc *wire.Codec, ctx context.CoreContext, tokens tokens.M
 
 		resp := response{
 			Address: vars["address"],
-			Balance: tokenBalance{
+			Balance: TokenBalance{
 				Symbol: params.symbol,
 				Free:   utils.Fixed8(coins.AmountOf(params.symbol).Int64()),
 				Locked: utils.Fixed8(locked.Int64()),

--- a/plugins/tokens/client/rest/getbalances.go
+++ b/plugins/tokens/client/rest/getbalances.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -9,7 +8,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/BiJie/BinanceChain/common/utils"
 	"github.com/BiJie/BinanceChain/plugins/tokens"
 	"github.com/BiJie/BinanceChain/wire"
 )
@@ -18,13 +16,9 @@ import (
 func BalancesReqHandler(
 	cdc *wire.Codec, ctx context.CoreContext, tokens tokens.Mapper,
 ) http.HandlerFunc {
-	type params struct {
-		address sdk.AccAddress
-	}
-
 	type response struct {
 		Address  string         `json:"address"`
-		Balances []tokenBalance `json:"balances"`
+		Balances []TokenBalance `json:"balances"`
 	}
 	responseType := "application/json"
 
@@ -46,55 +40,10 @@ func BalancesReqHandler(
 			return
 		}
 
-		params := params{
-			address: addr,
-		}
-
-		coins, err := getCoinsCC(cdc, ctx, params.address)
+		bals, err := GetBalances(cdc, ctx, tokens, addr)
 		if err != nil {
-			throw(w, http.StatusNotFound, err)
+			throw(w, http.StatusInternalServerError, err)
 			return
-		}
-
-		// must do it this way because GetTokenList relies on store.Iterator
-		// which we can't use from a CoreContext
-		var denoms map[string]bool
-		denoms = map[string]bool{}
-		for _, coin := range coins {
-			denom := coin.Denom
-			exists := tokens.ExistsCC(ctx, denom)
-			// TODO: we probably actually want to show zero balances.
-			// if exists && !sdk.Int.IsZero(coins.AmountOf(denom)) {
-			if exists {
-				denoms[denom] = true
-			}
-		}
-
-		symbs := make([]string, 0, len(denoms))
-		bals := make([]tokenBalance, 0, len(denoms))
-		for symb := range denoms {
-			symbs = append(symbs, symb)
-			// count locked and frozen coins
-			locked := sdk.NewInt(0)
-			frozen := sdk.NewInt(0)
-			lockedc, err := getLockedCC(cdc, ctx, params.address)
-			if err != nil {
-				fmt.Println("getLockedCC error ignored, will use `0`")
-			} else {
-				locked = lockedc.AmountOf(symb)
-			}
-			frozenc, err := getFrozenCC(cdc, ctx, params.address)
-			if err != nil {
-				fmt.Println("getFrozenCC error ignored, will use `0`")
-			} else {
-				frozen = frozenc.AmountOf(symb)
-			}
-			bals = append(bals, tokenBalance{
-				Symbol: symb,
-				Free:   utils.Fixed8(coins.AmountOf(symb).Int64()),
-				Locked: utils.Fixed8(locked.Int64()),
-				Frozen: utils.Fixed8(frozen.Int64()),
-			})
 		}
 
 		resp := response{
@@ -108,6 +57,7 @@ func BalancesReqHandler(
 			return
 		}
 
+		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
 		w.Write(output)
 	}

--- a/plugins/tokens/client/rest/gettoken.go
+++ b/plugins/tokens/client/rest/gettoken.go
@@ -69,6 +69,7 @@ func GetTokenReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFu
 			return
 		}
 
+		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
 		w.Write(output)
 	}

--- a/plugins/tokens/client/rest/gettokens.go
+++ b/plugins/tokens/client/rest/gettokens.go
@@ -91,6 +91,7 @@ func GetTokensReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerF
 			return
 		}
 
+		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
 		w.Write(output)
 	}


### PR DESCRIPTION
### Description

This API is for getting details of an individual account.

Unlike the cosmos account API, this one returns only the necessary data and satisfies the [Swagger spec](https://github.com/BiJie/bnc-http-ap/blob/master/swagger.yml).

### Rationale

The current Cosmos API returns extra/unnecessary data that may not be required by the client.

### Example

**NOTE:** The example output has changed! See the [comment below](https://github.com/BiJie/BinanceChain/pull/194#issuecomment-432229094).

```
$ curl -s http://localhost:8080/api/v1/account/cosmosaccaddr173hyu6dtfkrj9vujjhvz2ayehrng64rxq3h4yp | json_pp
{
   "sequence" : "3",
   "coins" : [
      {
         "denom" : "BNB",
         "amount" : "4007498400373793280"
      },
      {
         "denom" : "XYY",
         "amount" : "99000000"
      }
   ],
   "address" : "cosmosaccaddr173hyu6dtfkrj9vujjhvz2ayehrng64rxq3h4yp",
   "account_number" : "2",
   "public_key" : {
      "value" : "AxsITzRpXHLiJZPS4iKqX1uG3LQMVs+CyZUxK2JVwRkJ",
      "type" : "tendermint/PubKeySecp256k1"
   }
}
```

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

...

