### PR TITLE
[R4R] #257 Fix missing configuration and out-of-date deploy script

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -170,7 +170,7 @@ func defaultPublicationConfig() *PublicationConfig {
 }
 
 func (pubCfg PublicationConfig) ShouldPublishAny() bool {
-	return pubCfg.PublishOrderUpdates || pubCfg.PublishAccountBalance || pubCfg.PublishOrderBook
+	return pubCfg.PublishOrderUpdates || pubCfg.PublishAccountBalance || pubCfg.PublishOrderBook || pubCfg.PublishBlockFee
 }
 
 type LogConfig struct {

--- a/app/pub/publisher_kafka.go
+++ b/app/pub/publisher_kafka.go
@@ -73,6 +73,16 @@ func (publisher *KafkaMarketDataPublisher) newProducers() (config *sarama.Config
 			return
 		}
 	}
+	if cfg.PublishBlockFee {
+		if _, ok := publisher.producers[cfg.BlockFeeTopic]; !ok {
+			publisher.producers[cfg.BlockFeeTopic], err =
+				publisher.connectWithRetry(strings.Split(cfg.BlockFeeKafka, KafkaBrokerSep), config)
+		}
+		if err != nil {
+			Logger.Error("failed to create blockfee producer", "err", err)
+			return
+		}
+	}
 	return
 }
 

--- a/networks/testnet/deploy.sh
+++ b/networks/testnet/deploy.sh
@@ -262,12 +262,15 @@ sed -i -e "s/index_tags = \"\"/index_tags = \"tx.height\"/g" node_publisher/gaia
 sed -i -e "s/orderUpdatesKafka = \"127.0.0.1:9092\"/orderUpdatesKafka = \"${kafka_ip}:9092\"/g" node_publisher/gaiad/config/app.toml
 sed -i -e "s/accountBalanceKafka = \"127.0.0.1:9092\"/accountBalanceKafka = \"${kafka_ip}:9092\"/g" node_publisher/gaiad/config/app.toml
 sed -i -e "s/orderBookKafka = \"127.0.0.1:9092\"/orderBookKafka = \"${kafka_ip}:9092\"/g" node_publisher/gaiad/config/app.toml
+sed -i -e "s/blockFeeKafka = \"127.0.0.1:9092\"/blockFeeKafka = \"${kafka_ip}:9092\"/g" node_publisher/gaiad/config/app.toml
 sed -i -e "s/publishOrderUpdates = false/publishOrderUpdates = true/g" node_publisher/gaiad/config/app.toml
 sed -i -e "s/publishAccountBalance = false/publishAccountBalance = true/g" node_publisher/gaiad/config/app.toml
 sed -i -e "s/publishOrderBook = false/publishOrderBook = true/g" node_publisher/gaiad/config/app.toml
+sed -i -e "s/publishBlockFee = false/publishOrderBook = true/g" node_publisher/gaiad/config/app.toml
 sed -i -e "s/accountBalanceTopic = \"accounts\"/accountBalanceTopic = \"test\"/g" node_publisher/gaiad/config/app.toml
 sed -i -e "s/orderBookTopic = \"orders\"/orderBookTopic = \"test\"/g" node_publisher/gaiad/config/app.toml
 sed -i -e "s/orderUpdatesTopic = \"orders\"/orderUpdatesTopic = \"test\"/g" node_publisher/gaiad/config/app.toml
+sed -i -e "s/blockFeeTopic = \"accounts\"/blockFeeTopic = \"test\"/g" node_publisher/gaiad/config/app.toml
 
 # distribute config
 echo "Stopping publisher node in host  ${witness_ip}..."


### PR DESCRIPTION
### Description

configuration and deploy script fix

### Rationale

#257 

### Example

N/A

### Changes

add blockfee kafka producer 
add blockfee configuration sed command in testnet deployment

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#257 
