### PR TITLE
[R4R] Add log root config

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -57,7 +57,7 @@
 
 [[projects]]
   branch = "upgrade25"
-  digest = "1:7d79bc243dca6ad107138d9e72c57355f1f2187e679bc7412a40e71f0c63ca3c"
+  digest = "1:356beba2450da99130b22f1bae7ddb15c3e1f4d2a0b0991f3a1aba19d65d4ae0"
   name = "github.com/cosmos/cosmos-sdk"
   packages = [
     "baseapp",
@@ -851,6 +851,7 @@
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/spf13/cobra",
+    "github.com/spf13/pflag",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -83,7 +83,9 @@ publicationChannelSize = "{{ .PublicationConfig.PublicationChannelSize }}"
 logToConsole = {{ .LogConfig.LogToConsole }}
 
 ## The below parameters take effect only when logToConsole is false
-# Log file path relative to home path
+# Log file root, if not set, use home path
+logFileRoot = "{{ .LogConfig.LogFileRoot }}"
+# Log file path relative to log file root path
 logFilePath = "{{ .LogConfig.LogFilePath }}"
 # Number of logs keep in memory before writing to file
 logBuffSize = {{ .LogConfig.LogBuffSize }}
@@ -199,6 +201,7 @@ func (pubCfg PublicationConfig) ShouldPublishAny() bool {
 
 type LogConfig struct {
 	LogToConsole bool   `mapstructure:"logToConsole"`
+	LogFileRoot  string `mapstructure:"logFileRoot"`
 	LogFilePath  string `mapstructure:"logFilePath"`
 	LogBuffSize  int64  `mapstructure:"logBuffSize"`
 }
@@ -206,6 +209,7 @@ type LogConfig struct {
 func defaultLogConfig() *LogConfig {
 	return &LogConfig{
 		LogToConsole: true,
+		LogFileRoot:  "",
 		LogFilePath:  "bnc.log",
 		LogBuffSize:  10000,
 	}

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -88,7 +90,17 @@ func newLogger(ctx *config.BinanceChainContext) log.Logger {
 	if ctx.LogConfig.LogToConsole {
 		return bnclog.NewConsoleLogger()
 	} else {
-		return bnclog.NewAsyncFileLogger(ctx.LogConfig.LogFilePath, ctx.LogConfig.LogBuffSize)
+		logFilePath := ""
+		if ctx.LogConfig.LogFileRoot == "" {
+			logFilePath = path.Join(ctx.Config.RootDir, ctx.LogConfig.LogFilePath)
+		} else {
+			logFilePath = path.Join(ctx.LogConfig.LogFileRoot, ctx.LogConfig.LogFilePath)
+		}
+		err := cmn.EnsureDir(path.Dir(logFilePath), 0755)
+		if err != nil {
+			panic(fmt.Sprintf("create log dir failed, err=%s", err.Error()))
+		}
+		return bnclog.NewAsyncFileLogger(logFilePath, ctx.LogConfig.LogBuffSize)
 	}
 }
 


### PR DESCRIPTION
### Description

For we may need to separate the log file with block store, so we need to add config for log path.

### Rationale


### Example
add an example CLI or API response...

### Changes

Notable changes: 
* add log root path config
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

