### PR TITLE
optimize simulation handling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -56,8 +56,8 @@
   revision = "d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4"
 
 [[projects]]
-  branch = "upgrade25"
-  digest = "1:938e75b7cca7e036fc23d41e4db6b002f5db7fcdc5770573729cfefa1204c505"
+  branch = "seq"
+  digest = "1:75364bd9344c30645d2a326dd39b494ad688bdc1594f6bbc0b64203f8e3d025b"
   name = "github.com/cosmos/cosmos-sdk"
   packages = [
     "baseapp",
@@ -106,7 +106,7 @@
     "x/stake/types",
   ]
   pruneopts = "UT"
-  revision = "be3d06b766445fc87ac6e27532798b36c03cc63b"
+  revision = "fe726ab9e3c327a8e2df4de6e83196787209bb35"
   source = "github.com/BiJie/bnc-cosmos-sdk"
 
 [[projects]]
@@ -593,7 +593,8 @@
   version = "v0.11.0"
 
 [[projects]]
-  digest = "1:4b2c0e68c360933dfe4d834ab107c22cb73bc71df21ee289659882fe313062f2"
+  branch = "feature/simulate"
+  digest = "1:8864a7c3626e30fca90e006ed98b85fa84db118af37b27e68494352d8b9bc116"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
@@ -659,9 +660,8 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "3f17d89ee2b1a6441279873d81a444b3e0e5eece"
+  revision = "4111322f6a0c0e9e2d4308e2f11e8f2ec2cad184"
   source = "github.com/BiJie/bnc-tendermint"
-  version = "v0.25.1-br7"
 
 [[projects]]
   digest = "1:7886f86064faff6f8d08a3eb0e8c773648ff5a2e27730831e2bfbf07467f6666"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,12 +35,13 @@
 [[override]]
   name = "github.com/tendermint/tendermint"
   source = "github.com/BiJie/bnc-tendermint"
-  version = "=0.25.1-br7"
+  branch = "feature/simulate"
+  #version = "=0.25.1-br7"
 
 [[constraint]]
   name = "github.com/cosmos/cosmos-sdk"
   source = "github.com/BiJie/bnc-cosmos-sdk"
-  branch = "upgrade25"
+  branch = "seq"
 
 [[constraint]]
   name = "github.com/pkg/errors"

--- a/plugins/api/handlers.go
+++ b/plugins/api/handlers.go
@@ -84,8 +84,12 @@ func (s *server) handleNodeVersionReq() http.HandlerFunc {
 	return hnd.NodeVersionReqHandler(s.ctx)
 }
 
-func (s *server) handleAccountReq(cdc *wire.Codec, ctx context.CLIContext, tokens tkstore.Mapper, accStoreName string) http.HandlerFunc {
-	return hnd.AccountReqHandler(cdc, ctx, tokens, accStoreName)
+func (s *server) handleAccountReq(cdc *wire.Codec, ctx context.CLIContext, accStoreName string) http.HandlerFunc {
+	return hnd.AccountReqHandler(cdc, ctx, accStoreName)
+}
+
+func (s *server) handleSimulateAccountReq(cdc *wire.Codec, ctx context.CLIContext) http.HandlerFunc {
+	return hnd.SimulateAccountReqHandler(cdc, ctx)
 }
 
 func (s *server) handleSimulateReq(cdc *wire.Codec, ctx context.CLIContext) http.HandlerFunc {

--- a/plugins/api/handlers/account.go
+++ b/plugins/api/handlers/account.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/BiJie/BinanceChain/common/utils"
 	"github.com/gorilla/mux"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -14,13 +15,12 @@ import (
 
 	"github.com/BiJie/BinanceChain/common/types"
 	tkclient "github.com/BiJie/BinanceChain/plugins/tokens/client/rest"
-	tkstore "github.com/BiJie/BinanceChain/plugins/tokens/store"
 	"github.com/BiJie/BinanceChain/wire"
 )
 
 // AccountReqHandler queries for an account and returns its information.
 func AccountReqHandler(
-	cdc *wire.Codec, ctx context.CLIContext, tokens tkstore.Mapper, accStoreName string,
+	cdc *wire.Codec, ctx context.CLIContext, accStoreName string,
 ) http.HandlerFunc {
 	type response struct {
 		auth.BaseAccount
@@ -70,14 +70,106 @@ func AccountReqHandler(
 			return
 		}
 
-		bals, err := tkclient.GetBalances(cdc, ctx, tokens, account.GetAddress())
+		appAccount := account.(*types.AppAccount)
 		resp := response{
-			BaseAccount: account.(*types.AppAccount).BaseAccount,
-			Balances:    bals,
+			BaseAccount: appAccount.BaseAccount,
+			Balances:    toTokenBalances(appAccount),
 		}
 
 		w.Header().Set("Content-Type", responseType)
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(resp)
 	}
+}
+
+func SimulateAccountReqHandler(cdc *wire.Codec, ctx context.CLIContext) http.HandlerFunc {
+	type response struct {
+		auth.BaseAccount
+		Balances []tkclient.TokenBalance `json:"balances"`
+		Coins    *struct{}               `json:"coins,omitempty"` // omit `coins`
+	}
+
+	responseType := "application/json"
+
+	accDecoder := authcmd.GetAccountDecoder(cdc)
+
+	throw := func(w http.ResponseWriter, status int, message string) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(status)
+		w.Write([]byte(message))
+		return
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		bech32addr := vars["address"]
+
+		_, err := sdk.AccAddressFromBech32(bech32addr)
+		if err != nil {
+			throw(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		res, err := ctx.Query(fmt.Sprintf("/simulate/account/%s", bech32addr), nil)
+		if err != nil {
+			errMsg := fmt.Sprintf("couldn't query account. Error: %s", err.Error())
+			throw(w, http.StatusInternalServerError, errMsg)
+			return
+		}
+
+		// the query will return empty if there is no data for this account
+		if len(res) == 0 {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		// decode the value
+		account, err := accDecoder(res)
+		if err != nil {
+			errMsg := fmt.Sprintf("couldn't parse query result. Result: %s. Error: %s", res, err.Error())
+			throw(w, http.StatusInternalServerError, errMsg)
+			return
+		}
+
+		appAccount := account.(*types.AppAccount)
+		resp := response{
+			BaseAccount: appAccount.BaseAccount,
+			Balances:    toTokenBalances(appAccount),
+		}
+
+		w.Header().Set("Content-Type", responseType)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func toTokenBalances(acc *types.AppAccount) []tkclient.TokenBalance {
+	balances := make(map[string]tkclient.TokenBalance)
+	for _, coin := range acc.GetCoins() {
+		balances[coin.Denom] = tkclient.TokenBalance{Symbol: coin.Denom, Free: utils.Fixed8(coin.Amount)}
+	}
+
+	for _, coin := range acc.GetLockedCoins() {
+		if balance, ok := balances[coin.Denom]; ok {
+			balance.Locked = utils.Fixed8(coin.Amount)
+		} else {
+			balances[coin.Denom] = tkclient.TokenBalance{Symbol: coin.Denom, Locked: utils.Fixed8(coin.Amount)}
+		}
+	}
+
+	for _, coin := range acc.GetFrozenCoins() {
+		if balance, ok := balances[coin.Denom]; ok {
+			balance.Frozen = utils.Fixed8(coin.Amount)
+		} else {
+			balances[coin.Denom] = tkclient.TokenBalance{Symbol: coin.Denom, Frozen: utils.Fixed8(coin.Amount)}
+		}
+	}
+
+	res := make([]tkclient.TokenBalance, len(balances), len(balances))
+	i := 0
+	for _, balance := range balances {
+		res[i] = balance
+		i++
+	}
+	return res
 }

--- a/plugins/api/routes.go
+++ b/plugins/api/routes.go
@@ -21,10 +21,11 @@ func (s *server) bindRoutes() *server {
 		Methods("GET")
 
 	// auth routes
-	r.HandleFunc(prefix+"/account/{address}", s.handleAccountReq(s.cdc, s.ctx, s.tokens, s.accStoreName)).
+	r.HandleFunc(prefix+"/account/{address}", s.handleAccountReq(s.cdc, s.ctx, s.accStoreName)).
 		Methods("GET")
 
-	// tx routes
+	// simulation routes
+	r.HandleFunc(prefix+"/simulate/account/{address}", s.handleSimulateAccountReq(s.cdc, s.ctx))
 	r.HandleFunc(prefix+"/simulate", s.handleSimulateReq(s.cdc, s.ctx)).
 		Methods("POST")
 

--- a/plugins/dex/list/handler.go
+++ b/plugins/dex/list/handler.go
@@ -89,9 +89,11 @@ func handleList(
 	}
 
 	pair := types.NewTradingPair(msg.BaseAssetSymbol, msg.QuoteAssetSymbol, msg.InitPrice)
-	err = keeper.PairMapper.AddTradingPair(ctx, pair)
-	if err != nil {
-		return sdk.ErrInternal(err.Error()).Result()
+	if !ctx.IsSimulate() {
+		err = keeper.PairMapper.AddTradingPair(ctx, pair)
+		if err != nil {
+			return sdk.ErrInternal(err.Error()).Result()
+		}
 	}
 
 	// this is done in memory! we must not run this block in checktx or simulate!

--- a/plugins/tokens/burn/handler.go
+++ b/plugins/tokens/burn/handler.go
@@ -54,10 +54,12 @@ func handleBurnToken(ctx sdk.Context, tokenMapper store.Mapper, keeper bank.Keep
 	}
 
 	newTotalSupply := token.TotalSupply.ToInt64() - burnAmount
-	err = tokenMapper.UpdateTotalSupply(ctx, symbol, newTotalSupply)
-	if err != nil {
-		logger.Error("burn token failed", "reason", "update total supply failed: "+err.Error())
-		return sdk.ErrInternal(err.Error()).Result()
+    if !ctx.IsSimulate() {
+		err = tokenMapper.UpdateTotalSupply(ctx, symbol, newTotalSupply)
+		if err != nil {
+			logger.Error("burn token failed", "reason", "update total supply failed: "+err.Error())
+			return sdk.ErrInternal(err.Error()).Result()
+		}
 	}
 
 	logger.Info("successfully burnt token", "NewTotalSupply", newTotalSupply)


### PR DESCRIPTION
### Description

#375 
Add a query api for account in simulate.state.  In simulation mode, states except account state will never be updated.

### Rationale

#375 

### Example

GET api-server/simulate/account/{bech32addr}

### Changes

Notable changes: 
* Add a query api for account in simulate.state
* Simulation will not change any states except the account.
* Improve the original account api

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

