### PR TITLE
[R4R] #66 #192 ctx changed during match and allocate should be passed out

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -218,7 +218,7 @@ func (app *BinanceChain) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) a
 		// only match in the normal block
 		app.Logger.Debug("normal block", "height", height)
 		if app.publicationConfig.PublishOrderUpdates && pub.IsLive {
-			tradesToPublish = pub.MatchAndAllocateAllForPublish(app.DexKeeper, ctx)
+			tradesToPublish, ctx = pub.MatchAndAllocateAllForPublish(app.DexKeeper, ctx)
 		} else {
 			ctx = app.DexKeeper.MatchAndAllocateAll(ctx, nil, nil)
 		}
@@ -228,7 +228,7 @@ func (app *BinanceChain) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) a
 		bnclog.Info("Start Breathe Block Handling",
 			"height", height, "lastBlockTime", lastBlockTime, "newBlockTime", blockTime)
 		icoDone := ico.EndBlockAsync(ctx)
-		dex.EndBreatheBlock(ctx, app.DexKeeper, height, blockTime)
+		ctx = dex.EndBreatheBlock(ctx, app.DexKeeper, height, blockTime)
 
 		// other end blockers
 		<-icoDone

--- a/app/pub/keeper_pub_test.go
+++ b/app/pub/keeper_pub_test.go
@@ -121,7 +121,7 @@ func TestKeeper_IOCExpireWithFee(t *testing.T) {
 	require.Len(keeper.OrderChanges, 1)
 	require.Len(keeper.OrderChangesMap, 1)
 
-	trades := MatchAndAllocateAllForPublish(keeper, ctx)
+	trades, _ := MatchAndAllocateAllForPublish(keeper, ctx)
 
 	require.Len(keeper.OrderChanges, 2)
 	require.Len(keeper.OrderChangesMap, 1)
@@ -182,7 +182,7 @@ func Test_IOCPartialExpire(t *testing.T) {
 	assert.Equal("s-1", orderChange1.Id)
 	assert.Equal(orderPkg.Ack, orderChange1.Tpe)
 
-	trades := MatchAndAllocateAllForPublish(keeper, ctx)
+	trades, _ := MatchAndAllocateAllForPublish(keeper, ctx)
 
 	require.Len(keeper.OrderChanges, 3)
 	require.Len(keeper.OrderChangesMap, 2)
@@ -222,7 +222,7 @@ func Test_GTCPartialExpire(t *testing.T) {
 	assert.Equal("s-1", orderChange1.Id)
 	assert.Equal(orderPkg.Ack, orderChange1.Tpe)
 
-	trades := MatchAndAllocateAllForPublish(keeper, ctx)
+	trades, _ := MatchAndAllocateAllForPublish(keeper, ctx)
 	require.Len(trades, 1)
 	trade0 := trades[0]
 	assert.Equal("0-0", trade0.Id)
@@ -273,7 +273,7 @@ func Test_OneBuyVsTwoSell(t *testing.T) {
 	assert.Equal("s-2", orderChange2.Id)
 	assert.Equal(orderPkg.Ack, orderChange2.Tpe)
 
-	trades := MatchAndAllocateAllForPublish(keeper, ctx)
+	trades, _ := MatchAndAllocateAllForPublish(keeper, ctx)
 	require.Len(trades, 2)
 	trade0 := trades[0]
 	assert.Equal("0-0", trade0.Id)

--- a/plugins/dex/plugin.go
+++ b/plugins/dex/plugin.go
@@ -35,16 +35,16 @@ func createQueryHandler(keeper *DexKeeper) app.AbciQueryHandler {
 }
 
 // EndBreatheBlock processes the breathe block lifecycle event.
-func EndBreatheBlock(ctx sdk.Context, dexKeeper *DexKeeper, height int64, blockTime time.Time) {
+func EndBreatheBlock(ctx sdk.Context, dexKeeper *DexKeeper, height int64, blockTime time.Time) (newCtx sdk.Context) {
 	logger := bnclog.With("module", "dex")
 	logger.Info("Update tick size / lot size")
 	updateTickSizeAndLotSize(ctx, dexKeeper)
 	// TODO: update fee/rate
 	logger.Info("Expire stale orders")
 	if dexKeeper.CollectOrderInfoForPublish {
-		pub.ExpireOrdersForPublish(dexKeeper, ctx, blockTime)
+		newCtx = pub.ExpireOrdersForPublish(dexKeeper, ctx, blockTime)
 	} else {
-		dexKeeper.ExpireOrders(ctx, blockTime, nil, nil)
+		newCtx = dexKeeper.ExpireOrders(ctx, blockTime, nil, nil)
 	}
 	logger.Info("Mark BreathBlock", "blockHeight", height)
 	dexKeeper.MarkBreatheBlock(ctx, height, blockTime)
@@ -52,6 +52,7 @@ func EndBreatheBlock(ctx sdk.Context, dexKeeper *DexKeeper, height int64, blockT
 	if _, err := dexKeeper.SnapShotOrderBook(ctx, height); err != nil {
 		logger.Error("Failed to snapshot order book", "blockHeight", height, "err", err)
 	}
+	return
 }
 
 func updateTickSizeAndLotSize(ctx sdk.Context, dexKeeper *DexKeeper) {


### PR DESCRIPTION
### Description

Fix witness-order failed to consensus bug in QA

### Rationale

Fix witness-order failed to consensus bug in QA

### Example

N/A

### Changes

Notable changes: 
1. make MatchAndAllocateAll changed context passed to distribute fee
2. make expire orders changed context passed to distribute fee

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#66 
#192 

