### PR TITLE
TradingPair2Asset clean up to TradingPair2AssetSafe, resolve #229

### DIFF
--- a/common/utils/tokens.go
+++ b/common/utils/tokens.go
@@ -16,6 +16,14 @@ func TradingPair2Assets(symbol string) (baseAsset, quoteAsset string, err error)
 	return assets[0], assets[1], nil
 }
 
+func TradingPair2AssetsSafe(symbol string) (baseAsset, quoteAsset string) {
+	baseAsset, quoteAsset, err := TradingPair2Assets(symbol)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to parse trading pair symbol:%s into assets", symbol))
+	}
+	return
+}
+
 func Assets2TradingPair(baseAsset, quoteAsset string) (symbol string) {
 	return fmt.Sprintf("%s_%s", baseAsset, quoteAsset)
 }

--- a/plugins/dex/client/rest/openorders.go
+++ b/plugins/dex/client/rest/openorders.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/cosmos/cosmos-sdk/client/context"
+
 	"github.com/BiJie/BinanceChain/plugins/dex/store"
 	"github.com/BiJie/BinanceChain/wire"
-	"github.com/cosmos/cosmos-sdk/client/context"
 )
 
 func OpenOrdersReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFunc {

--- a/plugins/dex/order/handler.go
+++ b/plugins/dex/order/handler.go
@@ -99,7 +99,7 @@ func handleNewOrder(
 
 	// the following is done in the app's checkstate / deliverstate, so it's safe to ignore isCheckTx
 	var amountToLock int64
-	baseAsset, quoteAsset, _ := utils.TradingPair2Assets(msg.Symbol)
+	baseAsset, quoteAsset := utils.TradingPair2AssetsSafe(msg.Symbol)
 	var symbolToLock string
 	if msg.Side == Side.BUY {
 		// TODO: where is 10^8 stored?
@@ -207,7 +207,7 @@ func handleCancelOrder(
 	//unlocked the locked qty for the unfilled qty
 	unlockAmount := ord.LeavesQty()
 
-	baseAsset, quoteAsset, _ := utils.TradingPair2Assets(origOrd.Symbol)
+	baseAsset, quoteAsset := utils.TradingPair2AssetsSafe(origOrd.Symbol)
 	var symbolToUnlock string
 	if origOrd.Side == Side.BUY {
 		symbolToUnlock = strings.ToUpper(quoteAsset)

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -223,7 +223,7 @@ func (kp *Keeper) OrderExists(symbol, id string) (OrderInfo, bool) {
 }
 
 func (kp *Keeper) tradeToTransfers(trade me.Trade, symbol string) (Transfer, Transfer) {
-	baseAsset, quoteAsset, _ := utils.TradingPair2Assets(symbol)
+	baseAsset, quoteAsset := utils.TradingPair2AssetsSafe(symbol)
 	seller := kp.allOrders[symbol][trade.Sid].Sender
 	buyer := kp.allOrders[symbol][trade.Bid].Sender
 	// TODO: where is 10^8 stored?
@@ -236,7 +236,7 @@ func (kp *Keeper) tradeToTransfers(trade me.Trade, symbol string) (Transfer, Tra
 func (kp *Keeper) expiredToTransfer(ord me.OrderPart, ordMsg *OrderInfo, tranEventType transferEventType) Transfer {
 	//here is a trick to use the same currency as in and out ccy to simulate cancel
 	qty := ord.LeavesQty()
-	baseAsset, quoteAsset, _ := utils.TradingPair2Assets(ordMsg.Symbol)
+	baseAsset, quoteAsset := utils.TradingPair2AssetsSafe(ordMsg.Symbol)
 	var unlock int64
 	var unlockAsset string
 	if ordMsg.Side == Side.BUY {


### PR DESCRIPTION
### Description

We add TradingPair2AssetSafe, and directly panic inside.

### Rationale

Now TradingPair2Asset may return an error. but actually all our use cases of this function should never return error, because TradingPair would be checked when it is created or passed in by order.

We add TradingPair2AssetSafe, and directly panic inside.
this would resolve some 'smelly' item in the Sonarqube reports.

### Example

no changes to api.

### Changes

 common/utils/tokens.go                |  8 ++++++++
 common/utils/tokens_test.go           | 46 ++++++++++++++++++++++++++++++++++++++++++++++
 plugins/dex/client/rest/openorders.go |  3 ++-
 plugins/dex/order/handler.go          |  4 ++--
 plugins/dex/order/keeper.go           |  4 ++--

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

**Make test not passed because: 368 line of vendor/github.com/tendermint/iavl/proof_range.go  has a unused var. delete it and make test passed.
Since cosmos is going to upgrade, no issue for this.**

Sonarqube reports:
http://172.18.3.181:9000/project/issues?id=BinanceChain&resolved=false&sinceLeakPeriod=true&types=CODE_SMELL

File: plugins/dex/order/handler.go, plugins/dex/order/keeper do not have related problem.
### Already reviewed by

### Related issues

https://github.com/BiJie/BinanceChain/issues/229

