### PR TITLE
api: disabled keys rest for security

### DIFF
--- a/plugins/api/routes.go
+++ b/plugins/api/routes.go
@@ -60,7 +60,11 @@ func (s *server) bindRoutes() *server {
 
 	// legacy plugin routes
 	// TODO: make these more like the above for simplicity.
-	keys.RegisterRoutes(r, true)
+	
+	// keys rest routes disabled for security. while the nodes with keys (validators) run in a secure ringfenced environment,
+	// disabling this is a precaution to protect third-party validators that might not have protected their networks adequately.
+	//keys.RegisterRoutes(r, true)
+	
 	rpc.RegisterRoutes(s.ctx, r)
 	tx.RegisterRoutes(s.ctx, r, s.cdc)
 	auth.RegisterRoutes(s.ctx, r, s.cdc, s.accStoreName)


### PR DESCRIPTION
### Description

Disabled [keys rest routes](https://github.com/binance-chain/bnc-cosmos-sdk/blob/50675b8015ab0dbac91a926a2df746174dbb33f7/client/keys/root.go#L34) for security.

### Rationale

This is for access to bnbcli's keystore, which won't be available in our secure environment (it is not exposed through the APs and validators are walled off) but it is a precautionary measure to protect validator node owners in the future.
