### PR TITLE
add stake cmd

### DIFF
--- a/cmd/bnbcli/main.go
+++ b/cmd/bnbcli/main.go
@@ -10,7 +10,7 @@ import (
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	bankcmd "github.com/cosmos/cosmos-sdk/x/bank/client/cli"
 	govcmd "github.com/cosmos/cosmos-sdk/x/gov/client/cli"
-	ibccmd "github.com/cosmos/cosmos-sdk/x/ibc/client/cli"
+	stakecmd "github.com/cosmos/cosmos-sdk/x/stake/client/cli"
 	"github.com/spf13/cobra"
 	"github.com/tendermint/tendermint/libs/cli"
 
@@ -64,21 +64,6 @@ func main() {
 		client.PostCommands(
 			bankcmd.SendTxCmd(cdc),
 		)...)
-	rootCmd.AddCommand(
-		client.PostCommands(
-			ibccmd.IBCTransferCmd(cdc),
-		)...)
-
-	// temp. disabled staking commands
-	// rootCmd.AddCommand(
-	// 	client.PostCommands(
-	// 		ibccmd.IBCRelayCmd(cdc),
-	// 		simplestakingcmd.BondTxCmd(cdc),
-	// 	)...)
-	// rootCmd.AddCommand(
-	// 	client.PostCommands(
-	// 		simplestakingcmd.UnbondTxCmd(cdc),
-	// 	)...)
 
 	// add proxy, version and key info
 	rootCmd.AddCommand(
@@ -92,6 +77,12 @@ func main() {
 	tokencmd.AddCommands(rootCmd, cdc)
 	dexcmd.AddCommands(rootCmd, cdc)
 
+	// stake cmds
+	rootCmd.AddCommand(
+
+		client.PostCommands(
+			stakecmd.GetCmdCreateValidator(cdc),
+		)...)
 	govcmd.AddCommands(rootCmd, cdc)
 
 	// prepare and add flags


### PR DESCRIPTION
### Description

add stake cmd, currently only CreateValidatorCmd is needed.

### Rationale

#316  We need support update validators through gov.

### Example


### Changes

Notable changes: 
* add stake cmd
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

