### PR TITLE
fix the missing tag of CancelOrderMsg.Sender

### DIFF
--- a/plugins/dex/order/msg.go
+++ b/plugins/dex/order/msg.go
@@ -217,19 +217,19 @@ var _ sdk.Msg = CancelOrderMsg{}
 
 // CancelOrderMsg represents a message to cancel an open order
 type CancelOrderMsg struct {
-	Sender  sdk.AccAddress
-	Symbol  string `json:"symbol"`
-	Id      string `json:"id"`
-	RefId   string `json:"refid"`
+	Sender sdk.AccAddress `json:"sender"`
+	Symbol string         `json:"symbol"`
+	Id     string         `json:"id"`
+	RefId  string         `json:"refid"`
 }
 
 // NewCancelOrderMsg constructs a new CancelOrderMsg
 func NewCancelOrderMsg(sender sdk.AccAddress, symbol, id, refId string) CancelOrderMsg {
 	return CancelOrderMsg{
-		Sender:  sender,
-		Symbol:  symbol,
-		Id:      id,
-		RefId:   refId,
+		Sender: sender,
+		Symbol: symbol,
+		Id:     id,
+		RefId:  refId,
 	}
 }
 


### PR DESCRIPTION
### Description

fix the missing tag of CancelOrderMsg.Sender

### Rationale

we missed the tag of CancelOrderMsg.Sender

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

