### PR TITLE
[R4R] add breathe block config

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime/debug"
 	"sort"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -14,7 +15,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/gov"
 	"github.com/cosmos/cosmos-sdk/x/stake"
-
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	cmn "github.com/tendermint/tendermint/libs/common"
@@ -342,6 +342,14 @@ func (app *BinanceChain) DeliverTx(txBytes []byte) (res abci.ResponseDeliverTx) 
 	return res
 }
 
+func (app *BinanceChain) isBreatheBlock(height int64, lastBlockTime time.Time, blockTime time.Time) bool {
+	if app.baseConfig.BreatheBlockInterval > 0 {
+		return height%int64(app.baseConfig.BreatheBlockInterval) == 0
+	} else {
+		return !utils.SameDayInUTC(lastBlockTime, blockTime)
+	}
+}
+
 func (app *BinanceChain) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
 	// lastBlockTime would be 0 if this is the first block.
 	lastBlockTime := app.CheckState.Ctx.BlockHeader().Time
@@ -350,7 +358,7 @@ func (app *BinanceChain) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) a
 
 	var tradesToPublish []*pub.Trade
 
-	isBreatheBlock := !utils.SameDayInUTC(lastBlockTime, blockTime)
+	isBreatheBlock := app.isBreatheBlock(height, lastBlockTime, blockTime)
 	if !isBreatheBlock || height == 1 {
 		// only match in the normal block
 		app.Logger.Debug("normal block", "height", height)

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -5,10 +5,8 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/spf13/viper"
-
 	"github.com/cosmos/cosmos-sdk/server"
-
+	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/common"
 )
@@ -32,6 +30,8 @@ const appConfigTemplate = `# This is a TOML config file.
 # For more information, see https://github.com/toml-lang/toml
 
 [base]
+# Interval blocks of breathe block, if breatheBlockInterval is 0, breathe block will be created every day.
+breatheBlockInterval = {{ .BaseConfig.BreatheBlockInterval }}
 # Size of account cache
 accountCacheSize = {{ .BaseConfig.AccountCacheSize }}
 # Size of signature cache
@@ -218,16 +218,18 @@ func defaultLogConfig() *LogConfig {
 }
 
 type BaseConfig struct {
-	AccountCacheSize   int   `mapstructure:"accountCacheSize"`
-	SignatureCacheSize int   `mapstructure:"signatureCacheSize"`
-	StartMode          uint8 `mapstructure:"startMode"`
+	AccountCacheSize     int   `mapstructure:"accountCacheSize"`
+	SignatureCacheSize   int   `mapstructure:"signatureCacheSize"`
+	StartMode            uint8 `mapstructure:"startMode"`
+	BreatheBlockInterval int   `mapstructure:"breatheBlockInterval"`
 }
 
 func defaultBaseConfig() *BaseConfig {
 	return &BaseConfig{
-		AccountCacheSize:   30000,
-		SignatureCacheSize: 30000,
-		StartMode:          0,
+		AccountCacheSize:     30000,
+		SignatureCacheSize:   30000,
+		StartMode:            0,
+		BreatheBlockInterval: 0,
 	}
 }
 


### PR DESCRIPTION
### Description

sometimes, we want to test breathe block, it is not convenient now for it's related to time. So we add a config to create breathe block every n blocks(n is configurable). 

### Rationale


### Example


### Changes

Notable changes: 
* add breathe block intervals in app.toml


### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

