### PR TITLE
account api queries from check state

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -57,7 +57,7 @@
 
 [[projects]]
   branch = "upgrade25"
-  digest = "1:938e75b7cca7e036fc23d41e4db6b002f5db7fcdc5770573729cfefa1204c505"
+  digest = "1:7d79bc243dca6ad107138d9e72c57355f1f2187e679bc7412a40e71f0c63ca3c"
   name = "github.com/cosmos/cosmos-sdk"
   packages = [
     "baseapp",
@@ -106,7 +106,7 @@
     "x/stake/types",
   ]
   pruneopts = "UT"
-  revision = "be3d06b766445fc87ac6e27532798b36c03cc63b"
+  revision = "7e4dea04485b45888306930e193cd24975b37353"
   source = "github.com/BiJie/bnc-cosmos-sdk"
 
 [[projects]]
@@ -593,7 +593,7 @@
   version = "v0.11.0"
 
 [[projects]]
-  digest = "1:4b2c0e68c360933dfe4d834ab107c22cb73bc71df21ee289659882fe313062f2"
+  digest = "1:c64ec8177b2534ea182cec29084ea19f8bc6708e8f178ea279ce1dc962c7d9e1"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
@@ -659,9 +659,9 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "3f17d89ee2b1a6441279873d81a444b3e0e5eece"
+  revision = "53e87109f2f46efe36b012c21f5c5fd5519398ea"
   source = "github.com/BiJie/bnc-tendermint"
-  version = "v0.25.1-br7"
+  version = "v0.25.1-br8"
 
 [[projects]]
   digest = "1:7886f86064faff6f8d08a3eb0e8c773648ff5a2e27730831e2bfbf07467f6666"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 [[override]]
   name = "github.com/tendermint/tendermint"
   source = "github.com/BiJie/bnc-tendermint"
-  version = "=0.25.1-br7"
+  version = "=0.25.1-br8"
 
 [[constraint]]
   name = "github.com/cosmos/cosmos-sdk"

--- a/plugins/api/handlers.go
+++ b/plugins/api/handlers.go
@@ -85,8 +85,8 @@ func (s *server) handleNodeVersionReq() http.HandlerFunc {
 	return hnd.NodeVersionReqHandler(s.ctx)
 }
 
-func (s *server) handleAccountReq(cdc *wire.Codec, ctx context.CLIContext, tokens tkstore.Mapper, accStoreName string) http.HandlerFunc {
-	return hnd.AccountReqHandler(cdc, ctx, tokens, accStoreName)
+func (s *server) handleAccountReq(cdc *wire.Codec, ctx context.CLIContext) http.HandlerFunc {
+	return hnd.AccountReqHandler(cdc, ctx)
 }
 
 func (s *server) handleSimulateReq(cdc *wire.Codec, ctx context.CLIContext) http.HandlerFunc {

--- a/plugins/api/routes.go
+++ b/plugins/api/routes.go
@@ -21,7 +21,7 @@ func (s *server) bindRoutes() *server {
 		Methods("GET")
 
 	// auth routes
-	r.HandleFunc(prefix+"/account/{address}", s.handleAccountReq(s.cdc, s.ctx, s.tokens, s.accStoreName)).
+	r.HandleFunc(prefix+"/account/{address}", s.handleAccountReq(s.cdc, s.ctx)).
 		Methods("GET")
 
 	// tx routes


### PR DESCRIPTION
### Description

The issue is as #376 decribed, but we use the check state instead of simulate state. 
http-ap will not call simulate api any more, it just broadcast transactions to witness node. so the latest state is in the check state of witness node. 

### Rationale

account api should return the latest sequence of one's account.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* optimize account handler
* query from check state

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

