### PR TITLE
[R4R]data of response use encode/json instead of amino

### DIFF
--- a/plugins/dex/order/handler.go
+++ b/plugins/dex/order/handler.go
@@ -1,6 +1,7 @@
 package order
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -144,7 +145,7 @@ func handleNewOrder(
 	response := NewOrderResponse{
 		OrderID: msg.Id,
 	}
-	serialized, err := cdc.MarshalJSON(&response)
+	serialized, err := json.Marshal(&response)
 	if err != nil {
 		return sdk.ErrInternal(err.Error()).Result()
 	}

--- a/plugins/dex/wire.go
+++ b/plugins/dex/wire.go
@@ -14,8 +14,6 @@ func RegisterWire(cdc *wire.Codec) {
 	cdc.RegisterConcrete(order.NewOrderMsg{}, "dex/NewOrder", nil)
 	cdc.RegisterConcrete(order.CancelOrderMsg{}, "dex/CancelOrder", nil)
 
-	cdc.RegisterConcrete(order.NewOrderResponse{}, "dex/NewOrderResponse", nil)
-
 	cdc.RegisterConcrete(list.ListMsg{}, "dex/ListMsg", nil)
 	cdc.RegisterConcrete(types.TradingPair{}, "dex/TradingPair", nil)
 


### PR DESCRIPTION
### Description

The data field of response of Binanchain use both json and amino.
Now we change to use json only.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

