### PR TITLE
[R4R] fix flaky mock publish test

### DIFF
--- a/app/app_pub_test.go
+++ b/app/app_pub_test.go
@@ -119,9 +119,11 @@ func TestAppPub_AddOrder(t *testing.T) {
 	app.EndBlocker(ctx, abci.RequestEndBlock{Height: 42})
 
 	publisher := app.publisher.(*pub.MockMarketDataPublisher)
+	publisher.Lock.Lock()
 	require.Len(publisher.BooksPublished, 1)
 	require.Len(publisher.BooksPublished[0].Books, 1)
 	assert.Equal(pub.OrderBookDelta{"XYZ_BNB", []pub.PriceLevel{{102000, 3000000}}, make([]pub.PriceLevel, 0)}, publisher.BooksPublished[0].Books[0])
+	publisher.Lock.Unlock()
 }
 
 func TestAppPub_MatchOrder(t *testing.T) {
@@ -138,11 +140,13 @@ func TestAppPub_MatchOrder(t *testing.T) {
 	app.EndBlocker(ctx, abci.RequestEndBlock{Height: 41})
 
 	publisher := app.publisher.(*pub.MockMarketDataPublisher)
+	publisher.Lock.Lock()
 	require.Len(publisher.BooksPublished, 1)
 	require.Len(publisher.AccountPublished, 1)
 	require.Len(publisher.AccountPublished[0].Accounts, 1)
 	expectedAccountToPub := pub.Account{buyer.String(), []*pub.AssetBalance{{"BNB", 99999694000, 0, 306000}, {"XYZ", 100000000000, 0, 0}}}
 	require.Equal(expectedAccountToPub, publisher.AccountPublished[0].Accounts[0])
+	publisher.Lock.Unlock()
 
 	// we add a sell order to fully execute the buyer order
 	msg = orderPkg.NewNewOrderMsg(seller, orderPkg.GenerateOrderID(1, seller), orderPkg.Side.SELL, "XYZ_BNB", 102000, 400000000)
@@ -153,6 +157,7 @@ func TestAppPub_MatchOrder(t *testing.T) {
 	require.Equal(sdk.ABCICodeOK, res.Code, res.Log)
 	app.EndBlocker(ctx, abci.RequestEndBlock{Height: 42})
 
+	publisher.Lock.Lock()
 	require.Len(publisher.BooksPublished, 2)
 	require.Len(publisher.BooksPublished[1].Books, 1)
 	assert.Equal(pub.OrderBookDelta{"XYZ_BNB", []pub.PriceLevel{{102000, 0}}, []pub.PriceLevel{{102000, 100000000}}}, publisher.BooksPublished[1].Books[0])
@@ -162,6 +167,7 @@ func TestAppPub_MatchOrder(t *testing.T) {
 	require.Len(publisher.AccountPublished[1].Accounts, 2)
 	require.Contains(publisher.AccountPublished[1].Accounts, expectedAccountToPub)
 	require.Contains(publisher.AccountPublished[1].Accounts, expectedAccountToPubSeller)
+	publisher.Lock.Unlock()
 
 	// we execute qty 1000000 sell order but add a new qty 1000000 sell order, both buy and sell price level should not publish
 	msg = orderPkg.NewNewOrderMsg(buyer, orderPkg.GenerateOrderID(2, buyer), orderPkg.Side.BUY, "XYZ_BNB", 102000, 100000000)
@@ -174,15 +180,17 @@ func TestAppPub_MatchOrder(t *testing.T) {
 	am.SetAccount(ctx, sellerAcc)
 	res = handler(ctx, msg)
 	app.EndBlocker(ctx, abci.RequestEndBlock{Height: 43})
+
+	publisher.Lock.Lock()
 	expectedAccountToPub = pub.Account{buyer.String(), []*pub.AssetBalance{{"BNB", 99999897949, 0, 0}, {"XYZ", 100100000000, 0, 0}}}
 	expectedAccountToPubSeller = pub.Account{seller.String(), []*pub.AssetBalance{{"BNB", 100000101949, 0, 0}, {"XYZ", 99900000000, 0, 0}}}
-
 	require.Len(publisher.BooksPublished, 3)
 	require.Len(publisher.BooksPublished[2].Books, 0)
 	require.Len(publisher.AccountPublished, 3)
 	require.Len(publisher.AccountPublished[2].Accounts, 2)
 	require.Contains(publisher.AccountPublished[2].Accounts, expectedAccountToPub)
 	require.Contains(publisher.AccountPublished[2].Accounts, expectedAccountToPubSeller)
+	publisher.Lock.Unlock()
 }
 
 func TestAppPub_MatchAndCancelFee(t *testing.T) {
@@ -225,7 +233,9 @@ func TestAppPub_MatchAndCancelFee(t *testing.T) {
 	app.EndBlocker(ctx, abci.RequestEndBlock{Height: 42})
 
 	publisher := app.publisher.(*pub.MockMarketDataPublisher)
+	publisher.Lock.Lock()
 	require.Len(publisher.TradesAndOrdersPublished, 2)
 	assert.Equal("BNB:51", publisher.TradesAndOrdersPublished[1].Trades.Trades[0].Sfee)
 	assert.Equal("BNB:57;#Cxl:1", publisher.TradesAndOrdersPublished[1].Trades.Trades[0].Bfee)
+	publisher.Lock.Unlock()
 }

--- a/app/pub/publisher_mock.go
+++ b/app/pub/publisher_mock.go
@@ -2,6 +2,7 @@ package pub
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/tendermint/tendermint/libs/log"
 
@@ -13,9 +14,14 @@ type MockMarketDataPublisher struct {
 	BooksPublished           []*Books
 	TradesAndOrdersPublished []*tradesAndOrders
 	BlockFeePublished        []BlockFee
+
+	Lock *sync.Mutex // as mock publisher is only used in testing, its no harm to have this granularity Lock
 }
 
 func (publisher *MockMarketDataPublisher) publish(msg AvroMsg, tpe msgType, height int64, timestamp int64) {
+	publisher.Lock.Lock()
+	defer publisher.Lock.Unlock()
+
 	switch tpe {
 	case accountsTpe:
 		publisher.AccountPublished = append(publisher.AccountPublished, msg.(*accounts))
@@ -31,6 +37,9 @@ func (publisher *MockMarketDataPublisher) publish(msg AvroMsg, tpe msgType, heig
 }
 
 func (publisher *MockMarketDataPublisher) Stop() {
+	publisher.Lock.Lock()
+	defer publisher.Lock.Unlock()
+
 	publisher.AccountPublished = make([]*accounts, 0)
 	publisher.BooksPublished = make([]*Books, 0)
 	publisher.TradesAndOrdersPublished = make([]*tradesAndOrders, 0)
@@ -42,6 +51,7 @@ func NewMockMarketDataPublisher(logger log.Logger, config *config.PublicationCon
 		make([]*Books, 0),
 		make([]*tradesAndOrders, 0),
 		make([]BlockFee, 0),
+		&sync.Mutex{},
 	}
 	if err := setup(logger, config, publisher); err != nil {
 		publisher.Stop()


### PR DESCRIPTION
### Description

SHOULD be a fix for http://18.179.14.54:8080/job/qa_binancechain/87/console

### Rationale

fix flaky unit test

### Example

N/A

### Changes

add lock to mock publisher

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

