### PR TITLE
Renamed /api/v1/pairs to /api/v1/markets

### DIFF
--- a/plugins/api/routes.go
+++ b/plugins/api/routes.go
@@ -29,7 +29,7 @@ func (s *server) bindRoutes() *server {
 		Methods("POST")
 
 	// dex routes
-	r.HandleFunc(prefix+"/pairs", s.handlePairsReq(s.cdc, s.ctx)).
+	r.HandleFunc(prefix+"/markets", s.handlePairsReq(s.cdc, s.ctx)).
 		Methods("GET")
 	r.HandleFunc(prefix+"/depth", s.handleDexDepthReq(s.cdc, s.ctx)).
 		Queries("symbol", "{symbol}", "limit", "{limit:[0-9]+}").


### PR DESCRIPTION
### Description

Renamed /api/v1/pairs to /api/v1/markets, as per the API document:

https://docs.google.com/spreadsheets/d/1bBYIo0h1_TAvmYyXC4ig8x1z869dDSHosECZ8j5YCkU/edit#gid=0

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)
