### PR TITLE
implement mint function

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -152,7 +152,7 @@ func TestGenesis(t *testing.T) {
 	baseAcc := auth.BaseAccount{
 		Address: addr,
 	}
-	tokens := []tokens.GenesisToken{{"BNB", "BNB", 100000, addr}}
+	tokens := []tokens.GenesisToken{{"BNB", "BNB", 100000, addr, false}}
 	acc := &common.AppAccount{baseAcc, "blah", sdk.Coins(nil), sdk.Coins(nil)}
 
 	err := setGenesis(bapp, tokens, acc)

--- a/common/types/token.go
+++ b/common/types/token.go
@@ -31,9 +31,10 @@ type Token struct {
 	OrigSymbol  string         `json:"original_symbol"`
 	TotalSupply utils.Fixed8   `json:"total_supply"`
 	Owner       sdk.AccAddress `json:"owner"`
+	Mintable    bool           `json:"mintable"`
 }
 
-func NewToken(name, symbol string, totalSupply int64, owner sdk.AccAddress) (*Token, error) {
+func NewToken(name, symbol string, totalSupply int64, owner sdk.AccAddress, mintable bool) (*Token, error) {
 	// double check that the symbol is suffixed
 	if err := ValidateMapperTokenSymbol(symbol); err != nil {
 		return nil, err
@@ -48,13 +49,14 @@ func NewToken(name, symbol string, totalSupply int64, owner sdk.AccAddress) (*To
 		OrigSymbol:  parts[0],
 		TotalSupply: utils.Fixed8(totalSupply),
 		Owner:       owner,
+		Mintable:    mintable,
 	}, nil
 }
 
 func (token *Token) IsOwner(addr sdk.AccAddress) bool { return bytes.Equal(token.Owner, addr) }
 func (token Token) String() string {
-	return fmt.Sprintf("{Name: %v, Symbol: %v, TotalSupply: %v, Owner: %X}",
-		token.Name, token.Symbol, token.TotalSupply, token.Owner)
+	return fmt.Sprintf("{Name: %v, Symbol: %v, TotalSupply: %v, Owner: %X, Mintable: %v}",
+		token.Name, token.Symbol, token.TotalSupply, token.Owner, token.Mintable)
 }
 
 // Token Validation

--- a/common/types/token_test.go
+++ b/common/types/token_test.go
@@ -62,7 +62,7 @@ var tokenMapperSymbolTestCases = []struct {
 func TestNewToken(t *testing.T) {
 	for _, tt := range tokenMapperSymbolTestCases {
 		t.Run(tt.symbol, func(t *testing.T) {
-			_, err := types.NewToken(tt.symbol, tt.symbol, 100000, sdk.AccAddress{})
+			_, err := types.NewToken(tt.symbol, tt.symbol, 100000, sdk.AccAddress{}, false)
 			if (err == nil) != tt.correct {
 				t.Errorf("NewToken() error = %v, correct %v", err, tt.correct)
 				return
@@ -70,7 +70,7 @@ func TestNewToken(t *testing.T) {
 		})
 	}
 	// extra test. an orig symbol that is valid in TestValidateIssueMsgTokenSymbol but not here
-	if _, err := types.NewToken("XYZ", "XYZ", 100000, sdk.AccAddress{}); err == nil {
+	if _, err := types.NewToken("XYZ", "XYZ", 100000, sdk.AccAddress{}, false); err == nil {
 		t.Errorf("NewToken() error = %v, expected XYZ to be invalid", err)
 	}
 }

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -80,14 +80,19 @@ check_operation "Send Token" "${result}" "${chain_operation_words}"
 
 sleep 1s
 # issue token
-result=$(expect ./issue.exp BTC Bitcoin 1000000000000000 bob ${chain_id} ${cli_home})
+result=$(expect ./issue.exp BTC Bitcoin 1000000000000000 true bob ${chain_id} ${cli_home})
 btc_symbol=$(echo "${result}" | tail -n 1 | grep -o "BTC-[0-9A-Z]*")
 check_operation "Issue Token" "${result}" "${chain_operation_words}"
 
+# mint token
+result=$(expect ./mint.exp ${btc_symbol} 1000000000000000 bob ${chain_id} ${cli_home})
+check_operation "Mint Token" "${result}" "${chain_operation_words}"
+
 sleep 1s
 # propose list
-r1544486400esult=$(expect ./propose_list.exp ${chain_id} alice 200000000000:BNB ${btc_symbol} BNB 100000000 "list BTC/BNB" "list BTC/BNB" ${cli_home} 1644486400)
-check_operation "Propose List" "${result}" "${chain_operation_words}"
+((expire_time=$(date '+%s')+1000))
+result=$(expect ./propose_list.exp ${chain_id} alice 200000000000:BNB ${btc_symbol} BNB 100000000 "list BTC/BNB" "list BTC/BNB" ${cli_home} ${expire_time})
+check_operation "Propose list" "${result}" "${chain_operation_words}"
 
 sleep 2s
 # vote for propose

--- a/networks/demo/issue.exp
+++ b/networks/demo/issue.exp
@@ -3,15 +3,16 @@
 set symbol [lindex $argv 0]
 set token_name [lindex $argv 1]
 set supply [lindex $argv 2]
-set from [lindex $argv 3]
-set chain_id [lindex $argv 4]
-set home [lindex $argv 5]
+set mintable [lindex $argv 3]
+set from [lindex $argv 4]
+set chain_id [lindex $argv 5]
+set home [lindex $argv 6]
 
 set timeout 30
 	if {"${home}" == ""} {
-		spawn ./bnbcli token issue -s $symbol --token-name $token_name -n $supply --from $from --chain-id $chain_id
+		spawn ./bnbcli token issue -s $symbol --token-name $token_name -n $supply --mintable $mintable --from $from --chain-id $chain_id
 	} else {
-		spawn ./bnbcli token issue --home $home -s $symbol --token-name $token_name -n $supply --from $from --chain-id $chain_id
+		spawn ./bnbcli token issue --home $home -s $symbol --token-name $token_name -n $supply --mintable $mintable --from $from --chain-id $chain_id
 	}
 	expect "Password*"
 	send "12345678\r"

--- a/networks/demo/mint.exp
+++ b/networks/demo/mint.exp
@@ -1,0 +1,17 @@
+#!/usr/bin/expect
+
+set symbol [lindex $argv 0]
+set amount [lindex $argv 1]
+set from [lindex $argv 2]
+set chain_id [lindex $argv 3]
+set home [lindex $argv 4]
+
+set timeout 30
+	if {"${home}" == ""} {
+		spawn ./bnbcli token mint -s $symbol  -n $amount --from $from --chain-id $chain_id
+	} else {
+		spawn ./bnbcli token mint --home $home -s $symbol -n $amount --from $from --chain-id $chain_id
+	}
+	expect "Password*"
+	send "12345678\r"
+interact

--- a/plugins/tokens/abci_test.go
+++ b/plugins/tokens/abci_test.go
@@ -24,8 +24,8 @@ var (
 	app          = bca.NewBinanceChain(logger, db, os.Stdout)
 	pk           = ed25519.GenPrivKey().PubKey()
 	addr         = sdk.AccAddress(pk.Address())
-	token1Ptr, _ = common.NewToken("XXX", "XXX-000", 10000000000, addr)
-	token2Ptr, _ = common.NewToken("XXY", "XXY-000", 10000000000, addr)
+	token1Ptr, _ = common.NewToken("XXX", "XXX-000", 10000000000, addr, false)
+	token2Ptr, _ = common.NewToken("XXY", "XXY-000", 10000000000, addr, false)
 	token1       = *token1Ptr
 	token2       = *token2Ptr
 )

--- a/plugins/tokens/client/cli/commands.go
+++ b/plugins/tokens/client/cli/commands.go
@@ -25,6 +25,7 @@ func AddCommands(cmd *cobra.Command, cdc *wire.Codec) {
 	tokenCmd.AddCommand(
 		client.PostCommands(
 			issueTokenCmd(cmdr),
+			mintTokenCmd(cmdr),
 			burnTokenCmd(cmdr),
 			freezeTokenCmd(cmdr),
 			unfreezeTokenCmd(cmdr))...)

--- a/plugins/tokens/fee.go
+++ b/plugins/tokens/fee.go
@@ -11,14 +11,16 @@ import (
 )
 
 const (
-	IssueFee    = 2e11
+	IssueFee    = 2000e8
+	MintFee     = 500e8
 	BurnFee     = 1e6
 	FreezeFee   = 1e6
 	TransferFee = 1e6
 )
 
 func init() {
-	fees.RegisterCalculator(issue.Route, fees.FixedFeeCalculator(IssueFee, types.FeeForAll))
+	fees.RegisterCalculator(issue.IssueMsgType, fees.FixedFeeCalculator(IssueFee, types.FeeForAll))
+	fees.RegisterCalculator(issue.MintMsgType, fees.FixedFeeCalculator(MintFee, types.FeeForAll))
 	fees.RegisterCalculator(burn.BurnRoute, fees.FixedFeeCalculator(BurnFee, types.FeeForProposer))
 	fees.RegisterCalculator(freeze.FreezeRoute, fees.FixedFeeCalculator(FreezeFee, types.FeeForProposer))
 	// TODO: we will rewrite Transfer fees, so put it here temporarily

--- a/plugins/tokens/genesis.go
+++ b/plugins/tokens/genesis.go
@@ -13,6 +13,7 @@ type GenesisToken struct {
 	Symbol      string         `json:"symbol"`
 	TotalSupply int64          `json:"total_supply"`
 	Owner       sdk.AccAddress `json:"owner"`
+	Mintable    bool           `json:"mintable"`
 }
 
 func DefaultGenesisToken(owner sdk.AccAddress) GenesisToken {
@@ -21,6 +22,7 @@ func DefaultGenesisToken(owner sdk.AccAddress) GenesisToken {
 		types.NativeTokenSymbol,
 		types.NativeTokenTotalSupply,
 		owner,
+		false,
 	)
 	if err != nil {
 		panic(err)
@@ -30,6 +32,7 @@ func DefaultGenesisToken(owner sdk.AccAddress) GenesisToken {
 		Symbol:      token.Symbol,
 		TotalSupply: token.TotalSupply.ToInt64(),
 		Owner:       token.Owner,
+		Mintable:    token.Mintable,
 	}
 }
 
@@ -37,7 +40,7 @@ func InitGenesis(ctx sdk.Context, tokenMapper store.Mapper, coinKeeper bank.Keep
 	geneTokens []GenesisToken, validators []sdk.AccAddress, transferAmtForEach int64) {
 	var nativeTokenOwner sdk.AccAddress
 	for _, geneToken := range geneTokens {
-		token, err := types.NewToken(geneToken.Name, geneToken.Symbol, geneToken.TotalSupply, geneToken.Owner)
+		token, err := types.NewToken(geneToken.Name, geneToken.Symbol, geneToken.TotalSupply, geneToken.Owner, geneToken.Mintable)
 		if err != nil {
 			panic(err)
 		}

--- a/plugins/tokens/issue/handler.go
+++ b/plugins/tokens/issue/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -19,16 +20,19 @@ import (
 // NewHandler creates a new token issue message handler
 func NewHandler(tokenMapper store.Mapper, keeper bank.Keeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
-		if msg, ok := msg.(IssueMsg); ok {
+		switch msg := msg.(type) {
+		case IssueMsg:
 			return handleIssueToken(ctx, tokenMapper, keeper, msg)
+		case MintMsg:
+			return handleMintToken(ctx, tokenMapper, keeper, msg)
+		default:
+			errMsg := "Unrecognized msg type: " + reflect.TypeOf(msg).Name()
+			return sdk.ErrUnknownRequest(errMsg).Result()
 		}
-
-		errMsg := "Unrecognized msg type: " + reflect.TypeOf(msg).Name()
-		return sdk.ErrUnknownRequest(errMsg).Result()
 	}
 }
 
-func handleIssueToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Keeper, msg IssueMsg) sdk.Result {
+func handleIssueToken(ctx sdk.Context, tokenMapper store.Mapper, bankKeeper bank.Keeper, msg IssueMsg) sdk.Result {
 	errLogMsg := "issue token failed"
 	symbol := strings.ToUpper(msg.Symbol)
 	logger := log.With("module", "token", "symbol", symbol, "name", msg.Name, "total_supply", msg.TotalSupply, "issuer", msg.From)
@@ -59,7 +63,7 @@ func handleIssueToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Kee
 		return sdk.ErrInvalidCoins(fmt.Sprintf("symbol(%s) already exists", msg.Symbol)).Result()
 	}
 
-	token, err := common.NewToken(msg.Name, symbol, msg.TotalSupply, msg.From)
+	token, err := common.NewToken(msg.Name, symbol, msg.TotalSupply, msg.From, msg.Mintable)
 	if err != nil {
 		logger.Error(errLogMsg, "reason", "create token failed: "+err.Error())
 		return sdk.ErrInternal(fmt.Sprintf("unable to create token struct: %s", err.Error())).Result()
@@ -70,7 +74,7 @@ func handleIssueToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Kee
 		return sdk.ErrInvalidCoins(err.Error()).Result()
 	}
 
-	if _, _, sdkError := keeper.AddCoins(ctx, token.Owner,
+	if _, _, sdkError := bankKeeper.AddCoins(ctx, token.Owner,
 		sdk.Coins{{
 			Denom:  token.Symbol,
 			Amount: token.TotalSupply.ToInt64(),
@@ -90,5 +94,55 @@ func handleIssueToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Kee
 	return sdk.Result{
 		Data: serialized,
 		Log:  fmt.Sprintf("Issued %s", token.Symbol),
+	}
+}
+
+func handleMintToken(ctx sdk.Context, tokenMapper store.Mapper, bankKeeper bank.Keeper, msg MintMsg) sdk.Result {
+	symbol := strings.ToUpper(msg.Symbol)
+	logger := log.With("module", "token", "symbol", symbol, "amount", msg.Amount, "minter", msg.From)
+
+	errLogMsg := "mint token failed"
+	token, err := tokenMapper.GetToken(ctx, symbol)
+	if err != nil {
+		logger.Info(errLogMsg, "reason", "symbol not exist")
+		return sdk.ErrInvalidCoins(fmt.Sprintf("symbol(%s) does not exist", msg.Symbol)).Result()
+	}
+
+	if !token.Mintable {
+		logger.Info(errLogMsg, "reason", "token cannot be minted")
+		return sdk.ErrInvalidCoins(fmt.Sprintf("token(%s) cannot be minted", msg.Symbol)).Result()
+	}
+
+	if !token.IsOwner(msg.From) {
+		logger.Info(errLogMsg, "reason", "not the token owner")
+		return sdk.ErrUnauthorized(fmt.Sprintf("only the owner can mint token %s", msg.Symbol)).Result()
+	}
+
+	// use minus to prevent overflow
+	if msg.Amount > common.TokenMaxTotalSupply-token.TotalSupply.ToInt64() {
+		logger.Info(errLogMsg, "reason", "exceed the max total supply")
+		return sdk.ErrInvalidCoins(fmt.Sprintf("mint amount is too large, the max total supply is %ds",
+			common.TokenMaxTotalSupply)).Result()
+	}
+	newTotalSupply := token.TotalSupply.ToInt64() + msg.Amount
+	err = tokenMapper.UpdateTotalSupply(ctx, symbol, newTotalSupply)
+	if err != nil {
+		logger.Error(errLogMsg, "reason", "update total supply failed: "+err.Error())
+		return sdk.ErrInternal(fmt.Sprintf("update total supply failed")).Result()
+	}
+
+	_, _, sdkError := bankKeeper.AddCoins(ctx, token.Owner,
+		sdk.Coins{{
+			Denom:  token.Symbol,
+			Amount: msg.Amount,
+		}})
+	if sdkError != nil {
+		logger.Error(errLogMsg, "reason", "update balance failed: "+sdkError.Error())
+		return sdkError.Result()
+	}
+
+	logger.Info("finished minting token")
+	return sdk.Result{
+		Data: []byte(strconv.FormatInt(newTotalSupply, 10)),
 	}
 }

--- a/plugins/tokens/issue/handler_test.go
+++ b/plugins/tokens/issue/handler_test.go
@@ -1,0 +1,97 @@
+package issue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+
+	"github.com/BiJie/BinanceChain/common/testutils"
+	"github.com/BiJie/BinanceChain/common/types"
+	"github.com/BiJie/BinanceChain/plugins/tokens/store"
+	"github.com/BiJie/BinanceChain/wire"
+)
+
+func setup() (sdk.Context, sdk.Handler, auth.AccountKeeper, store.Mapper) {
+	ms, capKey1, capKey2 := testutils.SetupMultiStoreForUnitTest()
+	cdc := wire.NewCodec()
+	tokenMapper := store.NewMapper(cdc, capKey1)
+	accountKeeper := auth.NewAccountKeeper(cdc, capKey2, auth.ProtoBaseAccount)
+	bankKeeper := bank.NewBaseKeeper(accountKeeper)
+	handler := NewHandler(tokenMapper, bankKeeper)
+
+	accountStore := ms.GetKVStore(capKey2)
+	accountStoreCache := auth.NewAccountStoreCache(cdc, accountStore, 10)
+	ctx := sdk.NewContext(ms, abci.Header{ChainID: "mychainid", Height: 1},
+		sdk.RunTxModeDeliver, log.NewNopLogger()).
+		WithAccountCache(auth.NewAccountCache(accountStoreCache))
+	return ctx, handler, accountKeeper, tokenMapper
+}
+
+func TestHandleIssueToken(t *testing.T) {
+	ctx, handler, accountKeeper, tokenMapper := setup()
+	_, acc := testutils.NewAccount(ctx, accountKeeper, 100e8)
+
+	ctx = ctx.WithValue(baseapp.TxHashKey, "000")
+	msg := NewIssueMsg(acc.GetAddress(), "New BNB", "NNB", 100000e8, false)
+	sdkResult := handler(ctx, msg)
+	require.Equal(t, true, sdkResult.Code.IsOK())
+	token, err := tokenMapper.GetToken(ctx, "NNB-000")
+	require.NoError(t, err)
+	expectedToken, err := types.NewToken("New BNB", "NNB-000", 100000e8, acc.GetAddress(), false)
+	require.Equal(t, *expectedToken, token)
+
+	sdkResult = handler(ctx, msg)
+	require.Contains(t, sdkResult.Log, "symbol(NNB) already exists")
+}
+
+func TestHandleMintToken(t *testing.T) {
+	ctx, handler, accountKeeper, tokenMapper := setup()
+	_, acc := testutils.NewAccount(ctx, accountKeeper, 100e8)
+	mintMsg := NewMintMsg(acc.GetAddress(), "NNB-000", 10000e8)
+	sdkResult := handler(ctx, mintMsg)
+	require.Contains(t, sdkResult.Log, "symbol(NNB-000) does not exist")
+
+	issueMsg := NewIssueMsg(acc.GetAddress(), "New BNB", "NNB", 100000e8, true)
+	ctx = ctx.WithValue(baseapp.TxHashKey, "000")
+	sdkResult = handler(ctx, issueMsg)
+	require.Equal(t, true, sdkResult.Code.IsOK())
+
+	sdkResult = handler(ctx, mintMsg)
+	require.Equal(t, true, sdkResult.Code.IsOK())
+
+	token, err := tokenMapper.GetToken(ctx, "NNB-000")
+	require.NoError(t, err)
+	expectedToken, err := types.NewToken("New BNB", "NNB-000", 110000e8, acc.GetAddress(), true)
+	require.Equal(t, *expectedToken, token)
+
+	invalidMintMsg := NewMintMsg(acc.GetAddress(), "NNB-000", types.TokenMaxTotalSupply)
+	sdkResult = handler(ctx, invalidMintMsg)
+	require.Contains(t, sdkResult.Log, "mint amount is too large")
+
+	_, acc2 := testutils.NewAccount(ctx, accountKeeper, 100e8)
+	invalidMintMsg = NewMintMsg(acc2.GetAddress(), "NNB-000", types.TokenMaxTotalSupply)
+	sdkResult = handler(ctx, invalidMintMsg)
+	require.Contains(t, sdkResult.Log, "only the owner can mint token NNB")
+
+	// issue a non-mintable token
+	issueMsg = NewIssueMsg(acc.GetAddress(), "New BNB2", "NNB2", 100000e8, false)
+	ctx = ctx.WithValue(baseapp.TxHashKey, "000")
+	sdkResult = handler(ctx, issueMsg)
+	require.Equal(t, true, sdkResult.Code.IsOK())
+
+	mintMsg = NewMintMsg(acc.GetAddress(), "NNB2-000", 10000e8)
+	sdkResult = handler(ctx, mintMsg)
+	require.Contains(t, sdkResult.Log, "token(NNB2-000) cannot be minted")
+	
+	// mint native token
+	invalidMintMsg = NewMintMsg(acc.GetAddress(), "BNB", 10000e8)
+	require.Contains(t, invalidMintMsg.ValidateBasic().Error(), "cannot mint native token")
+}

--- a/plugins/tokens/wire.go
+++ b/plugins/tokens/wire.go
@@ -10,6 +10,7 @@ import (
 // Register concrete types on wire codec
 func RegisterWire(cdc *wire.Codec) {
 	cdc.RegisterConcrete(issue.IssueMsg{}, "tokens/IssueMsg", nil)
+	cdc.RegisterConcrete(issue.MintMsg{}, "tokens/MintMsg", nil)
 	cdc.RegisterConcrete(burn.BurnMsg{}, "tokens/BurnMsg", nil)
 	cdc.RegisterConcrete(freeze.FreezeMsg{}, "tokens/FreezeMsg", nil)
 	cdc.RegisterConcrete(freeze.UnfreezeMsg{}, "tokens/UnfreezeMsg", nil)


### PR DESCRIPTION
### Description

Tokens except the 'BNB' can be minted. The mint amount is still restricted by the MaxTotalSupply.

Updated: 
**we now allow the native token to be minted.**

### Rationale

#342 

### Example

> bnbcli token mint --amount 300000000000 --symbol NNB-000 --from nn --chain-id=test-chain-m7eiMl

### Changes

Notable changes: 
* implement mint tokens
* fix `List` integration test.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

