### PR TITLE
[R4R] integration_test: fix list proposal expiry

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -85,7 +85,7 @@ check_operation "Issue Token" "${result}" "${chain_operation_words}"
 
 sleep 1s
 # propose list
-result=$(expect ./propose_list.exp ${chain_id} alice 200000000000:BNB ${btc_symbol} BNB 100000000 "list ${btc_symbol}/BNB" "list ${btc_symbol}/BNB" ${cli_home} 1544486400)
+result=$(expect ./propose_list.exp ${chain_id} alice 200000000000:BNB ${btc_symbol} BNB 100000000 "list ${btc_symbol}/BNB" "list ${btc_symbol}/BNB" ${cli_home} 1644486400)
 check_operation "Propose list" "${result}" "${chain_operation_words}"
 
 sleep 2s


### PR DESCRIPTION
The previous timestamp was for `Tue, 11 Dec 2018 00:00:00 +0000`; that was reached today and so the test is failing.

The new timestamp expires in 2022 so we should be ok for some time.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)
