### PR TITLE
[R4R]change coin amount type to int64

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -49,25 +49,32 @@
   revision = "fdfc19097e7ac6b57035062056f5b7b4638b8898"
 
 [[projects]]
-  digest = "1:386de157f7d19259a7f9c81f26ce011223ce0f090353c1152ffdf730d7d10ac2"
+  digest = "1:1d8e1cb71c33a9470bbbae09bfec09db43c6bf358dfcae13cd8807c4e2a9a2bf"
   name = "github.com/btcsuite/btcutil"
-  packages = ["bech32"]
+  packages = [
+    "base58",
+    "bech32",
+  ]
   pruneopts = "UT"
   revision = "d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4"
 
 [[projects]]
   branch = "upgrade25"
-  digest = "1:b383cee5b88db397e396185cc533b65bee0f77647dbf6fe8b4573a87c566b327"
+  digest = "1:11c84745ebde631f8a48d0f87851b2b7e89f66f692b15b403fc87f5eef87bf81"
   name = "github.com/cosmos/cosmos-sdk"
   packages = [
     "baseapp",
     "client",
     "client/context",
     "client/keys",
+    "client/lcd",
+    "client/lcd/statik",
     "client/rpc",
     "client/tx",
     "client/utils",
+    "cmd/cosmos-sdk-cli/cmd",
     "cmd/gaia/app",
+    "cmd/gaia/init",
     "codec",
     "crypto",
     "crypto/keys",
@@ -78,6 +85,7 @@
     "server/config",
     "server/mock",
     "store",
+    "tests",
     "types",
     "version",
     "x/auth",
@@ -88,28 +96,41 @@
     "x/bank/client",
     "x/bank/client/cli",
     "x/bank/client/rest",
+    "x/bank/simulation",
     "x/distribution",
+    "x/distribution/client/cli",
     "x/distribution/keeper",
+    "x/distribution/simulation",
     "x/distribution/tags",
     "x/distribution/types",
     "x/gov",
+    "x/gov/client",
+    "x/gov/client/cli",
+    "x/gov/client/rest",
+    "x/gov/simulation",
     "x/gov/tags",
     "x/ibc",
     "x/ibc/client/cli",
     "x/mint",
     "x/mock",
+    "x/mock/simulation",
     "x/params",
     "x/params/subspace",
     "x/slashing",
+    "x/slashing/client/cli",
+    "x/slashing/client/rest",
+    "x/slashing/simulation",
     "x/stake",
     "x/stake/client/cli",
+    "x/stake/client/rest",
     "x/stake/keeper",
     "x/stake/querier",
+    "x/stake/simulation",
     "x/stake/tags",
     "x/stake/types",
   ]
   pruneopts = "UT"
-  revision = "95c0fda5d85c2318495cae854b4fc7544abe5f2e"
+  revision = "846a11e234ba8c01f3d47f6053e04e6a82d33086"
   source = "github.com/BiJie/bnc-cosmos-sdk"
 
 [[projects]]
@@ -165,6 +186,14 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "95f809107225be108efcf10a3509e4ea6ceef3c4"
+
+[[projects]]
+  digest = "1:547f5df5f708c880f0af507317c8d022b8d62053a5cb075e23c6eeed09eb2e4e"
+  name = "github.com/fortytw2/leaktest"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9a23578d06a26ec1b47bfc8965bf5e7011df8bd6"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
@@ -471,6 +500,14 @@
   revision = "ae68e2d4c00fed4943b5f6698d504a5fe083da8a"
 
 [[projects]]
+  digest = "1:ea0700160aca4ef099f4e06686a665a87691f4248dddd40796925eda2e46bd64"
+  name = "github.com/rakyll/statik"
+  packages = ["fs"]
+  pruneopts = "UT"
+  revision = "aa8a7b1baecd0f31a436bf7956fcdcc609a83035"
+  version = "v0.1.4"
+
+[[projects]]
   digest = "1:c4556a44e350b50a490544d9b06e9fba9c286c21d6c0e47f54f3a9214597298c"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
@@ -596,14 +633,18 @@
   version = "v0.11.0"
 
 [[projects]]
-  digest = "1:ac53a600d1fd468d9b71fbe765bbdf5643d182e06784a6f169ed1a565c17e95c"
+  digest = "1:615e18adbf63c8ef87828287e3179d6f61a617516713cd5178ee19794db5c212"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
     "abci/example/code",
+    "abci/example/counter",
     "abci/example/kvstore",
     "abci/server",
+    "abci/tests/server",
     "abci/types",
+    "abci/version",
+    "benchmarks/proto",
     "blockchain",
     "cmd/tendermint/commands",
     "config",
@@ -613,6 +654,7 @@
     "crypto/armor",
     "crypto/ed25519",
     "crypto/encoding/amino",
+    "crypto/internal/benchmarking",
     "crypto/merkle",
     "crypto/multisig",
     "crypto/multisig/bitarray",
@@ -627,12 +669,16 @@
     "libs/clist",
     "libs/common",
     "libs/db",
+    "libs/db/remotedb",
+    "libs/db/remotedb/grpcdb",
+    "libs/db/remotedb/proto",
     "libs/errors",
     "libs/events",
     "libs/flowrate",
     "libs/log",
     "libs/pubsub",
     "libs/pubsub/query",
+    "libs/test",
     "lite",
     "lite/client",
     "lite/errors",
@@ -641,11 +687,13 @@
     "node",
     "p2p",
     "p2p/conn",
+    "p2p/dummy",
     "p2p/pex",
     "p2p/upnp",
     "privval",
     "proxy",
     "rpc/client",
+    "rpc/client/mock",
     "rpc/core",
     "rpc/core/types",
     "rpc/grpc",
@@ -653,11 +701,16 @@
     "rpc/lib/client",
     "rpc/lib/server",
     "rpc/lib/types",
+    "rpc/test",
     "state",
     "state/txindex",
     "state/txindex/kv",
     "state/txindex/null",
+    "tools/tm-monitor/eventmeter",
+    "tools/tm-monitor/mock",
+    "tools/tm-monitor/monitor",
     "types",
+    "types/proto3",
     "types/time",
     "version",
   ]
@@ -807,15 +860,20 @@
     "github.com/beorn7/perks/quantile",
     "github.com/bgentry/speakeasy",
     "github.com/btcsuite/btcd/btcec",
+    "github.com/btcsuite/btcutil/base58",
     "github.com/btcsuite/btcutil/bech32",
     "github.com/cosmos/cosmos-sdk/baseapp",
     "github.com/cosmos/cosmos-sdk/client",
     "github.com/cosmos/cosmos-sdk/client/context",
     "github.com/cosmos/cosmos-sdk/client/keys",
+    "github.com/cosmos/cosmos-sdk/client/lcd",
+    "github.com/cosmos/cosmos-sdk/client/lcd/statik",
     "github.com/cosmos/cosmos-sdk/client/rpc",
     "github.com/cosmos/cosmos-sdk/client/tx",
     "github.com/cosmos/cosmos-sdk/client/utils",
+    "github.com/cosmos/cosmos-sdk/cmd/cosmos-sdk-cli/cmd",
     "github.com/cosmos/cosmos-sdk/cmd/gaia/app",
+    "github.com/cosmos/cosmos-sdk/cmd/gaia/init",
     "github.com/cosmos/cosmos-sdk/codec",
     "github.com/cosmos/cosmos-sdk/crypto",
     "github.com/cosmos/cosmos-sdk/crypto/keys",
@@ -826,6 +884,7 @@
     "github.com/cosmos/cosmos-sdk/server/config",
     "github.com/cosmos/cosmos-sdk/server/mock",
     "github.com/cosmos/cosmos-sdk/store",
+    "github.com/cosmos/cosmos-sdk/tests",
     "github.com/cosmos/cosmos-sdk/types",
     "github.com/cosmos/cosmos-sdk/version",
     "github.com/cosmos/cosmos-sdk/x/auth",
@@ -836,23 +895,36 @@
     "github.com/cosmos/cosmos-sdk/x/bank/client",
     "github.com/cosmos/cosmos-sdk/x/bank/client/cli",
     "github.com/cosmos/cosmos-sdk/x/bank/client/rest",
+    "github.com/cosmos/cosmos-sdk/x/bank/simulation",
     "github.com/cosmos/cosmos-sdk/x/distribution",
+    "github.com/cosmos/cosmos-sdk/x/distribution/client/cli",
     "github.com/cosmos/cosmos-sdk/x/distribution/keeper",
+    "github.com/cosmos/cosmos-sdk/x/distribution/simulation",
     "github.com/cosmos/cosmos-sdk/x/distribution/tags",
     "github.com/cosmos/cosmos-sdk/x/distribution/types",
     "github.com/cosmos/cosmos-sdk/x/gov",
+    "github.com/cosmos/cosmos-sdk/x/gov/client",
+    "github.com/cosmos/cosmos-sdk/x/gov/client/cli",
+    "github.com/cosmos/cosmos-sdk/x/gov/client/rest",
+    "github.com/cosmos/cosmos-sdk/x/gov/simulation",
     "github.com/cosmos/cosmos-sdk/x/gov/tags",
     "github.com/cosmos/cosmos-sdk/x/ibc",
     "github.com/cosmos/cosmos-sdk/x/ibc/client/cli",
     "github.com/cosmos/cosmos-sdk/x/mint",
     "github.com/cosmos/cosmos-sdk/x/mock",
+    "github.com/cosmos/cosmos-sdk/x/mock/simulation",
     "github.com/cosmos/cosmos-sdk/x/params",
     "github.com/cosmos/cosmos-sdk/x/params/subspace",
     "github.com/cosmos/cosmos-sdk/x/slashing",
+    "github.com/cosmos/cosmos-sdk/x/slashing/client/cli",
+    "github.com/cosmos/cosmos-sdk/x/slashing/client/rest",
+    "github.com/cosmos/cosmos-sdk/x/slashing/simulation",
     "github.com/cosmos/cosmos-sdk/x/stake",
     "github.com/cosmos/cosmos-sdk/x/stake/client/cli",
+    "github.com/cosmos/cosmos-sdk/x/stake/client/rest",
     "github.com/cosmos/cosmos-sdk/x/stake/keeper",
     "github.com/cosmos/cosmos-sdk/x/stake/querier",
+    "github.com/cosmos/cosmos-sdk/x/stake/simulation",
     "github.com/cosmos/cosmos-sdk/x/stake/tags",
     "github.com/cosmos/cosmos-sdk/x/stake/types",
     "github.com/cosmos/go-bip39",
@@ -862,6 +934,7 @@
     "github.com/eapache/go-xerial-snappy",
     "github.com/eapache/queue",
     "github.com/ebuchman/fail-test",
+    "github.com/fortytw2/leaktest",
     "github.com/fsnotify/fsnotify",
     "github.com/go-kit/kit/log",
     "github.com/go-kit/kit/log/level",
@@ -923,6 +996,7 @@
     "github.com/prometheus/procfs/internal/util",
     "github.com/prometheus/procfs/nfs",
     "github.com/prometheus/procfs/xfs",
+    "github.com/rakyll/statik/fs",
     "github.com/rcrowley/go-metrics",
     "github.com/spf13/afero",
     "github.com/spf13/afero/mem",
@@ -953,9 +1027,13 @@
     "github.com/tendermint/iavl",
     "github.com/tendermint/tendermint/abci/client",
     "github.com/tendermint/tendermint/abci/example/code",
+    "github.com/tendermint/tendermint/abci/example/counter",
     "github.com/tendermint/tendermint/abci/example/kvstore",
     "github.com/tendermint/tendermint/abci/server",
+    "github.com/tendermint/tendermint/abci/tests/server",
     "github.com/tendermint/tendermint/abci/types",
+    "github.com/tendermint/tendermint/abci/version",
+    "github.com/tendermint/tendermint/benchmarks/proto",
     "github.com/tendermint/tendermint/blockchain",
     "github.com/tendermint/tendermint/cmd/tendermint/commands",
     "github.com/tendermint/tendermint/config",
@@ -965,6 +1043,7 @@
     "github.com/tendermint/tendermint/crypto/armor",
     "github.com/tendermint/tendermint/crypto/ed25519",
     "github.com/tendermint/tendermint/crypto/encoding/amino",
+    "github.com/tendermint/tendermint/crypto/internal/benchmarking",
     "github.com/tendermint/tendermint/crypto/merkle",
     "github.com/tendermint/tendermint/crypto/multisig",
     "github.com/tendermint/tendermint/crypto/multisig/bitarray",
@@ -979,12 +1058,16 @@
     "github.com/tendermint/tendermint/libs/clist",
     "github.com/tendermint/tendermint/libs/common",
     "github.com/tendermint/tendermint/libs/db",
+    "github.com/tendermint/tendermint/libs/db/remotedb",
+    "github.com/tendermint/tendermint/libs/db/remotedb/grpcdb",
+    "github.com/tendermint/tendermint/libs/db/remotedb/proto",
     "github.com/tendermint/tendermint/libs/errors",
     "github.com/tendermint/tendermint/libs/events",
     "github.com/tendermint/tendermint/libs/flowrate",
     "github.com/tendermint/tendermint/libs/log",
     "github.com/tendermint/tendermint/libs/pubsub",
     "github.com/tendermint/tendermint/libs/pubsub/query",
+    "github.com/tendermint/tendermint/libs/test",
     "github.com/tendermint/tendermint/lite",
     "github.com/tendermint/tendermint/lite/client",
     "github.com/tendermint/tendermint/lite/errors",
@@ -993,11 +1076,13 @@
     "github.com/tendermint/tendermint/node",
     "github.com/tendermint/tendermint/p2p",
     "github.com/tendermint/tendermint/p2p/conn",
+    "github.com/tendermint/tendermint/p2p/dummy",
     "github.com/tendermint/tendermint/p2p/pex",
     "github.com/tendermint/tendermint/p2p/upnp",
     "github.com/tendermint/tendermint/privval",
     "github.com/tendermint/tendermint/proxy",
     "github.com/tendermint/tendermint/rpc/client",
+    "github.com/tendermint/tendermint/rpc/client/mock",
     "github.com/tendermint/tendermint/rpc/core",
     "github.com/tendermint/tendermint/rpc/core/types",
     "github.com/tendermint/tendermint/rpc/grpc",
@@ -1005,11 +1090,16 @@
     "github.com/tendermint/tendermint/rpc/lib/client",
     "github.com/tendermint/tendermint/rpc/lib/server",
     "github.com/tendermint/tendermint/rpc/lib/types",
+    "github.com/tendermint/tendermint/rpc/test",
     "github.com/tendermint/tendermint/state",
     "github.com/tendermint/tendermint/state/txindex",
     "github.com/tendermint/tendermint/state/txindex/kv",
     "github.com/tendermint/tendermint/state/txindex/null",
+    "github.com/tendermint/tendermint/tools/tm-monitor/eventmeter",
+    "github.com/tendermint/tendermint/tools/tm-monitor/mock",
+    "github.com/tendermint/tendermint/tools/tm-monitor/monitor",
     "github.com/tendermint/tendermint/types",
+    "github.com/tendermint/tendermint/types/proto3",
     "github.com/tendermint/tendermint/types/time",
     "github.com/tendermint/tendermint/version",
     "github.com/zondax/ledger-goclient",

--- a/app/account_test.go
+++ b/app/account_test.go
@@ -36,9 +36,9 @@ func BenchmarkGetAccount(b *testing.B) {
 		acc.BaseAccount.AccountNumber = testApp.AccountKeeper.GetNextAccountNumber(ctx)
 	}
 
-	acc.SetCoins(sdk.Coins{sdk.NewInt64Coin("BNB", 1000), sdk.NewInt64Coin("BTC", 1000), sdk.NewInt64Coin("ETH", 100)})
-	acc.SetLockedCoins(sdk.Coins{sdk.NewInt64Coin("BNB", 1000), sdk.NewInt64Coin("BTC", 1000), sdk.NewInt64Coin("ETH", 100)})
-	acc.SetFrozenCoins(sdk.Coins{sdk.NewInt64Coin("BNB", 1000), sdk.NewInt64Coin("BTC", 1000), sdk.NewInt64Coin("ETH", 100)})
+	acc.SetCoins(sdk.Coins{sdk.NewCoin("BNB", 1000), sdk.NewCoin("BTC", 1000), sdk.NewCoin("ETH", 100)})
+	acc.SetLockedCoins(sdk.Coins{sdk.NewCoin("BNB", 1000), sdk.NewCoin("BTC", 1000), sdk.NewCoin("ETH", 100)})
+	acc.SetFrozenCoins(sdk.Coins{sdk.NewCoin("BNB", 1000), sdk.NewCoin("BTC", 1000), sdk.NewCoin("ETH", 100)})
 
 	testApp.AccountKeeper.SetAccount(ctx, acc)
 	for i := 0; i < b.N; i++ {
@@ -68,9 +68,9 @@ func BenchmarkSetAccount(b *testing.B) {
 		acc.BaseAccount.AccountNumber = testApp.AccountKeeper.GetNextAccountNumber(ctx)
 	}
 
-	acc.SetCoins(sdk.Coins{sdk.NewInt64Coin("BNB", 1000), sdk.NewInt64Coin("BTC", 1000), sdk.NewInt64Coin("ETH", 100)})
-	acc.SetLockedCoins(sdk.Coins{sdk.NewInt64Coin("BNB", 1000), sdk.NewInt64Coin("BTC", 1000), sdk.NewInt64Coin("ETH", 100)})
-	acc.SetFrozenCoins(sdk.Coins{sdk.NewInt64Coin("BNB", 1000), sdk.NewInt64Coin("BTC", 1000), sdk.NewInt64Coin("ETH", 100)})
+	acc.SetCoins(sdk.Coins{sdk.NewCoin("BNB", 1000), sdk.NewCoin("BTC", 1000), sdk.NewCoin("ETH", 100)})
+	acc.SetLockedCoins(sdk.Coins{sdk.NewCoin("BNB", 1000), sdk.NewCoin("BTC", 1000), sdk.NewCoin("ETH", 100)})
+	acc.SetFrozenCoins(sdk.Coins{sdk.NewCoin("BNB", 1000), sdk.NewCoin("BTC", 1000), sdk.NewCoin("ETH", 100)})
 
 	for i := 0; i < b.N; i++ {
 		testApp.AccountKeeper.SetAccount(ctx, acc)

--- a/app/app.go
+++ b/app/app.go
@@ -188,7 +188,7 @@ func (app *BinanceChain) initChainerFn() sdk.InitChainer {
 			_, _, sdkErr := app.CoinKeeper.AddCoins(ctx, token.Owner, append((sdk.Coins)(nil),
 				sdk.Coin{
 					Denom:  token.Symbol,
-					Amount: sdk.NewInt(token.TotalSupply.ToInt64()),
+					Amount: token.TotalSupply.ToInt64(),
 				}))
 			if sdkErr != nil {
 				panic(sdkErr)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -61,7 +61,7 @@ var (
 	logger                            = log.NewTMLogger(os.Stdout)
 	testApp                           = NewBinanceChain(logger, memDB, os.Stdout)
 	genAccs, addrs, pubKeys, privKeys = mock.CreateGenAccounts(4,
-		sdk.Coins{sdk.NewInt64Coin("BNB", 500e8), sdk.NewInt64Coin("BTC", 200e8)})
+		sdk.Coins{sdk.NewCoin("BNB", 500e8), sdk.NewCoin("BTC", 200e8)})
 	testClient = NewTestClient(testApp)
 )
 
@@ -88,7 +88,7 @@ func InitAccounts(ctx sdk.Context, app *BinanceChain) *[]auth.Account {
 func ResetAccounts(ctx sdk.Context, app *BinanceChain, ccy1 int64, ccy2 int64, ccy3 int64) {
 	for _, acc := range genAccs {
 		a := app.AccountKeeper.GetAccount(ctx, acc.GetAddress())
-		a.SetCoins(sdk.Coins{sdk.NewInt64Coin("BNB", ccy1), sdk.NewInt64Coin("BTC", ccy2), sdk.NewInt64Coin("ETH", ccy3)})
+		a.SetCoins(sdk.Coins{sdk.NewCoin("BNB", ccy1), sdk.NewCoin("BTC", ccy2), sdk.NewCoin("ETH", ccy3)})
 		app.AccountKeeper.SetAccount(ctx, a)
 	}
 }
@@ -108,11 +108,11 @@ func NewTestClient(a *BinanceChain) *TestClient {
 }
 
 func GetAvail(ctx sdk.Context, add sdk.AccAddress, ccy string) int64 {
-	return testApp.CoinKeeper.GetCoins(ctx, add).AmountOf(ccy).Int64()
+	return testApp.CoinKeeper.GetCoins(ctx, add).AmountOf(ccy)
 }
 
 func GetLocked(ctx sdk.Context, add sdk.AccAddress, ccy string) int64 {
-	return testApp.AccountKeeper.GetAccount(ctx, add).(common.NamedAccount).GetLockedCoins().AmountOf(ccy).Int64()
+	return testApp.AccountKeeper.GetAccount(ctx, add).(common.NamedAccount).GetLockedCoins().AmountOf(ccy)
 }
 
 func setGenesis(bapp *BinanceChain, tokens []common.Token, accs ...*common.AppAccount) error {
@@ -159,7 +159,7 @@ func TestGenesis(t *testing.T) {
 	require.Nil(t, err)
 	// A checkTx context
 	ctx := bapp.BaseApp.NewContext(sdk.RunTxModeCheck, abci.Header{})
-	acc.SetCoins(sdk.Coins{sdk.Coin{"BNB", sdk.NewInt(100000)}})
+	acc.SetCoins(sdk.Coins{sdk.Coin{"BNB", 100000}})
 	res1 := bapp.AccountKeeper.GetAccount(ctx, baseAcc.Address).(common.NamedAccount)
 	require.Equal(t, acc, res1)
 

--- a/app/fee_distribution.go
+++ b/app/fee_distribution.go
@@ -47,15 +47,15 @@ func distributeFee(ctx sdk.Context, am auth.AccountKeeper, valMapper val.Mapper,
 		for _, token := range fee.Tokens {
 			// TODO: int64 is enough, will drop big.Int
 			// TODO: temporarily, the validators average the fees. Will change to use power as a weight to calc fees.
-			amount := token.Amount.Int64()
+			amount := token.Amount
 			avgAmount := amount / valSize
 			roundingAmount := amount - avgAmount*valSize
 			if avgAmount != 0 {
-				avgTokens = append(avgTokens, sdk.NewInt64Coin(token.Denom, avgAmount))
+				avgTokens = append(avgTokens, sdk.NewCoin(token.Denom, avgAmount))
 			}
 
 			if roundingAmount != 0 {
-				roundingTokens = append(roundingTokens, sdk.NewInt64Coin(token.Denom, roundingAmount))
+				roundingTokens = append(roundingTokens, sdk.NewCoin(token.Denom, roundingAmount))
 			}
 		}
 

--- a/app/fee_distribution_test.go
+++ b/app/fee_distribution_test.go
@@ -57,7 +57,7 @@ func checkBalance(t *testing.T, ctx sdk.Context, am auth.AccountKeeper, valMappe
 	for i, voteInfo := range ctx.VoteInfos() {
 		accAddr := getAccAddr(ctx, valMapper, voteInfo.Validator.Address)
 		valAcc := am.GetAccount(ctx, accAddr)
-		require.Equal(t, balances[i], valAcc.GetCoins().AmountOf(types.NativeToken).Int64())
+		require.Equal(t, balances[i], valAcc.GetCoins().AmountOf(types.NativeToken))
 	}
 }
 
@@ -75,7 +75,7 @@ func TestNoFeeDistribution(t *testing.T) {
 func TestFeeDistribution2Proposer(t *testing.T) {
 	// setup
 	am, valMapper, ctx, proposerAcc, _, _, _ := setup()
-	ctx = tx.WithFee(ctx, types.NewFee(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 10)}, types.FeeForProposer))
+	ctx = tx.WithFee(ctx, types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeToken, 10)}, types.FeeForProposer))
 	blockFee := distributeFee(ctx, am, valMapper, true)
 	require.Equal(t, pub.BlockFee{0, "BNB:10", []string{proposerAcc.GetAddress().String()}}, blockFee)
 	checkBalance(t, ctx, am, valMapper, []int64{110, 100, 100, 100})
@@ -85,13 +85,13 @@ func TestFeeDistribution2AllValidators(t *testing.T) {
 	// setup
 	am, valMapper, ctx, proposerAcc, valAcc1, valAcc2, valAcc3 := setup()
 	// fee amount can be divided evenly
-	ctx = tx.WithFee(ctx, types.NewFee(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 40)}, types.FeeForAll))
+	ctx = tx.WithFee(ctx, types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeToken, 40)}, types.FeeForAll))
 	blockFee := distributeFee(ctx, am, valMapper, true)
 	require.Equal(t, pub.BlockFee{0, "BNB:40", []string{proposerAcc.GetAddress().String(), valAcc1.GetAddress().String(), valAcc2.GetAddress().String(), valAcc3.GetAddress().String()}}, blockFee)
 	checkBalance(t, ctx, am, valMapper, []int64{110, 110, 110, 110})
 
 	// cannot be divided evenly
-	ctx = tx.WithFee(ctx, types.NewFee(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 50)}, types.FeeForAll))
+	ctx = tx.WithFee(ctx, types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeToken, 50)}, types.FeeForAll))
 	blockFee = distributeFee(ctx, am, valMapper, true)
 	require.Equal(t, pub.BlockFee{0, "BNB:50", []string{proposerAcc.GetAddress().String(), valAcc1.GetAddress().String(), valAcc2.GetAddress().String(), valAcc3.GetAddress().String()}}, blockFee)
 	checkBalance(t, ctx, am, valMapper, []int64{124, 122, 122, 122})

--- a/app/ordertx_test.go
+++ b/app/ordertx_test.go
@@ -208,7 +208,7 @@ func Test_Match(t *testing.T) {
 	assert.Equal(int64(96e8), lastPx)
 	assert.Equal(4, len(trades))
 	// total execution is 900e8 BTC @ price 96e8, notional is 86400e8, fee is 43.2e8 BNB
-	assert.Equal(sdk.Coins{sdk.NewInt64Coin("BNB", 86.4e8)}, tx.Fee(ctx).Tokens)
+	assert.Equal(sdk.Coins{sdk.NewCoin("BNB", 86.4e8)}, tx.Fee(ctx).Tokens)
 	assert.Equal(int64(100900e8), GetAvail(ctx, add, "BTC"))
 	assert.Equal(int64(13556.8e8), GetAvail(ctx, add, "BNB"))
 	assert.Equal(int64(0), GetLocked(ctx, add, "BTC"))
@@ -268,7 +268,7 @@ func Test_Match(t *testing.T) {
 	assert.Equal(4, len(trades))
 	// total execution is 90e8 ETH @ price 97e8, notional is 8730e8
 	// fee for this round is 8.73e8 BNB, totalFee is 95.13e8 BNB
-	assert.Equal(sdk.Coins{sdk.NewInt64Coin("BNB", 95.13e8)}, tx.Fee(ctx).Tokens)
+	assert.Equal(sdk.Coins{sdk.NewCoin("BNB", 95.13e8)}, tx.Fee(ctx).Tokens)
 	assert.Equal(int64(100900e8), GetAvail(ctx, add, "BTC"))
 	assert.Equal(int64(13556.8e8), GetAvail(ctx, add, "BNB"))
 	assert.Equal(int64(0), GetLocked(ctx, add, "BTC"))

--- a/app/pub/helpers.go
+++ b/app/pub/helpers.go
@@ -27,9 +27,9 @@ func GetAccountBalances(mapper auth.AccountKeeper, ctx sdk.Context, accSlices ..
 
 					for _, freeCoin := range acc.GetCoins() {
 						if assetBalance, ok := assetsMap[freeCoin.Denom]; ok {
-							assetBalance.Free = freeCoin.Amount.Int64()
+							assetBalance.Free = freeCoin.Amount
 						} else {
-							newAB := &AssetBalance{Asset: freeCoin.Denom, Free: freeCoin.Amount.Int64()}
+							newAB := &AssetBalance{Asset: freeCoin.Denom, Free: freeCoin.Amount}
 							assets = append(assets, newAB)
 							assetsMap[freeCoin.Denom] = newAB
 						}
@@ -37,9 +37,9 @@ func GetAccountBalances(mapper auth.AccountKeeper, ctx sdk.Context, accSlices ..
 
 					for _, frozenCoin := range acc.GetFrozenCoins() {
 						if assetBalance, ok := assetsMap[frozenCoin.Denom]; ok {
-							assetBalance.Frozen = frozenCoin.Amount.Int64()
+							assetBalance.Frozen = frozenCoin.Amount
 						} else {
-							newAB := &AssetBalance{Asset: frozenCoin.Denom, Frozen: frozenCoin.Amount.Int64()}
+							newAB := &AssetBalance{Asset: frozenCoin.Denom, Frozen: frozenCoin.Amount}
 							assets = append(assets, newAB)
 							assetsMap[frozenCoin.Denom] = newAB
 						}
@@ -47,9 +47,9 @@ func GetAccountBalances(mapper auth.AccountKeeper, ctx sdk.Context, accSlices ..
 
 					for _, lockedCoin := range acc.GetLockedCoins() {
 						if assetBalance, ok := assetsMap[lockedCoin.Denom]; ok {
-							assetBalance.Locked = lockedCoin.Amount.Int64()
+							assetBalance.Locked = lockedCoin.Amount
 						} else {
-							newAB := &AssetBalance{Asset: lockedCoin.Denom, Locked: lockedCoin.Amount.Int64()}
+							newAB := &AssetBalance{Asset: lockedCoin.Denom, Locked: lockedCoin.Amount}
 							assets = append(assets, newAB)
 							assetsMap[lockedCoin.Denom] = newAB
 						}

--- a/common/testutils/testutils.go
+++ b/common/testutils/testutils.go
@@ -33,7 +33,7 @@ func SetupMultiStoreWithDBForUnitTest() (dbm.DB, sdk.MultiStore, *sdk.KVStoreKey
 // coins to more than cover the fee
 func NewNativeTokens(amount int64) sdk.Coins {
 	return sdk.Coins{
-		sdk.NewInt64Coin(types.NativeToken, amount),
+		sdk.NewCoin(types.NativeToken, amount),
 	}
 }
 
@@ -56,15 +56,15 @@ func NewAccountForPub(ctx sdk.Context, am auth.AccountKeeper, free, locked, free
 	privKey, addr := PrivAndAddr()
 	acc := am.NewAccountWithAddress(ctx, addr)
 	coins := NewNativeTokens(free)
-	coins = append(coins, sdk.NewInt64Coin("XYZ", free))
+	coins = append(coins, sdk.NewCoin("XYZ", free))
 	acc.SetCoins(coins)
 
 	appAcc := acc.(*types.AppAccount)
 	lockedCoins := NewNativeTokens(locked)
-	lockedCoins = append(lockedCoins, sdk.NewInt64Coin("XYZ", locked))
+	lockedCoins = append(lockedCoins, sdk.NewCoin("XYZ", locked))
 	appAcc.SetLockedCoins(lockedCoins)
 	freezeCoins := NewNativeTokens(freeze)
-	freezeCoins = append(freezeCoins, sdk.NewInt64Coin("XYZ", freeze))
+	freezeCoins = append(freezeCoins, sdk.NewCoin("XYZ", freeze))
 	appAcc.SetFrozenCoins(freezeCoins)
 	am.SetAccount(ctx, acc)
 	return privKey, acc

--- a/common/tx/ante_test.go
+++ b/common/tx/ante_test.go
@@ -489,7 +489,7 @@ func TestAnteHandlerFeesInCheckTx(t *testing.T) {
 
 	ctx = ctx.WithRunTxMode(sdk.RunTxModeCheck)
 	ctx = runAnteHandlerWithMultiTxFees(ctx, anteHandler, priv1, acc1.GetAddress(), tx.FixedFeeCalculator(10, types.FeeForProposer))
-	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 90)})
+	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewCoin(types.NativeToken, 90)})
 	checkFee(t, ctx, types.Fee{})
 }
 
@@ -498,22 +498,22 @@ func TestAnteHandlerOneTxFee(t *testing.T) {
 	am, ctx, anteHandler := setup()
 	priv1, acc1 := testutils.NewAccount(ctx, am, 100)
 	ctx = runAnteHandlerWithMultiTxFees(ctx, anteHandler, priv1, acc1.GetAddress(), tx.FreeFeeCalculator())
-	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 100)})
+	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewCoin(types.NativeToken, 100)})
 	checkFee(t, ctx, types.Fee{})
 
 	// one tx, FeeForProposer
 	am, ctx, anteHandler = setup()
 	priv1, acc1 = testutils.NewAccount(ctx, am, 100)
 	ctx = runAnteHandlerWithMultiTxFees(ctx, anteHandler, priv1, acc1.GetAddress(), tx.FixedFeeCalculator(10, types.FeeForProposer))
-	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 90)})
-	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 10)}, types.FeeForProposer))
+	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewCoin(types.NativeToken, 90)})
+	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeToken, 10)}, types.FeeForProposer))
 
 	// one tx, FeeForAll
 	am, ctx, anteHandler = setup()
 	priv1, acc1 = testutils.NewAccount(ctx, am, 100)
 	ctx = runAnteHandlerWithMultiTxFees(ctx, anteHandler, priv1, acc1.GetAddress(), tx.FixedFeeCalculator(10, types.FeeForAll))
-	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 90)})
-	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 10)}, types.FeeForAll))
+	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewCoin(types.NativeToken, 90)})
+	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeToken, 10)}, types.FeeForAll))
 }
 
 func TestAnteHandlerMultiTxFees(t *testing.T) {
@@ -523,8 +523,8 @@ func TestAnteHandlerMultiTxFees(t *testing.T) {
 	ctx = runAnteHandlerWithMultiTxFees(ctx, anteHandler, priv1, acc1.GetAddress(),
 		tx.FreeFeeCalculator(),
 		tx.FixedFeeCalculator(10, types.FeeForProposer))
-	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 90)})
-	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 10)}, types.FeeForProposer))
+	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewCoin(types.NativeToken, 90)})
+	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeToken, 10)}, types.FeeForProposer))
 
 	// two txs, 1. FeeProposer 2. FeeFree
 	am, ctx, anteHandler = setup()
@@ -532,8 +532,8 @@ func TestAnteHandlerMultiTxFees(t *testing.T) {
 	ctx = runAnteHandlerWithMultiTxFees(ctx, anteHandler, priv1, acc1.GetAddress(),
 		tx.FixedFeeCalculator(10, types.FeeForProposer),
 		tx.FreeFeeCalculator())
-	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 90)})
-	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 10)}, types.FeeForProposer))
+	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewCoin(types.NativeToken, 90)})
+	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeToken, 10)}, types.FeeForProposer))
 
 	// two txs, 1. FeeProposer 2. FeeForAll
 	am, ctx, anteHandler = setup()
@@ -541,8 +541,8 @@ func TestAnteHandlerMultiTxFees(t *testing.T) {
 	ctx = runAnteHandlerWithMultiTxFees(ctx, anteHandler, priv1, acc1.GetAddress(),
 		tx.FixedFeeCalculator(10, types.FeeForProposer),
 		tx.FixedFeeCalculator(10, types.FeeForAll))
-	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 80)})
-	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 20)}, types.FeeForAll))
+	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewCoin(types.NativeToken, 80)})
+	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeToken, 20)}, types.FeeForAll))
 
 	// two txs, 1. FeeForAll 2. FeeProposer
 	am, ctx, anteHandler = setup()
@@ -550,8 +550,8 @@ func TestAnteHandlerMultiTxFees(t *testing.T) {
 	ctx = runAnteHandlerWithMultiTxFees(ctx, anteHandler, priv1, acc1.GetAddress(),
 		tx.FixedFeeCalculator(10, types.FeeForAll),
 		tx.FixedFeeCalculator(10, types.FeeForProposer))
-	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 80)})
-	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 20)}, types.FeeForAll))
+	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewCoin(types.NativeToken, 80)})
+	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeToken, 20)}, types.FeeForAll))
 
 	// three txs, 1. FeeForAll 2. FeeProposer 3. FeeFree
 	am, ctx, anteHandler = setup()
@@ -560,6 +560,6 @@ func TestAnteHandlerMultiTxFees(t *testing.T) {
 		tx.FixedFeeCalculator(10, types.FeeForAll),
 		tx.FixedFeeCalculator(10, types.FeeForProposer),
 		tx.FreeFeeCalculator())
-	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 80)})
-	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 20)}, types.FeeForAll))
+	checkBalance(t, am, ctx, acc1.GetAddress(), sdk.Coins{sdk.NewCoin(types.NativeToken, 80)})
+	checkFee(t, ctx, types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeToken, 20)}, types.FeeForAll))
 }

--- a/common/tx/fee_calculator.go
+++ b/common/tx/fee_calculator.go
@@ -30,7 +30,7 @@ func FixedFeeCalculator(amount int64, feeType types.FeeDistributeType) FeeCalcul
 	}
 
 	return func(msg sdk.Msg) types.Fee {
-		return types.NewFee(append(sdk.Coins{}, sdk.NewInt64Coin(types.NativeToken, amount)), feeType)
+		return types.NewFee(append(sdk.Coins{}, sdk.NewCoin(types.NativeToken, amount)), feeType)
 	}
 }
 

--- a/common/tx/fee_calculator_test.go
+++ b/common/tx/fee_calculator_test.go
@@ -22,12 +22,12 @@ func TestFixedFeeCalculator(t *testing.T) {
 	calculator = tx.FixedFeeCalculator(10, types.FeeForAll)
 	fee = calculator(msg)
 	require.Equal(t, types.FeeForAll, fee.Type)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 10)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(types.NativeToken, 10)}, fee.Tokens)
 
 	calculator = tx.FixedFeeCalculator(10, types.FeeForProposer)
 	fee = calculator(msg)
 	require.Equal(t, types.FeeForProposer, fee.Type)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 10)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(types.NativeToken, 10)}, fee.Tokens)
 }
 
 func TestFreeFeeCalculator(t *testing.T) {
@@ -49,7 +49,7 @@ func TestRegisterAndGetCalculators(t *testing.T) {
 	require.NotNil(t, calculator)
 	fee := calculator(msg)
 	require.Equal(t, types.FeeForProposer, fee.Type)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 10)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(types.NativeToken, 10)}, fee.Tokens)
 
 	tx.UnsetAllCalculators()
 	require.Nil(t, tx.GetCalculator(msg.Type()))

--- a/common/types/fee.go
+++ b/common/types/fee.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -80,7 +81,7 @@ func (fee Fee) serialize() string {
 	} else {
 		var buffer bytes.Buffer
 		for _, coin := range fee.Tokens {
-			buffer.WriteString(fmt.Sprintf("%s%s%s%s", coin.Denom, amountDenomSeparator, coin.Amount.String(), serializeSeparator))
+			buffer.WriteString(fmt.Sprintf("%s%s%s%s", coin.Denom, amountDenomSeparator, strconv.FormatInt(coin.Amount, 10), serializeSeparator))
 		}
 		res := buffer.String()
 		return res[:len(res)-1]

--- a/plugins/dex/order/fee_test.go
+++ b/plugins/dex/order/fee_test.go
@@ -32,21 +32,21 @@ func TestFeeManager_CalcOrderFees(t *testing.T) {
 		"ABC_BNB": 1e7,
 	}
 	// BNB
-	tradeIn := sdk.NewInt64Coin(types.NativeToken, 100e8)
+	tradeIn := sdk.NewCoin(types.NativeToken, 100e8)
 	fee := keeper.FeeManager.CalcOrderFee(acc.GetCoins(), tradeIn, lastTradePrices)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 5e6)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(types.NativeToken, 5e6)}, fee.Tokens)
 
 	// !BNB
 	_, acc = testutils.NewAccount(ctx, am, 100)
 	// has enough bnb
-	tradeIn = sdk.NewInt64Coin("ABC", 1000e8)
-	acc.SetCoins(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 1e8)})
+	tradeIn = sdk.NewCoin("ABC", 1000e8)
+	acc.SetCoins(sdk.Coins{sdk.NewCoin(types.NativeToken, 1e8)})
 	fee = keeper.FeeManager.CalcOrderFee(acc.GetCoins(), tradeIn, lastTradePrices)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 5e6)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(types.NativeToken, 5e6)}, fee.Tokens)
 	// no enough bnb
-	acc.SetCoins(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 1e6)})
+	acc.SetCoins(sdk.Coins{sdk.NewCoin(types.NativeToken, 1e6)})
 	fee = keeper.FeeManager.CalcOrderFee(acc.GetCoins(), tradeIn, lastTradePrices)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin("ABC", 1e8)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin("ABC", 1e8)}, fee.Tokens)
 }
 
 func TestFeeManager_CalcFixedFee(t *testing.T) {
@@ -60,34 +60,34 @@ func TestFeeManager_CalcFixedFee(t *testing.T) {
 	// in BNB
 	// no enough BNB, but inAsset == BNB
 	fee := keeper.FeeManager.CalcFixedFee(acc.GetCoins(), eventFullyExpire, types.NativeToken, lastTradePrices)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 1e4)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(types.NativeToken, 1e4)}, fee.Tokens)
 	// enough BNB
-	acc.SetCoins(sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 3e4)})
+	acc.SetCoins(sdk.Coins{sdk.NewCoin(types.NativeToken, 3e4)})
 	fee = keeper.FeeManager.CalcFixedFee(acc.GetCoins(), eventFullyExpire, types.NativeToken, lastTradePrices)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 2e4)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(types.NativeToken, 2e4)}, fee.Tokens)
 
 	fee = keeper.FeeManager.CalcFixedFee(acc.GetCoins(), eventIOCFullyExpire, types.NativeToken, lastTradePrices)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 1e4)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(types.NativeToken, 1e4)}, fee.Tokens)
 
 	fee = keeper.FeeManager.CalcFixedFee(acc.GetCoins(), eventFullyCancel, types.NativeToken, lastTradePrices)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 2e4)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(types.NativeToken, 2e4)}, fee.Tokens)
 
 	// ABC_BNB, sell ABC
 	fee = keeper.FeeManager.CalcFixedFee(acc.GetCoins(), eventFullyExpire, "ABC", lastTradePrices)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin(types.NativeToken, 2e4)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(types.NativeToken, 2e4)}, fee.Tokens)
 
 	// No enough native token, but enough ABC
-	acc.SetCoins(sdk.Coins{{Denom: types.NativeToken, Amount: sdk.NewInt(1e4)}, {Denom: "ABC", Amount: sdk.NewInt(1e8)}})
+	acc.SetCoins(sdk.Coins{{Denom: types.NativeToken, Amount: 1e4}, {Denom: "ABC", Amount: 1e8}})
 	fee = keeper.FeeManager.CalcFixedFee(acc.GetCoins(), eventFullyExpire, "ABC", lastTradePrices)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin("ABC", 1e6)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin("ABC", 1e6)}, fee.Tokens)
 
 	// No enough native token and ABC
-	acc.SetCoins(sdk.Coins{{Denom: types.NativeToken, Amount: sdk.NewInt(1e4)}, {Denom: "ABC", Amount: sdk.NewInt(1e5)}})
+	acc.SetCoins(sdk.Coins{{Denom: types.NativeToken, Amount: 1e4}, {Denom: "ABC", Amount: 1e5}})
 	fee = keeper.FeeManager.CalcFixedFee(acc.GetCoins(), eventFullyExpire, "ABC", lastTradePrices)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin("ABC", 1e5)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin("ABC", 1e5)}, fee.Tokens)
 
 	// BNB_BTC, sell BTC
-	acc.SetCoins(sdk.Coins{{Denom: "BTC", Amount: sdk.NewInt(1e4)}})
+	acc.SetCoins(sdk.Coins{{Denom: "BTC", Amount: 1e4}})
 	fee = keeper.FeeManager.CalcFixedFee(acc.GetCoins(), eventFullyExpire, "BTC", lastTradePrices)
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin("BTC", 1e2)}, fee.Tokens)
+	require.Equal(t, sdk.Coins{sdk.NewCoin("BTC", 1e2)}, fee.Tokens)
 }

--- a/plugins/dex/order/handler.go
+++ b/plugins/dex/order/handler.go
@@ -107,11 +107,11 @@ func handleNewOrder(
 		symbolToLock = strings.ToUpper(baseAsset)
 	}
 	freeBalance := acc.GetCoins()
-	if freeBalance.AmountOf(symbolToLock).Int64() < amountToLock {
+	if freeBalance.AmountOf(symbolToLock) < amountToLock {
 		return sdk.ErrInsufficientCoins("do not have enough token to lock").Result()
 	}
 
-	toLockCoins := sdk.Coins{{Denom: symbolToLock, Amount: sdk.NewInt(amountToLock)}}
+	toLockCoins := sdk.Coins{{Denom: symbolToLock, Amount: amountToLock}}
 	// the following is done in the app's checkstate / deliverstate, so it's safe to ignore isCheckTx
 	// TODO: perform reduce avail + increase locked + insert orderbook atomically
 	acc.SetCoins(freeBalance.Minus(toLockCoins))

--- a/plugins/dex/order/keeper_test.go
+++ b/plugins/dex/order/keeper_test.go
@@ -490,8 +490,8 @@ func TestKeeper_ExpireOrders(t *testing.T) {
 	keeper.AddOrder(OrderInfo{NewNewOrderMsg(addr, "5", Side.SELL, "ABC_BNB", 2e6, 2e8), 15000, 0, 15000, 0, 0, ""}, false)
 	keeper.AddOrder(OrderInfo{NewNewOrderMsg(addr, "6", Side.BUY, "XYZ_BNB", 2e6, 2e6), 20000, 0, 20000, 0, 0, ""}, false)
 	acc.(types.NamedAccount).SetLockedCoins(sdk.Coins{
-		sdk.NewInt64Coin("ABC", 3e8),
-		sdk.NewInt64Coin("BNB", 11e4),
+		sdk.NewCoin("ABC", 3e8),
+		sdk.NewCoin("BNB", 11e4),
 	}.Sort())
 	am.SetAccount(ctx, acc)
 
@@ -512,18 +512,18 @@ func TestKeeper_ExpireOrders(t *testing.T) {
 	require.Equal(t, int64(2e6), buys[0].TotalLeavesQty())
 	require.Len(t, keeper.allOrders["XYZ_BNB"], 1)
 	expectFees := types.NewFee(sdk.Coins{
-		sdk.NewInt64Coin("BNB", 6e4),
-		sdk.NewInt64Coin("ABC", 1e7),
+		sdk.NewCoin("BNB", 6e4),
+		sdk.NewCoin("ABC", 1e7),
 	}.Sort(), types.FeeForProposer)
 	require.Equal(t, expectFees, tx.Fee(ctx))
 	acc = am.GetAccount(ctx, acc.GetAddress())
 	require.Equal(t, sdk.Coins{
-		sdk.NewInt64Coin("ABC", 2e8),
-		sdk.NewInt64Coin("BNB", 4e4),
+		sdk.NewCoin("ABC", 2e8),
+		sdk.NewCoin("BNB", 4e4),
 	}.Sort(), acc.(types.NamedAccount).GetLockedCoins())
 	require.Equal(t, sdk.Coins{
-		sdk.NewInt64Coin("ABC", 9e7),
-		sdk.NewInt64Coin("BNB", 1e4),
+		sdk.NewCoin("ABC", 9e7),
+		sdk.NewCoin("BNB", 1e4),
 	}.Sort(), acc.GetCoins())
 }
 

--- a/plugins/dex/order/transfer.go
+++ b/plugins/dex/order/transfer.go
@@ -168,6 +168,6 @@ func (s *sortedAsset) addAsset(asset string, amt int64) {
 		if s.tokens == nil {
 			s.tokens = sdk.Coins{}
 		}
-		s.tokens = s.tokens.Plus(sdk.Coins{{Denom: asset, Amount: sdk.NewInt(amt)}})
+		s.tokens = s.tokens.Plus(sdk.Coins{{Denom: asset, Amount: amt}})
 	}
 }

--- a/plugins/tokens/burn/handler.go
+++ b/plugins/tokens/burn/handler.go
@@ -38,7 +38,7 @@ func handleBurnToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Keep
 	}
 
 	coins := keeper.GetCoins(ctx, token.Owner)
-	if coins.AmountOf(symbol).Int64() < burnAmount ||
+	if coins.AmountOf(symbol) < burnAmount ||
 		token.TotalSupply.ToInt64() < burnAmount {
 		logger.Info("burn token failed", "reason", "no enough tokens to burn")
 		return sdk.ErrInsufficientCoins("do not have enough token to burn").Result()
@@ -46,7 +46,7 @@ func handleBurnToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Keep
 
 	_, _, sdkError := keeper.SubtractCoins(ctx, token.Owner, sdk.Coins{{
 		Denom:  symbol,
-		Amount: sdk.NewInt(burnAmount),
+		Amount: burnAmount,
 	}})
 	if sdkError != nil {
 		logger.Error("burn token failed", "reason", "subtract tokens failed: "+sdkError.Error())

--- a/plugins/tokens/client/rest/getbalance.go
+++ b/plugins/tokens/client/rest/getbalance.go
@@ -59,8 +59,7 @@ func BalanceReqHandler(cdc *wire.Codec, ctx context.CLIContext, tokens tokens.Ma
 		}
 
 		// count locked and frozen coins
-		locked := sdk.NewInt(0)
-		frozen := sdk.NewInt(0)
+		var locked, frozen int64
 		lockedc, err := getLockedCC(cdc, ctx, params.address)
 		if err != nil {
 			fmt.Println("getLockedCC error ignored, will use `0`")
@@ -78,9 +77,9 @@ func BalanceReqHandler(cdc *wire.Codec, ctx context.CLIContext, tokens tokens.Ma
 			Address: vars["address"],
 			Balance: TokenBalance{
 				Symbol: params.symbol,
-				Free:   utils.Fixed8(coins.AmountOf(params.symbol).Int64()),
-				Locked: utils.Fixed8(locked.Int64()),
-				Frozen: utils.Fixed8(frozen.Int64()),
+				Free:   utils.Fixed8(coins.AmountOf(params.symbol)),
+				Locked: utils.Fixed8(locked),
+				Frozen: utils.Fixed8(frozen),
 			},
 		}
 

--- a/plugins/tokens/client/rest/helpers.go
+++ b/plugins/tokens/client/rest/helpers.go
@@ -48,8 +48,7 @@ func GetBalances(
 	for symb := range denoms {
 		symbs = append(symbs, symb)
 		// count locked and frozen coins
-		locked := sdk.NewInt(0)
-		frozen := sdk.NewInt(0)
+		var locked, frozen int64
 		lockedc, err := getLockedCC(cdc, ctx, addr)
 		if err != nil {
 			fmt.Println("getLockedCC error ignored, will use `0`")
@@ -64,9 +63,9 @@ func GetBalances(
 		}
 		bals = append(bals, TokenBalance{
 			Symbol: symb,
-			Free:   utils.Fixed8(coins.AmountOf(symb).Int64()),
-			Locked: utils.Fixed8(locked.Int64()),
-			Frozen: utils.Fixed8(frozen.Int64()),
+			Free:   utils.Fixed8(coins.AmountOf(symb)),
+			Locked: utils.Fixed8(locked),
+			Frozen: utils.Fixed8(frozen),
 		})
 	}
 

--- a/plugins/tokens/freeze/handler.go
+++ b/plugins/tokens/freeze/handler.go
@@ -33,14 +33,14 @@ func handleFreezeToken(ctx sdk.Context, tokenMapper store.Mapper, accKeeper auth
 	symbol := strings.ToUpper(msg.Symbol)
 	logger := log.With("module", "token", "symbol", symbol, "amount", freezeAmount, "addr", msg.From)
 	coins := keeper.GetCoins(ctx, msg.From)
-	if coins.AmountOf(symbol).Int64() < freezeAmount {
+	if coins.AmountOf(symbol) < freezeAmount {
 		logger.Info("freeze token failed", "reason", "no enough free tokens to freeze")
 		return sdk.ErrInsufficientCoins("do not have enough token to freeze").Result()
 	}
 
 	account := accKeeper.GetAccount(ctx, msg.From).(common.NamedAccount)
-	newFrozenTokens := account.GetFrozenCoins().Plus(sdk.Coins{{Denom: symbol, Amount: sdk.NewInt(freezeAmount)}})
-	newFreeTokens := account.GetCoins().Minus(sdk.Coins{{Denom: symbol, Amount: sdk.NewInt(freezeAmount)}})
+	newFrozenTokens := account.GetFrozenCoins().Plus(sdk.Coins{{Denom: symbol, Amount: freezeAmount}})
+	newFreeTokens := account.GetCoins().Minus(sdk.Coins{{Denom: symbol, Amount: freezeAmount}})
 	account.SetFrozenCoins(newFrozenTokens)
 	account.SetCoins(newFreeTokens)
 	accKeeper.SetAccount(ctx, account)
@@ -53,14 +53,14 @@ func handleUnfreezeToken(ctx sdk.Context, tokenMapper store.Mapper, accKeeper au
 	symbol := strings.ToUpper(msg.Symbol)
 	logger := log.With("module", "token", "symbol", symbol, "amount", unfreezeAmount, "addr", msg.From)
 	account := accKeeper.GetAccount(ctx, msg.From).(common.NamedAccount)
-	frozenAmount := account.GetFrozenCoins().AmountOf(symbol).Int64()
+	frozenAmount := account.GetFrozenCoins().AmountOf(symbol)
 	if frozenAmount < unfreezeAmount {
 		logger.Info("unfreeze token failed", "reason", "no enough frozen tokens to unfreeze")
 		return sdk.ErrInsufficientCoins("do not have enough token to unfreeze").Result()
 	}
 
-	newFrozenTokens := account.GetFrozenCoins().Minus(sdk.Coins{{Denom: symbol, Amount: sdk.NewInt(unfreezeAmount)}})
-	newFreeTokens := account.GetCoins().Plus(sdk.Coins{{Denom: symbol, Amount: sdk.NewInt(unfreezeAmount)}})
+	newFrozenTokens := account.GetFrozenCoins().Minus(sdk.Coins{{Denom: symbol, Amount: unfreezeAmount}})
+	newFreeTokens := account.GetCoins().Plus(sdk.Coins{{Denom: symbol, Amount: unfreezeAmount}})
 	account.SetFrozenCoins(newFrozenTokens)
 	account.SetCoins(newFreeTokens)
 	accKeeper.SetAccount(ctx, account)

--- a/plugins/tokens/issue/handler.go
+++ b/plugins/tokens/issue/handler.go
@@ -44,7 +44,7 @@ func handleIssueToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Kee
 	_, _, sdkError := keeper.AddCoins(ctx, token.Owner,
 		sdk.Coins{{
 			Denom:  token.Symbol,
-			Amount: sdk.NewInt(token.TotalSupply.ToInt64()),
+			Amount: token.TotalSupply.ToInt64(),
 		}})
 	if sdkError != nil {
 		logger.Error("issue token failed", "reason", "update balance failed: "+sdkError.Error())


### PR DESCRIPTION
### Description
We use int64 to store coins amount  instead of bigint
### Rationale
We use int64 to store coins amount instead of bigint, and so does stake module.

While stake is present as decimal, when do mul, div algorithm we still need big int to avoid overflow.

Change the decimal from 10 to 8.


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

related pr https://github.com/BiJie/bnc-cosmos-sdk/pull/10

