### PR TITLE
[R4R] publish 100 orderbook level at most by default

### DIFF
--- a/app/pub/publisher.go
+++ b/app/pub/publisher.go
@@ -15,7 +15,7 @@ const (
 	PublicationChannelSize        = 10000
 	TransferCollectionChannelSize = 4000
 	ToRemoveOrderIdChannelSize    = 1000
-	MaxOrderBookLevel             = 20
+	MaxOrderBookLevel             = 100
 )
 
 var (


### PR DESCRIPTION
### Description

follow up of https://github.com/BiJie/BinanceChain/pull/268

### Rationale

we want more levels

### Example

N/A

### Changes

one line config change

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

@notatestuser 

### Related issues

... reference related issue #'s here ...

