### PR TITLE
Add Data field in tx signature

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -57,7 +57,7 @@
 
 [[projects]]
   branch = "upgrade25"
-  digest = "1:8c906e08c7e6b567346ce721a775d172a3dc6fb85ddb751bbb1f9b0fe653c7ac"
+  digest = "1:ae6bfb916196e1f5bf393105286955f554f8dc079aad45d98df742118ee9111f"
   name = "github.com/cosmos/cosmos-sdk"
   packages = [
     "baseapp",
@@ -106,7 +106,7 @@
     "x/stake/types",
   ]
   pruneopts = "UT"
-  revision = "36b60a077425c7e941f8dff6ad6dca8f85071744"
+  revision = "03f72292b6a608d948554679bbf9267fcb4acad0"
   source = "github.com/BiJie/bnc-cosmos-sdk"
 
 [[projects]]

--- a/app/app_pub_test.go
+++ b/app/app_pub_test.go
@@ -42,7 +42,7 @@ func prepareGenTx(cdc *codec.Codec, chainId string,
 		stake.NewDescription("pub", "", "", ""),
 		stake.NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
 	)
-	tx := auth.NewStdTx([]sdk.Msg{msg}, nil, "", 0)
+	tx := auth.NewStdTx([]sdk.Msg{msg}, nil, "", 0, nil)
 	txBytes, err := wire.MarshalJSONIndent(cdc, tx)
 	if err != nil {
 		panic(err)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -30,25 +30,25 @@ type TestClient struct {
 }
 
 func (tc *TestClient) DeliverTxAsync(msg sdk.Msg, cdc *wire.Codec) *abcicli.ReqRes {
-	stdtx := auth.NewStdTx([]sdk.Msg{msg}, nil, "test", 0)
+	stdtx := auth.NewStdTx([]sdk.Msg{msg}, nil, "test", 0, nil)
 	tx, _ := tc.cdc.MarshalBinary(stdtx)
 	return tc.cl.DeliverTxAsync(tx)
 }
 
 func (tc *TestClient) CheckTxAsync(msg sdk.Msg, cdc *wire.Codec) *abcicli.ReqRes {
-	stdtx := auth.NewStdTx([]sdk.Msg{msg}, nil, "test", 0)
+	stdtx := auth.NewStdTx([]sdk.Msg{msg}, nil, "test", 0, nil)
 	tx, _ := tc.cdc.MarshalBinary(stdtx)
 	return tc.cl.CheckTxAsync(tx)
 }
 
 func (tc *TestClient) DeliverTxSync(msg sdk.Msg, cdc *wire.Codec) (*types.ResponseDeliverTx, error) {
-	stdtx := auth.NewStdTx([]sdk.Msg{msg}, nil, "test", 0)
+	stdtx := auth.NewStdTx([]sdk.Msg{msg}, nil, "test", 0, nil)
 	tx, _ := tc.cdc.MarshalBinary(stdtx)
 	return tc.cl.DeliverTxSync(tx)
 }
 
 func (tc *TestClient) CheckTxSync(msg sdk.Msg, cdc *wire.Codec) (*types.ResponseCheckTx, error) {
-	stdtx := auth.NewStdTx([]sdk.Msg{msg}, nil, "test", 0)
+	stdtx := auth.NewStdTx([]sdk.Msg{msg}, nil, "test", 0, nil)
 	tx, _ := tc.cdc.MarshalBinary(stdtx)
 	return tc.cl.CheckTxSync(tx)
 }

--- a/cmd/bnbchaind/init/init.go
+++ b/cmd/bnbchaind/init/init.go
@@ -138,7 +138,7 @@ func prepareCreateValidatorTx(cdc *codec.Codec, chainId, name, memo string,
 		stake.NewDescription(name, "", "", ""),
 		stake.NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
 	)
-	tx := auth.NewStdTx([]sdk.Msg{msg}, []auth.StdSignature{}, memo, auth.DefaultSource)
+	tx := auth.NewStdTx([]sdk.Msg{msg}, []auth.StdSignature{}, memo, auth.DefaultSource, nil)
 	txBldr := authtx.NewTxBuilderFromCLI().WithChainID(chainId).WithMemo(memo)
 	signedTx, err := txBldr.SignStdTx(name, app.DefaultKeyPass, tx, false)
 	if err != nil {

--- a/cmd/dexperf/main.go
+++ b/cmd/dexperf/main.go
@@ -544,7 +544,7 @@ func create(wg *sync.WaitGroup, s *sequence) {
 			PubKey:        pubkey,
 			Signature:     sigBytes,
 		}
-		txBytes, err := item.txBldr.Codec.MarshalBinary(auth.NewStdTx(ssMsg.Msgs, []auth.StdSignature{sig}, ssMsg.Memo, ssMsg.Source))
+		txBytes, err := item.txBldr.Codec.MarshalBinary(auth.NewStdTx(ssMsg.Msgs, []auth.StdSignature{sig}, ssMsg.Memo, ssMsg.Source, ssMsg.Data))
 		if err != nil {
 			fmt.Printf("failed to sign tran: %v\n", err)
 			continue

--- a/common/tx/ante.go
+++ b/common/tx/ante.go
@@ -4,17 +4,17 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/BiJie/BinanceChain/common/fees"
-	"github.com/BiJie/BinanceChain/common/log"
-	"github.com/BiJie/BinanceChain/common/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	"github.com/tendermint/tendermint/libs/common"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/BiJie/BinanceChain/common/fees"
+	"github.com/BiJie/BinanceChain/common/log"
+	"github.com/BiJie/BinanceChain/common/types"
 )
 
 const (
@@ -93,7 +93,7 @@ func NewTxPreChecker(am auth.AccountKeeper) sdk.PreChecker {
 			if err != nil {
 				return sdk.ErrInternal(err.Error()).Result()
 			}
-			signBytes := auth.StdSignBytes(chainID, accNums[i], sequences[i], msgs, stdTx.GetMemo(), stdTx.GetSource())
+			signBytes := auth.StdSignBytes(chainID, accNums[i], sequences[i], msgs, stdTx.GetMemo(), stdTx.GetSource(), stdTx.GetData())
 
 			res := processSig(txHash, sig, signerAcc, signBytes)
 			if !res.IsOK() {
@@ -158,7 +158,7 @@ func NewAnteHandler(am auth.AccountKeeper) sdk.AnteHandler {
 				mode == sdk.RunTxModeCheck ||
 				mode == sdk.RunTxModeSimulate {
 				// check signature, return account with incremented nonce
-				signBytes := auth.StdSignBytes(chainID, accNums[i], sequences[i], msgs, stdTx.GetMemo(), stdTx.GetSource())
+				signBytes := auth.StdSignBytes(chainID, accNums[i], sequences[i], msgs, stdTx.GetMemo(), stdTx.GetSource(), stdTx.GetData())
 				res := processSig(txHash, sig, signerAcc, signBytes)
 				if !res.IsOK() {
 					return newCtx, res, true

--- a/common/tx/ante_test.go
+++ b/common/tx/ante_test.go
@@ -57,28 +57,28 @@ func checkInvalidTx(t *testing.T, anteHandler sdk.AnteHandler, ctx sdk.Context, 
 func newTestTx(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums []int64, seqs []int64) sdk.Tx {
 	sigs := make([]auth.StdSignature, len(privs))
 	for i, priv := range privs {
-		signBytes := auth.StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], msgs, "", 0)
+		signBytes := auth.StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], msgs, "", 0, nil)
 		sig, err := priv.Sign(signBytes)
 		if err != nil {
 			panic(err)
 		}
 		sigs[i] = auth.StdSignature{PubKey: priv.PubKey(), Signature: sig, AccountNumber: accNums[i], Sequence: seqs[i]}
 	}
-	tx := auth.NewStdTx(msgs, sigs, "", 0)
+	tx := auth.NewStdTx(msgs, sigs, "", 0, nil)
 	return tx
 }
 
 func newTestTxWithMemo(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums []int64, seqs []int64, memo string) sdk.Tx {
 	sigs := make([]auth.StdSignature, len(privs))
 	for i, priv := range privs {
-		signBytes := auth.StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], msgs, memo, 0)
+		signBytes := auth.StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], msgs, memo, 0, nil)
 		sig, err := priv.Sign(signBytes)
 		if err != nil {
 			panic(err)
 		}
 		sigs[i] = auth.StdSignature{PubKey: priv.PubKey(), Signature: sig, AccountNumber: accNums[i], Sequence: seqs[i]}
 	}
-	tx := auth.NewStdTx(msgs, sigs, memo, 0)
+	tx := auth.NewStdTx(msgs, sigs, memo, 0, nil)
 	return tx
 }
 
@@ -92,7 +92,7 @@ func newTestTxWithSignBytes(msgs []sdk.Msg, privs []crypto.PrivKey, accNums []in
 		}
 		sigs[i] = auth.StdSignature{PubKey: priv.PubKey(), Signature: sig, AccountNumber: accNums[i], Sequence: seqs[i]}
 	}
-	tx := auth.NewStdTx(msgs, sigs, memo, 0)
+	tx := auth.NewStdTx(msgs, sigs, memo, 0, nil)
 	return tx
 }
 
@@ -395,7 +395,7 @@ func TestAnteHandlerBadSignBytes(t *testing.T) {
 		txn := newTestTxWithSignBytes(
 
 			msgs, privs, accnums, seqs,
-			auth.StdSignBytes(cs.chainID, cs.accnum, cs.seq, cs.msgs, "", 0),
+			auth.StdSignBytes(cs.chainID, cs.accnum, cs.seq, cs.msgs, "", 0, nil),
 			"",
 		)
 		checkInvalidTx(t, anteHandler, ctx, txn, cs.code)
@@ -690,7 +690,7 @@ func Test_NewTxPreCheckerSignature(t *testing.T) {
 		txn := newTestTxWithSignBytes(
 
 			msgs, privs, accnums, seqs,
-			auth.StdSignBytes(cs.chainID, cs.accnum, cs.seq, cs.msgs, "", 0),
+			auth.StdSignBytes(cs.chainID, cs.accnum, cs.seq, cs.msgs, "", 0, nil),
 			"",
 		)
 		res := prechecker(ctx, cdc.MustMarshalBinary(txn), txn)

--- a/plugins/dex/order/keeper_test.go
+++ b/plugins/dex/order/keeper_test.go
@@ -368,7 +368,7 @@ func MakeTxFromMsg(msgs []sdk.Msg, accountNumber, seqNum int64, privKey secp256k
 		AccountNumber: accountNumber,
 		Sequence:      seqNum,
 	}}
-	tx := auth.NewStdTx(signMsg.Msgs, sigs, signMsg.Memo, 0)
+	tx := auth.NewStdTx(signMsg.Msgs, sigs, signMsg.Memo, 0, nil)
 	return tx
 }
 


### PR DESCRIPTION
### Description

add Data filed to Signature

### Rationale


### Example


### Changes

Notable changes: 
*  add Data field to tx signature


### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

