### PR TITLE
api: working content-type response headers

### DIFF
--- a/plugins/api/handlers/account.go
+++ b/plugins/api/handlers/account.go
@@ -33,8 +33,8 @@ func AccountReqHandler(
 	accDecoder := authcmd.GetAccountDecoder(cdc)
 
 	throw := func(w http.ResponseWriter, status int, message string) {
-		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(status)
 		w.Write([]byte(message))
 		return
 	}
@@ -76,8 +76,8 @@ func AccountReqHandler(
 			Balances:    bals,
 		}
 
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
+		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(resp)
 	}
 }

--- a/plugins/api/handlers/simulate.go
+++ b/plugins/api/handlers/simulate.go
@@ -19,8 +19,8 @@ func SimulateReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFu
 	responseType := "application/json"
 
 	throw := func(w http.ResponseWriter, status int, message string) {
-		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(status)
 		w.Write([]byte(message))
 		return
 	}
@@ -66,8 +66,8 @@ func SimulateReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFu
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
+		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}
 }

--- a/plugins/dex/client/rest/getdepth.go
+++ b/plugins/dex/client/rest/getdepth.go
@@ -28,8 +28,8 @@ func DepthReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFunc 
 	responseType := "application/json"
 
 	throw := func(w http.ResponseWriter, status int, err error) {
-		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(status)
 		w.Write([]byte(err.Error()))
 		return
 	}
@@ -76,8 +76,8 @@ func DepthReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFunc 
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
+		w.WriteHeader(http.StatusOK)
 
 		err = rutils.StreamDepthResponse(w, ob, limit)
 		if err != nil {

--- a/plugins/dex/client/rest/getpairs.go
+++ b/plugins/dex/client/rest/getpairs.go
@@ -36,8 +36,8 @@ func GetPairsReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFu
 	responseType := "application/json"
 
 	throw := func(w http.ResponseWriter, status int, err error) {
-		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(status)
 		w.Write([]byte(err.Error()))
 		return
 	}
@@ -91,8 +91,8 @@ func GetPairsReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFu
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
+		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}
 }

--- a/plugins/dex/client/rest/openorders.go
+++ b/plugins/dex/client/rest/openorders.go
@@ -14,8 +14,8 @@ import (
 
 func OpenOrdersReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFunc {
 	throw := func(w http.ResponseWriter, status int, err error) {
-		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(status)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/plugins/dex/client/rest/putorder.go
+++ b/plugins/dex/client/rest/putorder.go
@@ -57,8 +57,8 @@ func PutOrderReqHandler(cdc *wire.Codec, ctx context.CoreContext, accStoreName s
 		return true
 	}
 	throw := func(w http.ResponseWriter, status int, err error) {
-		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(status)
 		w.Write([]byte(err.Error()))
 		return
 	}
@@ -166,8 +166,8 @@ func PutOrderReqHandler(cdc *wire.Codec, ctx context.CoreContext, accStoreName s
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
+		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}
 }

--- a/plugins/tokens/client/rest/getbalance.go
+++ b/plugins/tokens/client/rest/getbalance.go
@@ -26,8 +26,8 @@ func BalanceReqHandler(cdc *wire.Codec, ctx context.CoreContext, tokens tokens.M
 		Balance TokenBalance `json:"balance"`
 	}
 	throw := func(w http.ResponseWriter, status int, err error) {
-		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(status)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/plugins/tokens/client/rest/getbalances.go
+++ b/plugins/tokens/client/rest/getbalances.go
@@ -23,8 +23,8 @@ func BalancesReqHandler(
 	responseType := "application/json"
 
 	throw := func(w http.ResponseWriter, status int, err error) {
-		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(status)
 		w.Write([]byte(err.Error()))
 		return
 	}
@@ -57,8 +57,8 @@ func BalancesReqHandler(
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
+		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}
 }

--- a/plugins/tokens/client/rest/gettoken.go
+++ b/plugins/tokens/client/rest/gettoken.go
@@ -31,8 +31,8 @@ func GetTokenReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFu
 	responseType := "application/json"
 
 	throw := func(w http.ResponseWriter, status int, err error) {
-		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(status)
 		w.Write([]byte(err.Error()))
 		return
 	}
@@ -69,8 +69,8 @@ func GetTokenReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFu
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
+		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}
 }

--- a/plugins/tokens/client/rest/gettokens.go
+++ b/plugins/tokens/client/rest/gettokens.go
@@ -36,8 +36,8 @@ func GetTokensReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerF
 	responseType := "application/json"
 
 	throw := func(w http.ResponseWriter, status int, err error) {
-		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(status)
 		w.Write([]byte(err.Error()))
 		return
 	}
@@ -91,8 +91,8 @@ func GetTokensReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerF
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", responseType)
+		w.WriteHeader(http.StatusOK)
 		w.Write(output)
 	}
 }


### PR DESCRIPTION
### Description

Fixes setting the `Content-Type` output in all API responses so that the correct ones are sent. Oops!

This was essentially just an issue of `WriteHeader` being called before `Header().Set`, which made the header set a no-op.

### Example

```bash
$ curl -H 'X-Real-Ip: 0.0.0.0' http://localhost:8081/api/v1/depth\?symbol\=XYY_BNB -vv
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8081 (#0)
> GET /api/v1/depth?symbol=XYY_BNB HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.54.0
> Accept: */*
> X-Real-Ip: 0.0.0.0
>
< HTTP/1.1 200 OK
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Origin:
< Access-Control-Expose-Headers: X-Server-Time
< Content-Length: 1153
< Content-Type: application/json
< Date: Sun, 28 Oct 2018 08:00:32 GMT
< X-Bnc-Ap-Proxied: true
< X-Server-Time: 1540713632
<
{ ...
```

Before these changes, the `Content-Type` header of `text/plain` was being sent back by the node's API server.

### Changes

See the description above.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)
