### PR TITLE
 fee calculator for MultiTransfer

### DIFF
--- a/plugins/param/genesis.go
+++ b/plugins/param/genesis.go
@@ -15,13 +15,17 @@ import (
 
 const (
 	// Operate fee
-	GovFee      = 1e6
-	ListingFee  = 1e12
-	IssueFee    = 2000e8
-	MintFee     = 500e8
-	BurnFee     = 1e6
-	FreezeFee   = 1e6
-	TransferFee = 1e6
+	GovFee     = 1e6
+	ListingFee = 1e12
+	IssueFee   = 2000e8
+	MintFee    = 500e8
+	BurnFee    = 1e6
+	FreezeFee  = 1e6
+
+	// Transfer fee
+	TransferFee       = 1e6
+	MultiTransferFee  = 8e5
+	LowerLimitAsMulti = 2
 
 	// Dex fee
 	ExpireFee          = 1e5
@@ -53,7 +57,16 @@ var FeeGenesisState = []param.FeeParam{
 	&param.FixedFeeParams{issue.MintMsgType, MintFee, sdk.FeeForAll},
 	&param.FixedFeeParams{burn.BurnRoute, BurnFee, sdk.FeeForProposer},
 	&param.FixedFeeParams{freeze.FreezeRoute, FreezeFee, sdk.FeeForProposer},
-	&param.FixedFeeParams{bank.MsgSend{}.Type(), TransferFee, sdk.FeeForProposer},
+
+	// Transfer
+	&param.TransferFeeParam{
+		FixedFeeParams: param.FixedFeeParams{
+			MsgType: bank.MsgSend{}.Type(),
+			Fee:     TransferFee,
+			FeeFor:  sdk.FeeForProposer},
+		MultiTransferFee:  MultiTransferFee,
+		LowerLimitAsMulti: LowerLimitAsMulti,
+	},
 
 	// Dex
 	&param.DexFeeParam{

--- a/plugins/param/paramhub/fees.go
+++ b/plugins/param/paramhub/fees.go
@@ -28,22 +28,21 @@ func (keeper *Keeper) UpdateFeeParams(ctx sdk.Context, updates []types.FeeParam)
 	dexFeeLoc := 0
 	for index, update := range origin {
 		switch update := update.(type) {
-		case *types.FixedFeeParams:
-			opFeeMap[update.MsgType] = index
+		case types.MsgFeeParams:
+			opFeeMap[update.GetMsgType()] = index
 		case *types.DexFeeParam:
 			dexFeeLoc = index
 		default:
 			keeper.logger.Debug("Origin Fee param not supported ", "feeParam", update)
 		}
-
 	}
 	for _, update := range updates {
 		switch update := update.(type) {
-		case *types.FixedFeeParams:
-			if index, exist := opFeeMap[update.MsgType]; exist {
+		case types.MsgFeeParams:
+			if index, exist := opFeeMap[update.GetMsgType()]; exist {
 				origin[index] = update
 			} else {
-				opFeeMap[update.MsgType] = len(origin)
+				opFeeMap[update.GetMsgType()] = len(origin)
 				origin = append(origin, update)
 			}
 		case *types.DexFeeParam:
@@ -93,8 +92,8 @@ func (keeper *Keeper) registerFeeParamCallBack() {
 func (keeper *Keeper) updateFeeCalculator(updates []types.FeeParam) {
 	fees.UnsetAllCalculators()
 	for _, u := range updates {
-		if u, ok := u.(*types.FixedFeeParams); ok {
-			generator := fees.GetCalculatorGenerator(u.MsgType)
+		if u, ok := u.(types.MsgFeeParams); ok {
+			generator := fees.GetCalculatorGenerator(u.GetMsgType())
 			if generator == nil {
 				continue
 			} else {
@@ -102,7 +101,7 @@ func (keeper *Keeper) updateFeeCalculator(updates []types.FeeParam) {
 				if err != nil {
 					panic(err)
 				}
-				fees.RegisterCalculator(u.MsgType, generator(u))
+				fees.RegisterCalculator(u.GetMsgType(), generator(u))
 			}
 		}
 	}

--- a/plugins/param/plugin.go
+++ b/plugins/param/plugin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/BiJie/BinanceChain/plugins/dex/list"
 	"github.com/BiJie/BinanceChain/plugins/dex/order"
 	"github.com/BiJie/BinanceChain/plugins/param/paramhub"
+	"github.com/BiJie/BinanceChain/plugins/tokens"
 	"github.com/BiJie/BinanceChain/plugins/tokens/burn"
 	"github.com/BiJie/BinanceChain/plugins/tokens/freeze"
 	"github.com/BiJie/BinanceChain/plugins/tokens/issue"
@@ -46,6 +47,6 @@ func init() {
 		issue.MintMsgType:              fees.FixedFeeCalculatorGen,
 		burn.BurnRoute:                 fees.FixedFeeCalculatorGen,
 		freeze.FreezeRoute:             fees.FixedFeeCalculatorGen,
-		bank.MsgSend{}.Type():          fees.FixedFeeCalculatorGen,
+		bank.MsgSend{}.Type():          tokens.TransferFeeCalculatorGen,
 	}
 }

--- a/plugins/param/wire.go
+++ b/plugins/param/wire.go
@@ -8,6 +8,8 @@ import (
 // Register concrete types on wire codec
 func RegisterWire(cdc *wire.Codec) {
 	cdc.RegisterInterface((*types.FeeParam)(nil), nil)
+	cdc.RegisterInterface((*types.MsgFeeParams)(nil), nil)
 	cdc.RegisterConcrete(&types.FixedFeeParams{}, "params/FixedFeeParams", nil)
+	cdc.RegisterConcrete(&types.TransferFeeParam{}, "params/TransferFeeParams", nil)
 	cdc.RegisterConcrete(&types.DexFeeParam{}, "params/DexFeeParam", nil)
 }

--- a/plugins/tokens/fee.go
+++ b/plugins/tokens/fee.go
@@ -1,0 +1,44 @@
+package tokens
+
+import (
+	"github.com/BiJie/BinanceChain/common/utils"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+
+	"github.com/BiJie/BinanceChain/common/fees"
+	"github.com/BiJie/BinanceChain/common/types"
+	param "github.com/BiJie/BinanceChain/plugins/param/types"
+)
+
+var TransferFeeCalculatorGen = fees.FeeCalculatorGenerator(func(params param.FeeParam) fees.FeeCalculator {
+	transferFeeParam, ok := params.(*param.TransferFeeParam)
+	if !ok {
+		panic("Generator received unexpected param type")
+	}
+
+	return fees.FeeCalculator(func(msg sdk.Msg) types.Fee {
+		transferMsg, ok := msg.(bank.MsgSend)
+		if !ok {
+			panic("unexpected msg for TransferFeeCalculator")
+		}
+
+		totalFee := transferFeeParam.Fee
+		var inputNum int64 = 0
+		for _, input := range transferMsg.Inputs {
+			inputNum += int64(len(input.Coins))
+		}
+		var outputNum int64 = 0
+		for _, output := range transferMsg.Outputs {
+			outputNum += int64(len(output.Coins))
+		}
+		num := utils.MaxInt(inputNum, outputNum)
+		if num >= transferFeeParam.LowerLimitAsMulti {
+			if num > types.TokenMaxTotalSupply / transferFeeParam.MultiTransferFee {
+				totalFee = types.TokenMaxTotalSupply
+			} else {
+				totalFee = transferFeeParam.MultiTransferFee * num
+			}
+		}
+		return types.NewFee(sdk.Coins{sdk.NewCoin(types.NativeTokenSymbol, totalFee)}, transferFeeParam.FeeFor)
+	})
+})

--- a/plugins/tokens/fee_test.go
+++ b/plugins/tokens/fee_test.go
@@ -1,0 +1,94 @@
+package tokens_test
+
+import (
+	"testing"
+
+	"github.com/BiJie/BinanceChain/common/testutils"
+	common "github.com/BiJie/BinanceChain/common/types"
+	"github.com/BiJie/BinanceChain/plugins/param/types"
+	"github.com/BiJie/BinanceChain/plugins/tokens"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func newAddr() sdk.AccAddress {
+	_, addr := testutils.PrivAndAddr()
+	return addr
+}
+
+func checkFee(t *testing.T, fee common.Fee, expected int64) {
+	require.Equal(t,
+		common.NewFee(sdk.Coins{sdk.NewCoin(common.NativeTokenSymbol, expected)}, common.FeeForProposer),
+		fee)
+}
+
+func TestTransferFeeGen(t *testing.T) {
+	params := types.TransferFeeParam{
+		FixedFeeParams: types.FixedFeeParams{
+			MsgType: bank.MsgSend{}.Type(),
+			Fee:1e6,
+			FeeFor:common.FeeForProposer,
+		},
+		MultiTransferFee: 8e5,
+		LowerLimitAsMulti: 2,
+	}
+
+	calculator := tokens.TransferFeeCalculatorGen(&params)
+
+	// (1 addr, 1 coin) : (1 addr, 1 coin)
+	msg := bank.MsgSend{
+		Inputs: []bank.Input{bank.NewInput(newAddr(), sdk.Coins{ sdk.NewCoin(common.NativeTokenSymbol, 1000)})},
+		Outputs:[]bank.Output{bank.NewOutput(newAddr(), sdk.Coins{sdk.NewCoin(common.NativeTokenSymbol, 1000)})},
+	}
+	checkFee(t, calculator(msg), 1e6)
+
+	// (1 addr, 1 coin) : (2 addr, 1 coin)
+	msg = bank.MsgSend{
+		Inputs: []bank.Input{
+			bank.NewInput(newAddr(), sdk.Coins{ sdk.NewCoin(common.NativeTokenSymbol, 1000)}),
+		},
+		Outputs:[]bank.Output{
+			bank.NewOutput(newAddr(), sdk.Coins{sdk.NewCoin(common.NativeTokenSymbol, 500)}),
+			bank.NewOutput(newAddr(), sdk.Coins{sdk.NewCoin(common.NativeTokenSymbol, 500)}),
+		},
+	}
+	checkFee(t, calculator(msg), 16e5)
+
+	// (2 addr, 1 coin) : (1 addr, 1 coin)
+	msg = bank.MsgSend{
+		Inputs: []bank.Input{
+			bank.NewInput(newAddr(), sdk.Coins{ sdk.NewCoin(common.NativeTokenSymbol, 500)}),
+			bank.NewInput(newAddr(), sdk.Coins{ sdk.NewCoin(common.NativeTokenSymbol, 500)}),
+		},
+		Outputs:[]bank.Output{
+			bank.NewOutput(newAddr(), sdk.Coins{sdk.NewCoin(common.NativeTokenSymbol, 1000)}),
+		},
+	}
+	checkFee(t, calculator(msg), 16e5)
+
+	// (1 addr, 2 coin) : (1 addr, 2 coin)
+	msg = bank.MsgSend{
+		Inputs: []bank.Input{
+			bank.NewInput(newAddr(), sdk.Coins{ sdk.NewCoin(common.NativeTokenSymbol, 1000), sdk.NewCoin("XYZ", 1000)}),
+		},
+		Outputs:[]bank.Output{
+			bank.NewOutput(newAddr(), sdk.Coins{sdk.NewCoin(common.NativeTokenSymbol, 1000), sdk.NewCoin("XYZ", 1000)}),
+		},
+	}
+	checkFee(t, calculator(msg), 16e5)
+
+	// (1 addr, 2 coin) : (2 addr, 2 coin)
+	msg = bank.MsgSend{
+		Inputs: []bank.Input{
+			bank.NewInput(newAddr(), sdk.Coins{ sdk.NewCoin(common.NativeTokenSymbol, 1000), sdk.NewCoin("XYZ", 1000)}),
+		},
+		Outputs:[]bank.Output{
+			bank.NewOutput(newAddr(), sdk.Coins{sdk.NewCoin(common.NativeTokenSymbol, 1000), sdk.NewCoin("XYZ", 500)}),
+			bank.NewOutput(newAddr(), sdk.Coins{sdk.NewCoin("XYZ", 500)}),
+		},
+	}
+	checkFee(t, calculator(msg), 24e5)
+}
+
+


### PR DESCRIPTION
### Description

Transfer will collect fees by the number of the Outputs addresses. If the num meets the lower limit, some discount would be applied when calculating.

### Rationale

A multi-transfer tx costs much more than a 1:1 transfer tx both from cpu/memory side. So we consider redefine the calculator for transfer fee.

### Example

20% discount, lower limit is 2.
A 1:1 transfer tx will cost 1e6 BNB,
A 1:2 transfer tx will cost 16e5 BNB,
A 1:5 transfer tx will cost 4e6 BNB.

### Changes

Notable changes: 
* discount for multi-transfer tx fee
* 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

