### PR TITLE
change logfile format to adapt to log rotate, resolve #243

### DIFF
--- a/common/log/async_file_writer.go
+++ b/common/log/async_file_writer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -210,5 +211,10 @@ func (w *AsyncFileWriter) flushAndClose() error {
 }
 
 func (w *AsyncFileWriter) timeFilePath(filePath string) string {
-	return filePath + "." + time.Now().Format("2006-01-02_15")
+	ext := filepath.Ext(filePath)
+	if ext == "" {
+		return filePath + "." + time.Now().Format("2006-01-02_15")
+	} else {
+		return strings.TrimSuffix(filePath, ext[1:]) + time.Now().Format("2006-01-02_15") + ext
+	}
 }


### PR DESCRIPTION
### Description

bnc.log.2018-11-02_02 change to bnc.2018-11-02_02.log, since log rotate want have same file extention name.

### Rationale

The real log file name is like `hello.2018-11-04_22.log`

### Example

No api changed

### Changes

no
### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

https://github.com/BiJie/BinanceChain/issues/243

