### PR TITLE
[R4R] api-server would return 204 for non-exist account

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"sort"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -387,7 +388,7 @@ func (app *BinanceChain) ExportAppStateAndValidators() (appState json.RawMessage
 func (app *BinanceChain) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
 	defer func() {
 		if r := recover(); r != nil {
-			app.Logger.Error("internal error caused by query", "req", req)
+			app.Logger.Error("internal error caused by query", "req", req, "stack", debug.Stack())
 			res = sdk.ErrInternal("internal error").QueryResult()
 		}
 	}()
@@ -413,14 +414,22 @@ func (app *BinanceChain) AccountHandler(chainApp types.ChainApp, req abci.Reques
 	if len(path) == 2 {
 		addr := path[1]
 		if accAddress, err := sdk.AccAddressFromBech32(addr); err == nil {
-			acc := app.CheckState.AccountCache.GetAccount(accAddress)
-			bz, err := Codec.MarshalBinaryBare(acc)
-			if err != nil {
-				res = sdk.ErrInvalidAddress(addr).QueryResult()
+
+			if acc := app.CheckState.AccountCache.GetAccount(accAddress); acc != nil {
+				bz, err := Codec.MarshalBinaryBare(acc)
+				if err != nil {
+					res = sdk.ErrInvalidAddress(addr).QueryResult()
+				} else {
+					res = abci.ResponseQuery{
+						Code:  uint32(sdk.ABCICodeOK),
+						Value: bz,
+					}
+				}
 			} else {
+				// let api server return 204 No Content
 				res = abci.ResponseQuery{
 					Code:  uint32(sdk.ABCICodeOK),
-					Value: bz,
+					Value: make([]byte, 0, 0),
 				}
 			}
 		} else {


### PR DESCRIPTION
### Description

api-server would return 204 for non-exist account

### Rationale

previously return 504 and this if we query a valid but not exist account:
```
couldn't query account. Error: {"codespace":1,"code":1,"abci_code":65537,"message":"Error{internal error}"}
```

now we only return 204 No Content status code.

### Example

N/A

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

