### PR TITLE
[R4R]add sentry node app, resolve #279

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,11 @@ build:
 ifeq ($(OS),Windows_NT)
 	go build $(BUILD_FLAGS) -o build/bnbcli.exe ./cmd/bnbcli
 	go build $(BUILD_FLAGS) -o build/bnbchaind.exe ./cmd/bnbchaind
+	go build $(BUILD_FLAGS) -o build/bnbsentry.exe ./cmd/bnbsentry
 else
 	go build $(BUILD_FLAGS) -o build/bnbcli ./cmd/bnbcli
 	go build $(BUILD_FLAGS) -o build/bnbchaind ./cmd/bnbchaind
+	go build $(BUILD_FLAGS) -o build/bnbsentry ./cmd/bnbsentry
 endif
 
 build-linux:
@@ -31,6 +33,7 @@ build-alpine:
 install:
 	go install $(BUILD_FLAGS) ./cmd/bnbchaind
 	go install $(BUILD_FLAGS) ./cmd/bnbcli
+	go install $(BUILD_FLAGS) ./cmd/bnbsentry
 
 ########################################
 ### Dependencies

--- a/app/sentryapp.go
+++ b/app/sentryapp.go
@@ -1,0 +1,144 @@
+package app
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto/tmhash"
+	"github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/libs/db"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+var (
+	DefaultCacheSize  = 20000
+	DefaultMaxSurvive = 10
+)
+
+type SentryApplication struct {
+	abci.BaseApplication
+
+	logger log.Logger
+	cache  mapTxCache
+}
+
+type SentryConfig struct {
+	CacheSize  int
+	MaxSurvive int
+}
+
+var SentryAppConfig = SentryConfig{DefaultCacheSize, DefaultMaxSurvive}
+
+func NewSentryApplication(logger log.Logger, _ db.DB, _ io.Writer) abci.Application {
+
+	return &SentryApplication{
+		logger: logger,
+		cache:  newMapTxCache(SentryAppConfig.CacheSize),
+	}
+}
+
+func (app *SentryApplication) BeginBlock(req abci.RequestBeginBlock) abci.ResponseBeginBlock {
+	app.cache.nextRound()
+	return abci.ResponseBeginBlock{}
+}
+
+func (app *SentryApplication) Info(req abci.RequestInfo) (resInfo abci.ResponseInfo) {
+	return abci.ResponseInfo{Data: "{\"name\": \"dumyApp\"}"}
+}
+
+func (app *SentryApplication) CheckTx(tx []byte) abci.ResponseCheckTx {
+	return abci.ResponseCheckTx{Code: abci.CodeTypeOK}
+}
+
+func (app *SentryApplication) ReCheckTx(txBytes []byte) (res abci.ResponseCheckTx) {
+	// Decode the Tx.
+	txHash := common.HexBytes(tmhash.Sum(txBytes)).String()
+
+	if tx := app.cache.get(txHash); tx != nil {
+		if tx.survive >= SentryAppConfig.MaxSurvive {
+			app.cache.delete(txHash)
+			app.logger.Info("Remove tx", "txHash", txHash)
+			return abci.ResponseCheckTx{
+				Code: uint32(types.CodeInternal),
+				Log:  fmt.Sprintf("Tx expires. Hash: %s.", txHash),
+			}
+		} else {
+			// Mark as good
+			tx.rechecked = true
+		}
+	} else {
+		if app.cache.size() > SentryAppConfig.CacheSize {
+			app.logger.Debug("Remove tx", "txHash", txHash)
+			return abci.ResponseCheckTx{
+				Code: uint32(types.CodeInternal),
+				Log:  fmt.Sprintf("Cache is full, discard tx. Hash: %s", txHash),
+			}
+		}
+		app.logger.Info("Add tx", "txHash", txHash)
+		app.cache.add(txHash)
+	}
+
+	return abci.ResponseCheckTx{
+		Code: abci.CodeTypeOK,
+	}
+}
+
+// --------------------------------------------------------------------------------
+// A mirror of mempool.txs
+type mapTxCache struct {
+	mtx  sync.Mutex
+	pool map[string]*surviveTx
+}
+
+type surviveTx struct {
+	survive   int
+	rechecked bool
+}
+
+func newMapTxCache(size int) mapTxCache {
+	return mapTxCache{
+		pool: make(map[string]*surviveTx, size),
+	}
+}
+
+func (c mapTxCache) size() int {
+	return len(c.pool)
+}
+
+func (c mapTxCache) nextRound() {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	victims := make([]string, 0)
+	for k, tx := range c.pool {
+		// Do not rechecked last round, which means marked as bad tx by mempool or already in block.
+		if !tx.rechecked {
+			victims = append(victims, k)
+		} else {
+			tx.survive = tx.survive + 1
+			// Reset rechecked
+			tx.rechecked = false
+		}
+	}
+	for _, v := range victims {
+		delete(c.pool, v)
+	}
+}
+
+func (c mapTxCache) add(hash string) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.pool[hash] = &surviveTx{survive: 1, rechecked: true}
+}
+
+func (c mapTxCache) delete(hash string) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	delete(c.pool, hash)
+}
+
+func (c mapTxCache) get(hash string) *surviveTx {
+	return c.pool[hash]
+}

--- a/app/sentryapp_test.go
+++ b/app/sentryapp_test.go
@@ -1,0 +1,96 @@
+package app
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/BiJie/BinanceChain/common/log"
+	"github.com/stretchr/testify/assert"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randBytes(n int) []byte {
+	rand.Seed(time.Now().UnixNano())
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return b
+}
+
+func applyBlock(t *testing.T, app *SentryApplication, checkTxs [][]byte, recheckTxs [][]byte, recheckRes []bool, cacheSize int, msg string) {
+	assert := assert.New(t)
+	app.BeginBlock(abci.RequestBeginBlock{})
+	for _, tx := range checkTxs {
+		resp := app.CheckTx(tx)
+		assert.Equal(abci.CodeTypeOK, resp.Code, msg)
+	}
+	app.EndBlock(abci.RequestEndBlock{})
+	app.Commit()
+	for i, tx := range recheckTxs {
+		resp := app.ReCheckTx(tx)
+		assert.Equal(recheckRes[i], resp.Code == abci.CodeTypeOK, msg)
+	}
+	assert.Equal(cacheSize, len(app.cache.pool), msg)
+}
+
+func Test_SentryApplication(t *testing.T) {
+	assert := assert.New(t)
+	app := NewSentryApplication(log.NewAsyncFileLogger(os.DevNull, 1024), nil, nil)
+	sentryApp := app.(*SentryApplication)
+	checkTxs := make([][]byte, 1000)
+	for i := 0; i < 1000; i++ {
+		checkTxs[i] = randBytes(10)
+	}
+	recheckTx := make([][]byte, 10000)
+	for i := 0; i < 10000; i++ {
+		recheckTx[i] = randBytes(10)
+	}
+	genRecheckRes := func(n, start, end int) []bool {
+		assert.True(n > 0)
+		assert.True(start >= 0)
+		assert.True(end <= n)
+		res := make([]bool, n)
+		for i := start; i < end; i++ {
+			res[i] = true
+		}
+		return res
+	}
+	testCases := []struct {
+		checkTxs   [][]byte
+		recheckTxs [][]byte
+		recheckRes []bool
+		cacheSize  int
+		msg        string
+	}{
+		{checkTxs: checkTxs, recheckTxs: recheckTx[:1000], recheckRes: genRecheckRes(1000, 0, 1000), cacheSize: 1000, msg: "step 1"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[1000:2000], recheckRes: genRecheckRes(1000, 0, 1000), cacheSize: 2000, msg: "step 2"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[2000:3000], recheckRes: genRecheckRes(1000, 0, 1000), cacheSize: 2000, msg: "step 3"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[3000:4000], recheckRes: genRecheckRes(1000, 0, 1000), cacheSize: 2000, msg: "step 4"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[4000:5000], recheckRes: genRecheckRes(1000, 0, 1000), cacheSize: 2000, msg: "step 5"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[5000:6000], recheckRes: genRecheckRes(1000, 0, 1000), cacheSize: 2000, msg: "step 6"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[5500:6000], recheckRes: genRecheckRes(1000, 0, 1000), cacheSize: 1000, msg: "step 7"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[5500:6000], recheckRes: genRecheckRes(500, 0, 500), cacheSize: 500, msg: "step 8"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[5500:6000], recheckRes: genRecheckRes(500, 0, 500), cacheSize: 500, msg: "step 9"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[5500:6000], recheckRes: genRecheckRes(500, 0, 500), cacheSize: 500, msg: "step 10"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[5500:6000], recheckRes: genRecheckRes(500, 0, 500), cacheSize: 500, msg: "step 11"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[6000:6500], recheckRes: genRecheckRes(500, 0, 500), cacheSize: 1000, msg: "step 12"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[6500:7000], recheckRes: genRecheckRes(500, 0, 500), cacheSize: 1000, msg: "step 13"},
+		{checkTxs: checkTxs, recheckTxs: recheckTx[7000:7500], recheckRes: genRecheckRes(500, 0, 500), cacheSize: 1000, msg: "step 14"},
+		{checkTxs: checkTxs, recheckTxs: nil, recheckRes: nil, cacheSize: 500, msg: "step 15"},
+		{checkTxs: checkTxs, recheckTxs: nil, recheckRes: nil, cacheSize: 0, msg: "step 16"},
+	}
+	for _, c := range testCases {
+		applyBlock(t, sentryApp, c.checkTxs, c.recheckTxs, c.recheckRes, c.cacheSize, c.msg)
+	}
+	for i := 0; i < DefaultMaxSurvive-1; i++ {
+		applyBlock(t, sentryApp, checkTxs, recheckTx[8000:9000], genRecheckRes(1000, 0, 1000), 1000, fmt.Sprintf("survive %d", i+1))
+	}
+	applyBlock(t, sentryApp, checkTxs, recheckTx[8000:9000], genRecheckRes(1000, 0, 0), 0, fmt.Sprintf("survive %d", DefaultMaxSurvive))
+
+}

--- a/cmd/bnbsentry/main.go
+++ b/cmd/bnbsentry/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/BiJie/BinanceChain/app"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/tendermint/tendermint/libs/cli"
+)
+
+func main() {
+	cdc := app.Codec
+	ctx := app.ServerContext
+
+	rootCmd := &cobra.Command{
+		Use:               "bnbsentry",
+		Short:             "BNBChain Sentry (server)",
+		PersistentPreRunE: app.PersistentPreRunEFn(ctx),
+	}
+
+	server.AddCommands(ctx.ToCosmosServerCtx(), cdc, rootCmd, nil)
+	startCmd := server.StartCmd(ctx.ToCosmosServerCtx(), app.NewSentryApplication)
+
+	startCmd.Flags().IntVarP(&app.SentryAppConfig.CacheSize, "cache_size", "c", app.DefaultCacheSize, "The cache size of sentry node")
+	startCmd.Flags().IntVarP(&app.SentryAppConfig.MaxSurvive, "max_survive", "s", app.DefaultMaxSurvive, "The max survive of sentry node")
+	rootCmd.AddCommand(startCmd)
+	// prepare and add flags
+	executor := cli.PrepareBaseCmd(rootCmd, "BC", app.DefaultNodeHome)
+
+	executor.Execute()
+}


### PR DESCRIPTION
### Description
implement a sentry node that will not replay state.

### Rationale

add new binary that implement a new application that will not check tx and delivertx.
To avoid mempool go grow huge, The application cache the recheck txs and expire them in 
fixed block.

### Example

`./bnbsentry start --home seed/gaiad --p2p.laddr tcp://0.0.0.0:26676 --address tcp://0.0.0.0:26678 --rpc.laddr tcp://0.0.0.0:26677`

### Changes

add new binary

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by



### Related issues


https://github.com/BiJie/BinanceChain/issues/279