### PR TITLE
dex abci: increased max levels to 60 for depth api

### DIFF
--- a/plugins/dex/abci.go
+++ b/plugins/dex/abci.go
@@ -13,7 +13,8 @@ import (
 	"github.com/BiJie/BinanceChain/plugins/dex/store"
 )
 
-const OB_LEVELS = 20
+// TODO: improve, should be configurable
+const OB_LEVELS = 60 // matches UI requirement
 
 func createAbciQueryHandler(keeper *DexKeeper) app.AbciQueryHandler {
 	return func(app app.ChainApp, req abci.RequestQuery, path []string) (res *abci.ResponseQuery) {


### PR DESCRIPTION
### Description

The max levels returned by the depth API has been increased from 20 to 60 to match the UI's expectation.
