### PR TITLE
[R4R]add trust-node flag

### DIFF
--- a/plugins/api/cli.go
+++ b/plugins/api/cli.go
@@ -61,6 +61,7 @@ func ServeCommand(cdc *wire.Codec) *cobra.Command {
 	cmd.Flags().String(sdk.FlagChainID, "", "The chain ID to connect to")
 	cmd.Flags().String(sdk.FlagNode, "tcp://localhost:26657", "Address of the node to connect to")
 	cmd.Flags().Int(flagMaxOpenConnections, 1000, "The number of maximum open connections")
+	cmd.Flags().Bool(sdk.FlagTrustNode, true, "Trust connected full node (don't verify proofs for responses)")
 
 	return cmd
 }


### PR DESCRIPTION
### Description
set trust-node flag for bnbcli

### Rationale
bnbcli do not have trust-node in flags.
However, trust-node in viper is binded with default value `false`.
And when create cliContext, it will create a verifier which will panic when  bnbchain server
height is 0.


### Example

no

### Changes

No

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

