### PR TITLE
add version info for binary, resolve #238

### DIFF
--- a/cmd/bnbchaind/main.go
+++ b/cmd/bnbchaind/main.go
@@ -14,6 +14,7 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/BiJie/BinanceChain/app"
+	"github.com/BiJie/BinanceChain/version"
 )
 
 func newApp(logger log.Logger, db dbm.DB, storeTracer io.Writer) abci.Application {
@@ -34,7 +35,7 @@ func main() {
 		Short:             "BNBChain Daemon (server)",
 		PersistentPreRunE: app.PersistentPreRunEFn(ctx),
 	}
-
+	rootCmd.AddCommand(version.VersionCmd)
 	server.AddCommands(ctx.ToCosmosServerCtx(), cdc, rootCmd, app.BinanceAppInit(),
 		server.ConstructAppCreator(newApp, "bnbchain"),
 		server.ConstructAppExporter(exportAppStateAndTMValidators, "bnbchain"))

--- a/cmd/bnbcli/main.go
+++ b/cmd/bnbcli/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/cosmos/cosmos-sdk/version"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	bankcmd "github.com/cosmos/cosmos-sdk/x/bank/client/cli"
 	ibccmd "github.com/cosmos/cosmos-sdk/x/ibc/client/cli"
@@ -20,6 +19,7 @@ import (
 	apiserv "github.com/BiJie/BinanceChain/plugins/api"
 	dexcmd "github.com/BiJie/BinanceChain/plugins/dex/client/cli"
 	tokencmd "github.com/BiJie/BinanceChain/plugins/tokens/client/cli"
+	"github.com/BiJie/BinanceChain/version"
 )
 
 // rootCmd is the entry point for this binary
@@ -61,7 +61,6 @@ func main() {
 		client.PostCommands(
 			ibccmd.IBCTransferCmd(cdc),
 		)...)
-
 	// temp. disabled staking commands
 	// rootCmd.AddCommand(
 	// 	client.PostCommands(

--- a/version/command.go
+++ b/version/command.go
@@ -1,0 +1,31 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// VersionCmd prints out the current sdk version
+	VersionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the app version",
+		Run:   printVersion,
+	}
+)
+
+// return version of CLI/node and commit hash
+func GetVersion() string {
+	v := Version
+	if GitCommit != "" {
+		v = v + "-" + GitCommit
+	}
+	return v
+}
+
+// CMD
+func printVersion(cmd *cobra.Command, args []string) {
+	v := GetVersion()
+	fmt.Println(v)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,7 @@
+//nolint
+package version
+
+const Version = "0.2.0"
+
+// GitCommit set by build flags
+var GitCommit = ""


### PR DESCRIPTION
### Description

add version cmd to show git info.

### Rationale

for now "bnbchaind version" only show tendermint release, it's hard to distinguish wether two validator useing same code.

### Example
usage:

```
 ./build/bnbcli version
0.2.0-ab58541
./build/bnbchaind  version
0.2.0-ab58541
```

### Changes

No
### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

https://github.com/BiJie/BinanceChain/issues/238
