### PR TITLE
fix cosmos-sdk revision in Gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -109,7 +109,7 @@
     "x/stake/types",
   ]
   pruneopts = "UT"
-  revision = "658b464b81a49da6010ea2f16c00f0e95bf3c888"
+  revision = "468f40005354724f0f044c99bd372a84f392daa9"
   source = "github.com/BiJie/bnc-cosmos-sdk"
 
 [[projects]]


### PR DESCRIPTION
### Description

fix revision of cosmos-sdk.

### Rationale

the old revision does not exist because the `upgrade25` branch is force updated and the old commit id lost.

### Example

### Changes

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by


### Related issues

