### PR TITLE
[R4R] #337 fix restore from snapshot keeper last price incorrectness

### DIFF
--- a/plugins/dex/order/keeper_recovery.go
+++ b/plugins/dex/order/keeper_recovery.go
@@ -150,9 +150,9 @@ func (kp *Keeper) LoadOrderBookSnapshot(ctx sdk.Context, daysBack int) (int64, e
 			eng.Book.InsertPriceLevel(&pl, me.SELLSIDE)
 		}
 		eng.LastTradePrice = ob.LastTradePrice
+		kp.lastTradePrices[symbol] = ob.LastTradePrice
 		ctx.Logger().Info("Successfully Loaded order snapshot", "pair", pair)
 	}
-	kp.updateLastTradePrices()
 	key := genActiveOrdersSnapshotKey(height)
 	bz := kvStore.Get([]byte(key))
 	if bz == nil {

--- a/plugins/dex/order/keeper_test.go
+++ b/plugins/dex/order/keeper_test.go
@@ -289,6 +289,7 @@ func TestKeeper_SnapShotAndLoadAfterMatch(t *testing.T) {
 	assert.Equal(info123457, *keeper2.OrderChangesMap["123457"])
 	assert.Equal(1, len(keeper2.engines))
 	assert.Equal(int64(102000), keeper2.engines["XYZ_BNB"].LastTradePrice)
+	assert.Equal(keeper.lastTradePrices, keeper2.lastTradePrices)
 	assert.Equal(int64(43), h)
 	buys, sells := keeper2.engines["XYZ_BNB"].Book.GetAllLevels()
 	assert.Equal(2, len(buys))


### PR DESCRIPTION
### Description

fix restore from snapshot keeper last price incorrectness

### Rationale

#337 

### Example

N/A

### Changes

restore last prices to keeper's last prices even there is no round order for breathe block

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#337 

