### PR TITLE
remove msg version & optimize all imports

### DIFF
--- a/app/app_pub_test.go
+++ b/app/app_pub_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"github.com/cosmos/cosmos-sdk/baseapp"
 	"os"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ import (
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
 
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/BiJie/BinanceChain/app/config"

--- a/app/pub/keeper_pub_test.go
+++ b/app/pub/keeper_pub_test.go
@@ -115,7 +115,7 @@ func TestKeeper_AddOrder(t *testing.T) {
 func TestKeeper_IOCExpireWithFee(t *testing.T) {
 	assert, require := setupKeeperTest(t)
 
-	msg := orderPkg.NewOrderMsg{0x01, buyer, "1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.BUY, 102000, 3000000, orderPkg.TimeInForce.IOC}
+	msg := orderPkg.NewOrderMsg{buyer, "1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.BUY, 102000, 3000000, orderPkg.TimeInForce.IOC}
 	keeper.AddOrder(orderPkg.OrderInfo{msg, 42, 100, 42, 100, 0, "08E19B16880CF70D59DDD996E3D75C66CD0405DE"}, false)
 
 	require.Len(keeper.OrderChanges, 1)
@@ -141,7 +141,7 @@ func TestKeeper_IOCExpireWithFee(t *testing.T) {
 func TestKeeper_ExpireWithFee(t *testing.T) {
 	assert, require := setupKeeperTest(t)
 
-	msg := orderPkg.NewOrderMsg{0x01, buyer, "1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.BUY, 102000, 3000000, orderPkg.TimeInForce.GTC}
+	msg := orderPkg.NewOrderMsg{buyer, "1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.BUY, 102000, 3000000, orderPkg.TimeInForce.GTC}
 	keeper.AddOrder(orderPkg.OrderInfo{msg, 42, 100, 42, 100, 0, "08E19B16880CF70D59DDD996E3D75C66CD0405DE"}, false)
 
 	require.Len(keeper.OrderChanges, 1)
@@ -166,9 +166,9 @@ func TestKeeper_ExpireWithFee(t *testing.T) {
 func Test_IOCPartialExpire(t *testing.T) {
 	assert, require := setupKeeperTest(t)
 
-	msg := orderPkg.NewOrderMsg{0x01, buyer, "b-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.BUY, 100000000, 300000000, orderPkg.TimeInForce.IOC}
+	msg := orderPkg.NewOrderMsg{buyer, "b-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.BUY, 100000000, 300000000, orderPkg.TimeInForce.IOC}
 	keeper.AddOrder(orderPkg.OrderInfo{msg, 42, 100, 42, 100, 0, ""}, false)
-	msg2 := orderPkg.NewOrderMsg{0x01, seller, "s-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.SELL, 100000000, 100000000, orderPkg.TimeInForce.GTC}
+	msg2 := orderPkg.NewOrderMsg{seller, "s-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.SELL, 100000000, 100000000, orderPkg.TimeInForce.GTC}
 	keeper.AddOrder(orderPkg.OrderInfo{msg2, 42, 100, 42, 100, 0, ""}, false)
 
 	require.Len(keeper.OrderChanges, 2)
@@ -206,9 +206,9 @@ func Test_IOCPartialExpire(t *testing.T) {
 func Test_GTCPartialExpire(t *testing.T) {
 	assert, require := setupKeeperTest(t)
 
-	msg := orderPkg.NewOrderMsg{0x01, buyer, "b-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.BUY, 100000000, 100000000, orderPkg.TimeInForce.GTC}
+	msg := orderPkg.NewOrderMsg{buyer, "b-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.BUY, 100000000, 100000000, orderPkg.TimeInForce.GTC}
 	keeper.AddOrder(orderPkg.OrderInfo{msg, 42, 100, 42, 100, 0, ""}, false)
-	msg2 := orderPkg.NewOrderMsg{0x01, seller, "s-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.SELL, 100000000, 300000000, orderPkg.TimeInForce.GTC}
+	msg2 := orderPkg.NewOrderMsg{seller, "s-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.SELL, 100000000, 300000000, orderPkg.TimeInForce.GTC}
 	keeper.AddOrder(orderPkg.OrderInfo{msg2, 42, 100, 42, 100, 0, ""}, false)
 
 	require.Len(keeper.OrderChanges, 2)
@@ -251,11 +251,11 @@ func Test_GTCPartialExpire(t *testing.T) {
 func Test_OneBuyVsTwoSell(t *testing.T) {
 	assert, require := setupKeeperTest(t)
 
-	msg := orderPkg.NewOrderMsg{0x01, buyer, "b-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.BUY, 100000000, 300000000, orderPkg.TimeInForce.GTC}
+	msg := orderPkg.NewOrderMsg{buyer, "b-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.BUY, 100000000, 300000000, orderPkg.TimeInForce.GTC}
 	keeper.AddOrder(orderPkg.OrderInfo{msg, 42, 100, 42, 100, 0, ""}, false)
-	msg2 := orderPkg.NewOrderMsg{0x01, seller, "s-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.SELL, 100000000, 100000000, orderPkg.TimeInForce.GTC}
+	msg2 := orderPkg.NewOrderMsg{seller, "s-1", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.SELL, 100000000, 100000000, orderPkg.TimeInForce.GTC}
 	keeper.AddOrder(orderPkg.OrderInfo{msg2, 42, 100, 42, 100, 0, ""}, false)
-	msg3 := orderPkg.NewOrderMsg{0x01, seller, "s-2", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.SELL, 100000000, 200000000, orderPkg.TimeInForce.GTC}
+	msg3 := orderPkg.NewOrderMsg{seller, "s-2", "XYZ_BNB", orderPkg.OrderType.LIMIT, orderPkg.Side.SELL, 100000000, 200000000, orderPkg.TimeInForce.GTC}
 	keeper.AddOrder(orderPkg.OrderInfo{msg3, 42, 100, 42, 100, 0, ""}, false)
 
 	require.Len(keeper.OrderChanges, 3)

--- a/app/pub/publisher.go
+++ b/app/pub/publisher.go
@@ -1,11 +1,12 @@
 package pub
 
 import (
+	tmlog "github.com/tendermint/tendermint/libs/log"
+
 	"github.com/BiJie/BinanceChain/app/config"
 	"github.com/BiJie/BinanceChain/common/log"
 	"github.com/BiJie/BinanceChain/common/types"
 	orderPkg "github.com/BiJie/BinanceChain/plugins/dex/order"
-	tmlog "github.com/tendermint/tendermint/libs/log"
 )
 
 const (

--- a/cmd/bnbchaind/utils/gentx.go
+++ b/cmd/bnbchaind/utils/gentx.go
@@ -2,6 +2,13 @@ package utils
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -9,15 +16,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	"github.com/cosmos/cosmos-sdk/x/stake/client/cli"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/common"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 )
 
 const (

--- a/cmd/bnbchaind/utils/init.go
+++ b/cmd/bnbchaind/utils/init.go
@@ -3,29 +3,31 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/BiJie/BinanceChain/app"
-	"github.com/BiJie/BinanceChain/wire"
-	"github.com/cosmos/cosmos-sdk/client"
-	serverCfg "github.com/cosmos/cosmos-sdk/server/config"
-	"github.com/tendermint/tendermint/crypto"
-	cmn "github.com/tendermint/tendermint/libs/common"
-	pvm "github.com/tendermint/tendermint/privval"
-	tmtypes "github.com/tendermint/tendermint/types"
 	"io/ioutil"
+	"os"
 	"path"
+	"path/filepath"
 	"sort"
 
-	"os"
-	"path/filepath"
-
-	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
 	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/common"
+	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/p2p"
+	pvm "github.com/tendermint/tendermint/privval"
+	tmtypes "github.com/tendermint/tendermint/types"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/server"
+	serverCfg "github.com/cosmos/cosmos-sdk/server/config"
+
+	"github.com/BiJie/BinanceChain/app"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 const (

--- a/cmd/bnbchaind/utils/init_test.go
+++ b/cmd/bnbchaind/utils/init_test.go
@@ -2,23 +2,24 @@ package utils
 
 import (
 	"bytes"
-	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
-	"github.com/tendermint/tendermint/libs/cli"
 	"io"
 	"io/ioutil"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/server"
-	"github.com/cosmos/cosmos-sdk/server/mock"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+
 	abciServer "github.com/tendermint/tendermint/abci/server"
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
+	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/log"
 
-	"github.com/spf13/viper"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/server/mock"
 )
 
 func TestInitCmd(t *testing.T) {

--- a/cmd/bnbchaind/utils/testnet.go
+++ b/cmd/bnbchaind/utils/testnet.go
@@ -3,20 +3,20 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"github.com/BiJie/BinanceChain/wire"
-	"github.com/cosmos/cosmos-sdk/server"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-
-	gc "github.com/cosmos/cosmos-sdk/server/config"
-
-	"os"
-
 	"github.com/spf13/viper"
+
 	cfg "github.com/tendermint/tendermint/config"
 	cmn "github.com/tendermint/tendermint/libs/common"
+
+	"github.com/cosmos/cosmos-sdk/server"
+	gc "github.com/cosmos/cosmos-sdk/server/config"
+
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 var (

--- a/common/client/helper.go
+++ b/common/client/helper.go
@@ -1,14 +1,16 @@
 package client
 
 import (
-	"github.com/BiJie/BinanceChain/common/types"
+	"github.com/pkg/errors"
+
 	"github.com/cosmos/cosmos-sdk/client/context"
 	txutils "github.com/cosmos/cosmos-sdk/client/utils"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	txbuilder "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
-	"github.com/pkg/errors"
+
+	"github.com/BiJie/BinanceChain/common/types"
 )
 
 func PrepareCtx(cdc *codec.Codec) (context.CLIContext, txbuilder.TxBuilder) {
@@ -44,7 +46,7 @@ func BuildUnsignedTx(builder txbuilder.TxBuilder, acc auth.Account, msgs []sdk.M
 	sequence := acc.GetSequence()
 	memo := builder.Memo
 
-	signMsg := 	txbuilder.StdSignMsg {
+	signMsg := txbuilder.StdSignMsg{
 		ChainID:       chainID,
 		AccountNumber: accnum,
 		Sequence:      sequence,

--- a/common/tx/ante_test.go
+++ b/common/tx/ante_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/libs/log"
 
-	"github.com/BiJie/BinanceChain/wire"
 	"github.com/BiJie/BinanceChain/common/testutils"
 	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/common/types"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 func newTestMsg(addrs ...sdk.AccAddress) *sdk.TestMsg {

--- a/plugins/dex/client/cli/list.go
+++ b/plugins/dex/client/cli/list.go
@@ -1,12 +1,12 @@
 package commands
 
 import (
-	"github.com/BiJie/BinanceChain/common/client"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/BiJie/BinanceChain/common/client"
 	"github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/common/utils"
 	"github.com/BiJie/BinanceChain/plugins/dex/list"

--- a/plugins/dex/client/cli/tx.go
+++ b/plugins/dex/client/cli/tx.go
@@ -3,8 +3,11 @@ package commands
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/BiJie/BinanceChain/common/client"
 	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/keys"
@@ -12,10 +15,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	txbuilder "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
+	"github.com/BiJie/BinanceChain/common/client"
 	"github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/common/utils"
 	"github.com/BiJie/BinanceChain/plugins/dex/order"

--- a/plugins/dex/fee.go
+++ b/plugins/dex/fee.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ListingFee     = 1e12
+	ListingFee = 1e12
 )
 
 func init() {

--- a/plugins/dex/list/msg.go
+++ b/plugins/dex/list/msg.go
@@ -14,7 +14,6 @@ const Route = "dexList"
 var _ sdk.Msg = ListMsg{}
 
 type ListMsg struct {
-	Version          byte           `json:"version"`
 	From             sdk.AccAddress `json:"from"`
 	BaseAssetSymbol  string         `json:"base_asset_symbol"`
 	QuoteAssetSymbol string         `json:"quote_asset_symbol"`
@@ -23,7 +22,6 @@ type ListMsg struct {
 
 func NewMsg(from sdk.AccAddress, baseAssetSymbol string, quoteAssetSymbol string, initPrice int64) ListMsg {
 	return ListMsg{
-		Version:          0x01,
 		From:             from,
 		BaseAssetSymbol:  baseAssetSymbol,
 		QuoteAssetSymbol: quoteAssetSymbol,
@@ -37,9 +35,6 @@ func (msg ListMsg) String() string               { return fmt.Sprintf("MsgList{%
 func (msg ListMsg) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.From} }
 
 func (msg ListMsg) ValidateBasic() sdk.Error {
-	if msg.Version != 0x01 {
-		return sdk.ErrInternal("Invalid version. Expected 0x01")
-	}
 	err := types.ValidateSymbol(msg.BaseAssetSymbol)
 	if err != nil {
 		return sdk.ErrInvalidCoins("base token: " + err.Error())

--- a/plugins/dex/order/fee_test.go
+++ b/plugins/dex/order/fee_test.go
@@ -1,12 +1,14 @@
 package order
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/BiJie/BinanceChain/common/testutils"
 	"github.com/BiJie/BinanceChain/common/types"
-	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func NewTestFeeConfig() FeeConfig {
@@ -75,17 +77,17 @@ func TestFeeManager_CalcFixedFee(t *testing.T) {
 	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 2e4)}, fee.Tokens)
 
 	// No enough native token, but enough ABC
-	acc.SetCoins(sdk.Coins{{Denom:types.NativeToken, Amount: sdk.NewInt(1e4)}, {Denom:"ABC", Amount:sdk.NewInt(1e8)}})
+	acc.SetCoins(sdk.Coins{{Denom: types.NativeToken, Amount: sdk.NewInt(1e4)}, {Denom: "ABC", Amount: sdk.NewInt(1e8)}})
 	fee = keeper.FeeManager.CalcFixedFee(acc.GetCoins(), eventFullyExpire, "ABC", lastTradePrices)
 	require.Equal(t, sdk.Coins{sdk.NewInt64Coin("ABC", 1e6)}, fee.Tokens)
 
 	// No enough native token and ABC
-	acc.SetCoins(sdk.Coins{{Denom:types.NativeToken, Amount: sdk.NewInt(1e4)}, {Denom:"ABC", Amount:sdk.NewInt(1e5)}})
+	acc.SetCoins(sdk.Coins{{Denom: types.NativeToken, Amount: sdk.NewInt(1e4)}, {Denom: "ABC", Amount: sdk.NewInt(1e5)}})
 	fee = keeper.FeeManager.CalcFixedFee(acc.GetCoins(), eventFullyExpire, "ABC", lastTradePrices)
 	require.Equal(t, sdk.Coins{sdk.NewInt64Coin("ABC", 1e5)}, fee.Tokens)
 
 	// BNB_BTC, sell BTC
-	acc.SetCoins(sdk.Coins{{Denom:"BTC", Amount: sdk.NewInt(1e4)}})
+	acc.SetCoins(sdk.Coins{{Denom: "BTC", Amount: sdk.NewInt(1e4)}})
 	fee = keeper.FeeManager.CalcFixedFee(acc.GetCoins(), eventFullyExpire, "BTC", lastTradePrices)
 	require.Equal(t, sdk.Coins{sdk.NewInt64Coin("BTC", 1e2)}, fee.Tokens)
 }

--- a/plugins/dex/order/keeper_test.go
+++ b/plugins/dex/order/keeper_test.go
@@ -8,18 +8,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	sdkstore "github.com/cosmos/cosmos-sdk/store"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/bank"
-	txbuilder "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
-
 	abci "github.com/tendermint/tendermint/abci/types"
 	bc "github.com/tendermint/tendermint/blockchain"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 	"github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
+
+	sdkstore "github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	txbuilder "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
+	"github.com/cosmos/cosmos-sdk/x/bank"
 
 	"github.com/BiJie/BinanceChain/common"
 	"github.com/BiJie/BinanceChain/common/testutils"
@@ -497,7 +497,7 @@ func TestKeeper_ExpireOrders(t *testing.T) {
 
 	breathTime, _ := time.Parse(time.RFC3339, "2018-01-02T00:00:01Z")
 	keeper.MarkBreatheBlock(ctx, 15000, breathTime)
-	
+
 	ctx = keeper.ExpireOrders(ctx, breathTime.AddDate(0, 0, 3), nil, nil)
 	buys, sells := keeper.engines["ABC_BNB"].Book.GetAllLevels()
 	require.Len(t, buys, 0)

--- a/plugins/dex/order/msg.go
+++ b/plugins/dex/order/msg.go
@@ -150,7 +150,6 @@ func TifStringToTifCode(tif string) (int8, error) {
 var _ sdk.Msg = NewOrderMsg{}
 
 type NewOrderMsg struct {
-	Version     byte           `json:"version"`
 	Sender      sdk.AccAddress `json:"sender"`
 	Id          string         `json:"id"`
 	Symbol      string         `json:"symbol"`
@@ -165,7 +164,6 @@ type NewOrderMsg struct {
 func NewNewOrderMsg(sender sdk.AccAddress, id string, side int8,
 	symbol string, price int64, qty int64) NewOrderMsg {
 	return NewOrderMsg{
-		Version:     0x01,
 		Sender:      sender,
 		Id:          id,
 		Symbol:      symbol,
@@ -183,7 +181,6 @@ func NewNewOrderMsgAuto(txBuilder txbuilder.TxBuilder, sender sdk.AccAddress, si
 	var id string
 	id = GenerateOrderID(txBuilder.Sequence+1, sender)
 	return NewOrderMsg{
-		Version:     0x01,
 		Sender:      sender,
 		Id:          id,
 		Symbol:      symbol,
@@ -220,7 +217,6 @@ var _ sdk.Msg = CancelOrderMsg{}
 
 // CancelOrderMsg represents a message to cancel an open order
 type CancelOrderMsg struct {
-	Version byte `json:"version"`
 	Sender  sdk.AccAddress
 	Symbol  string `json:"symbol"`
 	Id      string `json:"id"`
@@ -230,7 +226,6 @@ type CancelOrderMsg struct {
 // NewCancelOrderMsg constructs a new CancelOrderMsg
 func NewCancelOrderMsg(sender sdk.AccAddress, symbol, id, refId string) CancelOrderMsg {
 	return CancelOrderMsg{
-		Version: 0x01,
 		Sender:  sender,
 		Symbol:  symbol,
 		Id:      id,
@@ -270,10 +265,6 @@ func (msg CancelOrderMsg) GetInvolvedAddresses() []sdk.AccAddress {
 
 // ValidateBasic is used to quickly disqualify obviously invalid messages quickly
 func (msg NewOrderMsg) ValidateBasic() sdk.Error {
-	if msg.Version != 0x01 {
-		// TODO: use a dedicated error type
-		return sdk.ErrInternal("Invalid version. Expected 0x01")
-	}
 	// `-` is required in the compound order id: <address>-<sequence>
 	// NOTE: the actual validation of the ID happens in the AnteHandler for now.
 	if len(msg.Id) == 0 || !strings.Contains(msg.Id, "-") {
@@ -303,10 +294,6 @@ func (msg NewOrderMsg) ValidateBasic() sdk.Error {
 
 // ValidateBasic is used to quickly disqualify obviously invalid messages quickly
 func (msg CancelOrderMsg) ValidateBasic() sdk.Error {
-	if msg.Version != 0x01 {
-		// TODO: use a dedicated error type
-		return sdk.ErrInternal("Invalid version. Expected 0x01")
-	}
 	if len(msg.Sender) == 0 {
 		return sdk.ErrUnknownAddress(msg.Sender.String()).TraceSDK("")
 	}

--- a/plugins/dex/order/msg_test.go
+++ b/plugins/dex/order/msg_test.go
@@ -2,7 +2,6 @@ package order
 
 import (
 	"fmt"
-
 	"regexp"
 	"testing"
 
@@ -25,9 +24,9 @@ func newCLIContext() context.CLIContext {
 	nodeURI := "tcp://localhost:26657"
 	rpc := rpcclient.NewHTTP(nodeURI, "/")
 	return context.CLIContext{
-		Client:          rpc,
-		NodeURI:         nodeURI,
-		AccountStore:    cmn.AccountStoreName,
+		Client:       rpc,
+		NodeURI:      nodeURI,
+		AccountStore: cmn.AccountStoreName,
 	}
 }
 

--- a/plugins/dex/store/mapper_test.go
+++ b/plugins/dex/store/mapper_test.go
@@ -1,18 +1,20 @@
 package store
 
 import (
-	"github.com/BiJie/BinanceChain/wire"
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/store"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
 
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/BiJie/BinanceChain/common/utils"
 	"github.com/BiJie/BinanceChain/plugins/dex/types"
+	"github.com/BiJie/BinanceChain/wire"
 )
 
 func setup() (TradingPairMapper, sdk.Context) {

--- a/plugins/shared/msg/base.go
+++ b/plugins/shared/msg/base.go
@@ -10,7 +10,6 @@ import (
 )
 
 type MsgBase struct {
-	Version byte           `json:"version"`
 	From    sdk.AccAddress `json:"from"`
 	Symbol  string         `json:"symbol"`
 	Amount  int64          `json:"amount"`
@@ -19,9 +18,6 @@ type MsgBase struct {
 // ValidateBasic does a simple validation check that
 // doesn't require access to any other information.
 func (msg MsgBase) ValidateBasic() sdk.Error {
-	if msg.Version != 0x01 {
-		return sdk.ErrInternal("Invalid version. Expected 0x01")
-	}
 	err := types.ValidateSymbol(msg.Symbol)
 	if err != nil {
 		return sdk.ErrInvalidCoins(err.Error())

--- a/plugins/tokens/client/cli/issue.go
+++ b/plugins/tokens/client/cli/issue.go
@@ -1,15 +1,16 @@
 package commands
 
 import (
-	"github.com/BiJie/BinanceChain/common/client"
 	"strconv"
 	"strings"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/BiJie/BinanceChain/common/client"
 	"github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/plugins/tokens/issue"
 )

--- a/plugins/tokens/issue/msg.go
+++ b/plugins/tokens/issue/msg.go
@@ -17,7 +17,6 @@ const Route = "tokensIssue"
 var _ sdk.Msg = IssueMsg{}
 
 type IssueMsg struct {
-	Version     byte           `json:"version"`
 	From        sdk.AccAddress `json:"from"`
 	Name        string         `json:"name"`
 	Symbol      string         `json:"symbol"`
@@ -26,7 +25,6 @@ type IssueMsg struct {
 
 func NewMsg(from sdk.AccAddress, name, symbol string, supply int64) IssueMsg {
 	return IssueMsg{
-		Version:     0x01,
 		From:        from,
 		Name:        name,
 		Symbol:      symbol,
@@ -37,9 +35,6 @@ func NewMsg(from sdk.AccAddress, name, symbol string, supply int64) IssueMsg {
 // ValidateBasic does a simple validation check that
 // doesn't require access to any other information.
 func (msg IssueMsg) ValidateBasic() sdk.Error {
-	if msg.Version != 0x01 {
-		return sdk.ErrInternal("Invalid version. Expected 0x01")
-	}
 	if msg.From == nil {
 		return sdk.ErrInvalidAddress("sender address cannot be empty")
 	}


### PR DESCRIPTION
### Description

as titled

### Rationale

As discussed, we will define different msg types to do the versioning. 
Take the `transfer` as an example, if we need to support two versions, we will define two structs:
`type TransferMsgV1 struct`, 
`type TransferMsgV2 struct`,

With this solution, 
1. we can isolate the different fields that different versions use, also the handling logic.
2. we can avoid fixing(add version field) all the existing msgs in cosmos-sdk

### Example

### Changes

Notable changes: 
* remove the version field
* reorganize the imports

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

### Related issues

Closes: #254 

