### PR TITLE
[R4R] #332 Fix OrderChangeMap messed up after load from snapshot

### DIFF
--- a/plugins/dex/order/keeper_recovery.go
+++ b/plugins/dex/order/keeper_recovery.go
@@ -177,7 +177,7 @@ func (kp *Keeper) LoadOrderBookSnapshot(ctx sdk.Context, daysBack int) (int64, e
 		if kp.CollectOrderInfoForPublish {
 			if _, exists := kp.OrderChangesMap[m.Id]; !exists {
 				bnclog.Debug("add order to order changes map, during load snapshot, from active orders", "orderId", m.Id)
-				kp.OrderChangesMap[m.Id] = &m
+				kp.OrderChangesMap[m.Id] = &orderHolder
 			}
 		}
 	}


### PR DESCRIPTION
### Description

Fix OrderChangeMap messed up after load from snapshot

### Rationale

#332 

### Example

N/A

### Changes

Fix OrderChangeMap messed up after load from snapshot

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#332 

