### PR TITLE
fix data race issue in test cases

### DIFF
--- a/common/utils/concurrent_test.go
+++ b/common/utils/concurrent_test.go
@@ -1,6 +1,7 @@
 package utils_test
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ func TestConcurrentExecuteAsync(t *testing.T) {
 		nums[i] = []int{0}
 	}
 
-	sum := 0
+	var sum int64
 	numCh := make(chan int, 4)
 	producer := func() {
 		for i := 0; i < 100; i++ {
@@ -30,13 +31,13 @@ func TestConcurrentExecuteAsync(t *testing.T) {
 	}
 	postConsume := func() {
 		for _, numArr := range nums {
-			sum += numArr[0]
+			atomic.AddInt64(&sum,  int64(numArr[0]))
 		}
 	}
 	utils.ConcurrentExecuteAsync(4, producer, consumer, postConsume)
-	require.NotEqual(t, 4950, sum)
+	require.NotEqual(t, int64(4950), atomic.LoadInt64(&sum))
 	time.Sleep(1e6)
-	require.Equal(t, 4950, sum)
+	require.Equal(t, int64(4950), atomic.LoadInt64(&sum))
 	for num, numArr := range nums {
 		require.Equal(t, num, numArr[0])
 	}


### PR DESCRIPTION
### Description

The original `TestConcurrentExecuteAsync` has data race issue as the following:

> ==================
WARNING: DATA RACE
Write at 0x00c000094938 by goroutine 11:
  command-line-arguments_test.TestConcurrentExecuteAsync.func3()
      /Users/ricky/workspace/go/src/github.com/BiJie/BinanceChain/common/utils/concurrent_test.go:33 +0xc9
  github.com/BiJie/BinanceChain/common/utils.ConcurrentExecuteAsync.func2()
      /Users/ricky/workspace/go/src/github.com/BiJie/BinanceChain/common/utils/concurrent.go:20 +0x4c
Previous read at 0x00c000094938 by goroutine 6:
  command-line-arguments_test.TestConcurrentExecuteAsync()
      /Users/ricky/workspace/go/src/github.com/BiJie/BinanceChain/common/utils/concurrent_test.go:37 +0x371
  testing.tRunner()
      /usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:827 +0x162

### Rationale

as above.

### Example

### Changes

Notable changes: 
* fix `TestConcurrentExecuteAsync` data race issue

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

