### PR TITLE
[R4R] #398 compress kafka message

### DIFF
--- a/app/pub/publisher_kafka.go
+++ b/app/pub/publisher_kafka.go
@@ -37,7 +37,7 @@ func (publisher *KafkaMarketDataPublisher) newProducers() (config *sarama.Config
 	config.Producer.RequiredAcks = sarama.WaitForAll
 	config.Producer.Return.Successes = true
 	config.Producer.Retry.Max = 20
-	config.Producer.Compression = sarama.CompressionNone
+	config.Producer.Compression = sarama.CompressionGZIP
 
 	// This MIGHT be kafka java client's equivalent max.in.flight.requests.per.connection
 	// to make sure messages won't out-of-order

--- a/networks/publisher/pressure_maker/local.toml
+++ b/networks/publisher/pressure_maker/local.toml
@@ -2,6 +2,7 @@ numOfTradesPerBlock = 2
 numOfBlocks = 5
 blockIntervalMs = 1000
 mode = 2
+prometheusAddr = "127.0.0.1:29660"
 
 ##### publication related configurations #####
 [publication]


### PR DESCRIPTION
### Description

compress kafka message and refine pressure maker to help test risk monitor

### Rationale

#398 

profiling between different compression parameters result:

100K orders message on expire | batch_size | outgoing_byte_rate | request_latency_in_ms
-- | -- | -- | --
CompressionNone | 15.59M | 2.1-2.8M | 592-7.222k
CompressionGZIP | 300K | 75K-120K | 35-391
CompressionSnappy | 1.14M | 187K-289K | 5-232
CompressionLZ4 | 513K | 111K-166K | 23-71
  |   |   |  
2K order message + 1K trade on typical summit | batch_size | outgoing_byte_rate | request_latency_in_ms
CompressionNone | 185K-720K | 851K-1.2M | 6-42
CompressionGZIP | 55K-203K | 368K | 4-10
CompressionSnappy | 87K-321K | 480K-578K | 7-22
CompressionLZ4 | 81K-298K | 490K | 5-27



### Example

N/A

### Changes

change compression publish config from none to gzip

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#398 

