### PR TITLE
[R4R] add configuration for days count back of breathe block

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -195,16 +195,16 @@ func NewBinanceChain(logger log.Logger, db dbm.DB, traceStore io.Writer, baseApp
 
 func (app *BinanceChain) initDex() {
 	tradingPairMapper := dex.NewTradingPairMapper(app.Codec, common.PairStoreKey)
-	// TODO: make the concurrency configurable
 	app.DexKeeper = dex.NewOrderKeeper(common.DexStoreKey, app.AccountKeeper, tradingPairMapper,
-		app.RegisterCodespace(dex.DefaultCodespace), 2, app.Codec, app.publicationConfig.ShouldPublishAny())
+		app.RegisterCodespace(dex.DefaultCodespace), app.baseConfig.OrderKeeperConcurrency, app.Codec,
+		app.publicationConfig.ShouldPublishAny())
 	app.DexKeeper.SubscribeParamChange(app.ParamHub)
 	// do not proceed if we are in a unit test and `CheckState` is unset.
 	if app.CheckState == nil {
 		return
 	}
-	// count back to 7 days.
-	app.DexKeeper.InitOrderBook(app.CheckState.Ctx, 7,
+	// count back to days in config.
+	app.DexKeeper.InitOrderBook(app.CheckState.Ctx, app.baseConfig.BreatheBlockDaysCountBack,
 		baseapp.LoadBlockDB(), app.LastBlockHeight(), app.TxDecoder)
 }
 

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -38,6 +38,10 @@ accountCacheSize = {{ .BaseConfig.AccountCacheSize }}
 signatureCacheSize = {{ .BaseConfig.SignatureCacheSize }}
 # Running mode when start up, 0: Normal, 1: TransferOnly, 2: RecoverOnly
 startMode = {{ .BaseConfig.StartMode }}
+# Concurrency of OrderKeeper, should be power of 2
+orderKeeperConcurrency = {{ .BaseConfig.OrderKeeperConcurrency }}
+# Days count back for breathe block
+breatheBlockDaysCountBack = {{ .BaseConfig.BreatheBlockDaysCountBack }}
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
@@ -218,18 +222,22 @@ func defaultLogConfig() *LogConfig {
 }
 
 type BaseConfig struct {
-	AccountCacheSize     int   `mapstructure:"accountCacheSize"`
-	SignatureCacheSize   int   `mapstructure:"signatureCacheSize"`
-	StartMode            uint8 `mapstructure:"startMode"`
-	BreatheBlockInterval int   `mapstructure:"breatheBlockInterval"`
+	AccountCacheSize          int   `mapstructure:"accountCacheSize"`
+	SignatureCacheSize        int   `mapstructure:"signatureCacheSize"`
+	StartMode                 uint8 `mapstructure:"startMode"`
+	BreatheBlockInterval      int   `mapstructure:"breatheBlockInterval"`
+	OrderKeeperConcurrency    uint  `mapstructure:"orderKeeperConcurrency"`
+	BreatheBlockDaysCountBack int   `mapstructure:"breatheBlockDaysCountBack"`
 }
 
 func defaultBaseConfig() *BaseConfig {
 	return &BaseConfig{
-		AccountCacheSize:     30000,
-		SignatureCacheSize:   30000,
-		StartMode:            0,
-		BreatheBlockInterval: 0,
+		AccountCacheSize:          30000,
+		SignatureCacheSize:        30000,
+		StartMode:                 0,
+		BreatheBlockInterval:      0,
+		OrderKeeperConcurrency:    2,
+		BreatheBlockDaysCountBack: 7,
 	}
 }
 


### PR DESCRIPTION
### Description

Ref: #396 

### Rationale



### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add configuration for days count back of breathe block
* add configuration for concurrency of order keeper

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

