### PR TITLE
distribute the missing cancel fee

### DIFF
--- a/app/app_pub_test.go
+++ b/app/app_pub_test.go
@@ -83,6 +83,7 @@ func setupAppTest(t *testing.T) (*assert.Assertions, *require.Assertions) {
 		PublishOrderUpdates:    true,
 		PublishAccountBalance:  true,
 		PublishOrderBook:       true,
+		PublishBlockFee:        true,
 		PublicationChannelSize: 0, // deliberately sync publication
 	}
 	app.publisher = pub.NewMockMarketDataPublisher(logger, app.publicationConfig)
@@ -164,7 +165,7 @@ func TestAppPub_MatchOrder(t *testing.T) {
 	expectedAccountToPub = pub.Account{string(buyer), "BNB:153", []*pub.AssetBalance{{"BNB", 99999693847, 0, 0}, {"XYZ", 100300000000, 0, 0}}}
 	expectedAccountToPubSeller := pub.Account{string(seller), "BNB:153", []*pub.AssetBalance{{"BNB", 100000305847, 0, 0}, {"XYZ", 99600000000, 0, 100000000}}}
 	require.Len(publisher.AccountPublished, 2)
-	require.Len(publisher.AccountPublished[1].Accounts, 2)
+	require.Len(publisher.AccountPublished[1].Accounts, 3) // including the validator's account
 	require.Contains(publisher.AccountPublished[1].Accounts, expectedAccountToPub)
 	require.Contains(publisher.AccountPublished[1].Accounts, expectedAccountToPubSeller)
 	publisher.Lock.Unlock()
@@ -187,7 +188,7 @@ func TestAppPub_MatchOrder(t *testing.T) {
 	require.Len(publisher.BooksPublished, 3)
 	require.Len(publisher.BooksPublished[2].Books, 0)
 	require.Len(publisher.AccountPublished, 3)
-	require.Len(publisher.AccountPublished[2].Accounts, 2)
+	require.Len(publisher.AccountPublished[2].Accounts, 3) // including the validator's account
 	require.Contains(publisher.AccountPublished[2].Accounts, expectedAccountToPub)
 	require.Contains(publisher.AccountPublished[2].Accounts, expectedAccountToPubSeller)
 	publisher.Lock.Unlock()
@@ -237,5 +238,6 @@ func TestAppPub_MatchAndCancelFee(t *testing.T) {
 	require.Len(publisher.TradesAndOrdersPublished, 2)
 	assert.Equal("BNB:51", publisher.TradesAndOrdersPublished[1].Trades.Trades[0].Sfee)
 	assert.Equal("BNB:57;#Cxl:1", publisher.TradesAndOrdersPublished[1].Trades.Trades[0].Bfee)
+	assert.Equal("BNB:108", publisher.BlockFeePublished[1].Fee)
 	publisher.Lock.Unlock()
 }

--- a/plugins/dex/order/handler.go
+++ b/plugins/dex/order/handler.go
@@ -10,6 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 
+	"github.com/BiJie/BinanceChain/common/fees"
 	"github.com/BiJie/BinanceChain/common/log"
 	common "github.com/BiJie/BinanceChain/common/types"
 	"github.com/BiJie/BinanceChain/common/utils"
@@ -183,6 +184,7 @@ func handleCancelOrder(
 	}
 	acc := keeper.am.GetAccount(ctx, msg.Sender)
 	fee := keeper.FeeManager.CalcFixedFee(acc.GetCoins(), transfer.eventType, transfer.inAsset, keeper.lastTradePrices)
+	fees.Pool.AddFee(fee)
 	acc.SetCoins(acc.GetCoins().Minus(fee.Tokens))
 	keeper.am.SetAccount(ctx, acc)
 

--- a/plugins/tokens/fee.go
+++ b/plugins/tokens/fee.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	IssueFee    = 1e10
+	IssueFee    = 2e11
 	BurnFee     = 1e6
 	FreezeFee   = 1e6
 	TransferFee = 1e6


### PR DESCRIPTION
### Description

as titled, also, fix the issuing fee value

### Rationale

#291 

### Example

### Changes

Notable changes: 
* include the cancel fee to the fee pool
* fix the issuing fee value
* enhance the testcase for cancel fee.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

