### PR TITLE
fix cosmos revision in gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -57,7 +57,7 @@
 
 [[projects]]
   branch = "upgrade25"
-  digest = "1:973952f68c7701eabbdfc1ee3d953490f451d605af71a919b7b5ee1a4409e327"
+  digest = "1:b383cee5b88db397e396185cc533b65bee0f77647dbf6fe8b4573a87c566b327"
   name = "github.com/cosmos/cosmos-sdk"
   packages = [
     "baseapp",
@@ -109,7 +109,7 @@
     "x/stake/types",
   ]
   pruneopts = "UT"
-  revision = "5725498922b2f73bbc86ad05e4664c506f9b0afa"
+  revision = "7c9eb6337b465b3f8a9af0fa8dc4853a565b9ca5"
   source = "github.com/BiJie/bnc-cosmos-sdk"
 
 [[projects]]


### PR DESCRIPTION
### Description

update to the latest commit of bnc-cosmos-sdk@upgrade25

### Rationale

with the current gopkg.lock file, it's very weird that `make get_vendor_deps` cannot fetch the latest revision and auto-update the lock file.

So I remove that dep in gopkg.lock and rerun the `make get_vendor_deps`, now it works.

### Changes

Notable changes: 
* fix cosmos revision in gopkg.lock

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

