### PR TITLE
[R4R] Write and parse int64 total_supply to/from genesis file

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/mock"
 
 	common "github.com/BiJie/BinanceChain/common/types"
-	"github.com/BiJie/BinanceChain/common/utils"
 	"github.com/BiJie/BinanceChain/plugins/dex"
+	"github.com/BiJie/BinanceChain/plugins/tokens"
 	"github.com/BiJie/BinanceChain/wire"
 )
 
@@ -115,7 +115,7 @@ func GetLocked(ctx sdk.Context, add sdk.AccAddress, ccy string) int64 {
 	return testApp.AccountKeeper.GetAccount(ctx, add).(common.NamedAccount).GetLockedCoins().AmountOf(ccy)
 }
 
-func setGenesis(bapp *BinanceChain, tokens []common.Token, accs ...*common.AppAccount) error {
+func setGenesis(bapp *BinanceChain, tokens []tokens.GenesisToken, accs ...*common.AppAccount) error {
 	genaccs := make([]GenesisAccount, len(accs))
 	for i, acc := range accs {
 		pk := ed25519.GenPrivKey().PubKey()
@@ -152,7 +152,7 @@ func TestGenesis(t *testing.T) {
 	baseAcc := auth.BaseAccount{
 		Address: addr,
 	}
-	tokens := []common.Token{{"BNB", "BNB", "BNB", utils.Fixed8(100000), addr}}
+	tokens := []tokens.GenesisToken{{"BNB", "BNB", 100000, addr}}
 	acc := &common.AppAccount{baseAcc, "blah", sdk.Coins(nil), sdk.Coins(nil)}
 
 	err := setGenesis(bapp, tokens, acc)

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -36,12 +36,12 @@ var (
 )
 
 type GenesisState struct {
-	Tokens     []types.Token      `json:"tokens"`
-	Accounts   []GenesisAccount   `json:"accounts"`
-	DexGenesis dex.Genesis        `json:"dex"`
-	StakeData  stake.GenesisState `json:"stake"`
-	GovData    gov.GenesisState   `json:"gov"`
-	GenTxs     []json.RawMessage  `json:"gentxs"`
+	Tokens     []tokens.GenesisToken `json:"tokens"`
+	Accounts   []GenesisAccount      `json:"accounts"`
+	DexGenesis dex.Genesis           `json:"dex"`
+	StakeData  stake.GenesisState    `json:"stake"`
+	GovData    gov.GenesisState      `json:"gov"`
+	GenTxs     []json.RawMessage     `json:"gentxs"`
 }
 
 // GenesisAccount doesn't need pubkey or sequence
@@ -122,7 +122,7 @@ func BinanceAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (appState 
 
 	genesisState := GenesisState{
 		Accounts:   genAccounts,
-		Tokens:     []types.Token{nativeToken},
+		Tokens:     []tokens.GenesisToken{nativeToken},
 		DexGenesis: dex.DefaultGenesis,
 		StakeData:  stakeData,
 		GenTxs:     appGenTxs,

--- a/common/utils/fixed8.go
+++ b/common/utils/fixed8.go
@@ -90,12 +90,20 @@ func (f *Fixed8) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	var fl float64
-	if err := json.Unmarshal(data, &fl); err != nil {
-		return err
+	// try int64 first, it will fail if there is a dot (.)
+	var in int64
+	if err := json.Unmarshal(data, &in); err != nil {
+		var fl float64
+		if err := json.Unmarshal(data, &fl); err != nil {
+			return err
+		}
+		// if a float is unmarshaled assume it already includes the fraction after the dot
+		*f = Fixed8(float64(Fixed8Decimals) * fl)
+	} else {
+		// if an int is unmarshaled assume it should be parsed with the fraction included (int/10^8)
+		*f = Fixed8(in)
 	}
 
-	*f = Fixed8(float64(Fixed8Decimals) * fl)
 	return nil
 }
 

--- a/common/utils/fixed8_test.go
+++ b/common/utils/fixed8_test.go
@@ -57,19 +57,28 @@ func TestFixed8DecodeString(t *testing.T) {
 }
 
 func TestFixed8UnmarshalJSON(t *testing.T) {
-	fl := float64(123.45)
-	str := "123.45"
-	expected, _ := Fixed8DecodeString(str)
+	flt := float64(123.45)
+	fls := "123.45"
+	int := int64(200000000)
+
+	expFltF8, _ := Fixed8DecodeString(fls)
+	expIntF8 := NewFixed8(2) // 2.00000000
 
 	// UnmarshalJSON should decode floats
-	var u1 Fixed8
-	s, _ := json.Marshal(fl)
-	assert.Nil(t, json.Unmarshal(s, &u1))
-	assert.Equal(t, expected, u1)
+	var fltF8 Fixed8
+	s, _ := json.Marshal(flt)
+	assert.Nil(t, json.Unmarshal(s, &fltF8))
+	assert.Equal(t, expFltF8, fltF8)
+
+	// UnmarshalJSON should decode ints
+	var intF8 Fixed8
+	s, _ = json.Marshal(int)
+	assert.Nil(t, json.Unmarshal(s, &intF8))
+	assert.Equal(t, expIntF8, intF8)
 
 	// UnmarshalJSON should decode strings
-	var u2 Fixed8
-	s, _ = json.Marshal(str)
-	assert.Nil(t, json.Unmarshal(s, &u2))
-	assert.Equal(t, expected, u2)
+	var flsF8 Fixed8
+	s, _ = json.Marshal(fls)
+	assert.Nil(t, json.Unmarshal(s, &flsF8))
+	assert.Equal(t, expFltF8, flsF8)
 }

--- a/plugins/tokens/genesis.go
+++ b/plugins/tokens/genesis.go
@@ -8,7 +8,15 @@ import (
 	"github.com/BiJie/BinanceChain/plugins/tokens/store"
 )
 
-func DefaultGenesisToken(owner sdk.AccAddress) types.Token {
+
+type GenesisToken struct {
+	Name        string         `json:"name"`
+	Symbol      string         `json:"symbol"`
+	TotalSupply int64          `json:"total_supply"`
+	Owner       sdk.AccAddress `json:"owner"`
+}
+
+func DefaultGenesisToken(owner sdk.AccAddress) GenesisToken {
 	token, err := types.NewToken(
 		"Binance Chain Native Token",
 		types.NativeTokenSymbol,
@@ -18,14 +26,23 @@ func DefaultGenesisToken(owner sdk.AccAddress) types.Token {
 	if err != nil {
 		panic(err)
 	}
-	return *token
+	return GenesisToken{
+		Name: token.Name,
+		Symbol: token.Symbol,
+		TotalSupply: token.TotalSupply.ToInt64(),
+		Owner: token.Owner,
+	}
 }
 
 func InitGenesis(ctx sdk.Context, tokenMapper store.Mapper, coinKeeper bank.Keeper,
-	tokens []types.Token, validators []sdk.AccAddress, transferAmtForEach int64) {
+	geneTokens []GenesisToken, validators []sdk.AccAddress, transferAmtForEach int64) {
 	var nativeTokenOwner sdk.AccAddress
-	for _, token := range tokens {
-		err := tokenMapper.NewToken(ctx, token)
+	for _, geneToken := range geneTokens {
+		token, err := types.NewToken(geneToken.Name, geneToken.Symbol, geneToken.TotalSupply, geneToken.Owner)
+		if err != nil {
+			panic(err)
+		}
+		err = tokenMapper.NewToken(ctx, *token)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
### Description

The genesis file is currently using a fixed8 format for the native token's `total_supply`. This changes it to an int64 (in a string).

Before: `"total_supply": "200000000.00000000"`
After: `"total_supply": "20000000000000000"`

It also removes `original_symbol` from the json-serialized genesis token, which is present in the `Token` struct but not in the all new `GenesisToken` struct created for genesis.

Suggested by @rickyyangz

### Changes

Notable changes: 
* modified `Fixed8`'s `UnmarshalJSON` to unmarshal an int from json. if this fails, it resorts to unmarshalling a float.
* created a new `GenesisToken` struct which is used to write the genesis file with an int64 `total_supply`.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

@rickyyangz 

### Related issues

... reference related issue #'s here ...

