### PR TITLE
fix unlist iter bug, resolve #224

### DIFF
--- a/plugins/dex/client/rest/openorders.go
+++ b/plugins/dex/client/rest/openorders.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/cosmos/cosmos-sdk/client/context"
+
 	"github.com/BiJie/BinanceChain/plugins/dex/store"
 	"github.com/BiJie/BinanceChain/wire"
-	"github.com/cosmos/cosmos-sdk/client/context"
 )
 
 func OpenOrdersReqHandler(cdc *wire.Codec, ctx context.CoreContext) http.HandlerFunc {

--- a/plugins/dex/matcheng/unrolledlinkedlist.go
+++ b/plugins/dex/matcheng/unrolledlinkedlist.go
@@ -326,12 +326,14 @@ func (ull *ULList) GetTop() *PriceLevel {
 }
 
 func (ull *ULList) Iterate(levelNum int, iter LevelIter) {
+	var curLevel int
 	for b := ull.begin; b != ull.dend; b = b.next {
-		for i, _ := range b.elements {
-			iter(&b.elements[i])
-			if i >= levelNum {
+		for i := range b.elements {
+			if curLevel >= levelNum {
 				return
 			}
+			iter(&b.elements[i])
+			curLevel += 1
 		}
 	}
 }


### PR DESCRIPTION
### Description

fix ULList Iterate function parameter maxLevel do not control the return length bug

### Rationale

fix ULList Iterate function parameter maxLevel do not control the return length bug

### Example

add an example CLI or API response...

### Changes

plugins/dex/matcheng/unrolledlinkedlist.go

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#224 

