### PR TITLE
[R4R] collected fees need to be committed

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -14,7 +14,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/gov"
 	"github.com/cosmos/cosmos-sdk/x/params"
 	"github.com/cosmos/cosmos-sdk/x/stake"
+
 	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto/tmhash"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
@@ -24,6 +26,7 @@ import (
 	"github.com/BiJie/BinanceChain/app/pub"
 	"github.com/BiJie/BinanceChain/app/val"
 	"github.com/BiJie/BinanceChain/common"
+	"github.com/BiJie/BinanceChain/common/fees"
 	bnclog "github.com/BiJie/BinanceChain/common/log"
 	"github.com/BiJie/BinanceChain/common/tx"
 	"github.com/BiJie/BinanceChain/common/types"
@@ -268,6 +271,18 @@ func (app *BinanceChain) initChainerFn() sdk.InitChainer {
 			Validators: validators,
 		}
 	}
+}
+
+// Implements ABCI
+func (app *BinanceChain) DeliverTx(txBytes []byte) (res abci.ResponseDeliverTx) {
+	res = app.BaseApp.DeliverTx(txBytes)
+	if res.IsOK() {
+		// commit or panic
+		txHash := cmn.HexBytes(tmhash.Sum(txBytes)).String()
+		fees.Pool.CommitFee(txHash)
+	}
+
+	return res
 }
 
 func (app *BinanceChain) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {

--- a/app/app_pub_test.go
+++ b/app/app_pub_test.go
@@ -20,6 +20,7 @@ import (
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
 
+	"github.com/BiJie/BinanceChain/common/fees"
 	"github.com/BiJie/BinanceChain/app/config"
 	"github.com/BiJie/BinanceChain/app/pub"
 	"github.com/BiJie/BinanceChain/common/testutils"
@@ -215,7 +216,7 @@ func TestAppPub_MatchAndCancelFee(t *testing.T) {
 	app.SetDeliverState(abci.Header{Height: 41, Time: time.Unix(0, 100)})
 	sellerAcc.SetSequence(1)
 	am.SetAccount(ctx, sellerAcc)
-	ctx = ctx.WithValue(baseapp.TxHashKey, "")
+	ctx = ctx.WithValue(baseapp.TxHashKey, "").WithRunTxMode(sdk.RunTxModeDeliver)
 	res := handler(ctx, msg)
 	require.Equal(sdk.ABCICodeOK, res.Code, res.Log)
 
@@ -240,8 +241,10 @@ func TestAppPub_MatchAndCancelFee(t *testing.T) {
 	buyerAcc = am.GetAccount(ctx, buyer)
 	buyerAcc.SetSequence(3)
 	am.SetAccount(ctx, buyerAcc)
+	ctx = ctx.WithValue(baseapp.TxHashKey, "CANCEL1")
 	res = handler(ctx, cxlMsg)
 	require.Equal(sdk.ABCICodeOK, res.Code, res.Log)
+	fees.Pool.CommitFee("CANCEL1")
 
 	app.EndBlocker(ctx, abci.RequestEndBlock{Height: 42})
 

--- a/app/fee_distribution_test.go
+++ b/app/fee_distribution_test.go
@@ -82,7 +82,7 @@ func TestNoFeeDistribution(t *testing.T) {
 func TestFeeDistribution2Proposer(t *testing.T) {
 	// setup
 	am, valMapper, ctx, proposerAcc, _, _, _ := setup()
-	fees.Pool.AddFee(types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeTokenSymbol, 10)}, types.FeeForProposer))
+	fees.Pool.AddAndCommitFee("DIST", types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeTokenSymbol, 10)}, types.FeeForProposer))
 	blockFee := distributeFee(ctx, am, valMapper, true)
 	require.Equal(t, pub.BlockFee{0, "BNB:10", []string{string(proposerAcc.GetAddress())}}, blockFee)
 	checkBalance(t, ctx, am, valMapper, []int64{110, 100, 100, 100})
@@ -92,13 +92,13 @@ func TestFeeDistribution2AllValidators(t *testing.T) {
 	// setup
 	am, valMapper, ctx, proposerAcc, valAcc1, valAcc2, valAcc3 := setup()
 	// fee amount can be divided evenly
-	fees.Pool.AddFee(types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeTokenSymbol, 40)}, types.FeeForAll))
+	fees.Pool.AddAndCommitFee("DIST", types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeTokenSymbol, 40)}, types.FeeForAll))
 	blockFee := distributeFee(ctx, am, valMapper, true)
 	require.Equal(t, pub.BlockFee{0, "BNB:40", []string{string(proposerAcc.GetAddress()), string(valAcc1.GetAddress()), string(valAcc2.GetAddress()), string(valAcc3.GetAddress())}}, blockFee)
 	checkBalance(t, ctx, am, valMapper, []int64{110, 110, 110, 110})
 
 	// cannot be divided evenly
-	fees.Pool.AddFee(types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeTokenSymbol, 50)}, types.FeeForAll))
+	fees.Pool.AddAndCommitFee("DIST", types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeTokenSymbol, 50)}, types.FeeForAll))
 	blockFee = distributeFee(ctx, am, valMapper, true)
 	require.Equal(t, pub.BlockFee{0, "BNB:50", []string{string(proposerAcc.GetAddress()), string(valAcc1.GetAddress()), string(valAcc2.GetAddress()), string(valAcc3.GetAddress())}}, blockFee)
 	checkBalance(t, ctx, am, valMapper, []int64{124, 122, 122, 122})

--- a/common/fees/pool.go
+++ b/common/fees/pool.go
@@ -1,24 +1,48 @@
 package fees
 
 import (
+	"fmt"
+
 	"github.com/BiJie/BinanceChain/common/types"
 )
 
 // block level pool
-var Pool pool
+var Pool pool = newPool()
 
 type pool struct {
-	fees types.Fee
+	fees          map[string]types.Fee // TxHash -> fee
+	committedFees types.Fee
 }
 
-func (p *pool) AddFee(fee types.Fee) {
-	p.fees.AddFee(fee)
+func newPool() pool {
+	return pool{
+		fees:          map[string]types.Fee{},
+		committedFees: types.Fee{},
+	}
+}
+
+func (p *pool) AddFee(txHash string, fee types.Fee) {
+	p.fees[txHash] = fee
+}
+
+func (p *pool) AddAndCommitFee(txHash string, fee types.Fee) {
+	p.fees[txHash] = fee
+	p.committedFees.AddFee(fee)
+}
+
+func (p *pool) CommitFee(txHash string) {
+	if fee, ok := p.fees[txHash]; ok {
+		p.committedFees.AddFee(fee)
+	} else {
+		panic(fmt.Errorf("commit fee for an invalid TxHash(%s)", txHash))
+	}
 }
 
 func (p pool) BlockFees() types.Fee {
-	return p.fees
+	return p.committedFees
 }
 
 func (p *pool) Clear() {
-	p.fees = types.Fee{}
+	p.fees = map[string]types.Fee{}
+	p.committedFees = types.Fee{}
 }

--- a/plugins/dex/order/handler.go
+++ b/plugins/dex/order/handler.go
@@ -189,6 +189,15 @@ func handleCancelOrder(
 
 	// this is done in memory! we must not run this block in checktx or simulate!
 	if ctx.IsDeliverTx() {
+		if txHash, ok := ctx.Value(baseapp.TxHashKey).(string); !ok {
+			return sdk.NewError(
+				types.DefaultCodespace,
+				types.CodeFailCancelOrder,
+				"cannot get txHash from ctx").Result()
+		} else {
+			// add fee to pool, even it's free
+			fees.Pool.AddFee(txHash, fee)
+		}
 		//remove order from cache and order book
 		err := keeper.RemoveOrder(origOrd.Id, origOrd.Symbol, func(ord me.OrderPart) {
 			if keeper.CollectOrderInfoForPublish {
@@ -200,8 +209,6 @@ func handleCancelOrder(
 		if err != nil {
 			return sdk.NewError(types.DefaultCodespace, types.CodeFailCancelOrder, err.Error()).Result()
 		}
-
-		fees.Pool.AddFee(fee)
 	}
 
 	return sdk.Result{}

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -560,7 +560,7 @@ func (kp *Keeper) MatchAndAllocateAll(
 	}
 
 	totalFee := kp.allocateAndCalcFee(ctx, tradeOuts, postAlloTransHandler)
-	fees.Pool.AddFee(totalFee)
+	fees.Pool.AddAndCommitFee("MATCH", totalFee)
 	kp.clearAfterMatch()
 }
 
@@ -637,7 +637,7 @@ func (kp *Keeper) ExpireOrders(
 	}
 
 	totalFee := kp.allocateAndCalcFee(ctx, transferChs, postAlloTransHandler)
-	fees.Pool.AddFee(totalFee)
+	fees.Pool.AddAndCommitFee("EXPIRE", totalFee)
 }
 
 func (kp *Keeper) MarkBreatheBlock(ctx sdk.Context, height int64, blockTime time.Time) {


### PR DESCRIPTION
### Description

fix #356,   we need rollback the fee from the pool if the tx is failed

### Rationale

If the fee is not rolled back, this amount of tokens will be distributed to validators. That means the total supply of this token would be increased implicitly

### Example

### Changes

Notable changes: 
* add a commit method to feepool
* rewrite app.DeliverTx

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

