### PR TITLE
[R4R] Fix reset bug

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -672,6 +672,17 @@
   version = "v0.1.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:3e4c7966b60df887418bf1b880be9a1e6c36f97ef40491b7bad72d21a4334cd0"
+  name = "go.uber.org/ratelimit"
+  packages = [
+    ".",
+    "internal/clock",
+  ]
+  pruneopts = "UT"
+  revision = "c15da02342779cb6dc027fc95ee2277787698f36"
+
+[[projects]]
   digest = "1:aaff04fa01d9b824fde6799759cc597b3ac3671b9ad31924c28b6557d0ee5284"
   name = "golang.org/x/crypto"
   packages = [
@@ -872,6 +883,7 @@
     "github.com/tendermint/tendermint/rpc/lib/server",
     "github.com/tendermint/tendermint/state",
     "github.com/tendermint/tendermint/types",
+    "go.uber.org/ratelimit",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/networks/tools/reset.go
+++ b/networks/tools/reset.go
@@ -185,8 +185,8 @@ func resetAppVersionedTree(height int64, rootDir string) {
 	}
 	defer dbIns.Close()
 
-	keys := []store.StoreKey{common.MainStoreKey, common.AccountStoreKey, common.TokenStoreKey, common.DexStoreKey, common.PairStoreKey, common.GovStoreKey,
-		common.StakeStoreKey, common.ParamsStoreKey, common.ValAddrStoreKey}
+	keys := []store.StoreKey{common.MainStoreKey, common.AccountStoreKey, common.TokenStoreKey, common.DexStoreKey,
+		common.PairStoreKey, common.GovStoreKey, common.StakeStoreKey, common.ParamsStoreKey, common.ValAddrStoreKey}
 
 	for _, key := range keys {
 		dbAccount := db.NewPrefixDB(dbIns, []byte("s/k:"+key.Name()+"/"))


### PR DESCRIPTION
### Description

the previous version, we forget to delete new key stores, and we do not delete orphans of future versions.

### Rationale



### Example



### Changes

Notable changes: 
* delete new key stores
* delete orphans of future versions

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

