### PR TITLE
make bech32 prefix configurable

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -147,8 +147,8 @@ type AddressConfig struct {
 
 func defaultAddressConfig() *AddressConfig {
 	return &AddressConfig{
-		Bech32PrefixAccAddr:  "bnc",
-		Bech32PrefixAccPub:   "bncp",
+		Bech32PrefixAccAddr:  "bnb",
+		Bech32PrefixAccPub:   "bnbp",
 		Bech32PrefixValAddr:  "bva",
 		Bech32PrefixValPub:   "bvap",
 		Bech32PrefixConsAddr: "bca",

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/cosmos/cosmos-sdk/version"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/tendermint/tendermint/abci/server"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -116,6 +117,12 @@ func PersistentPreRunEFn(context *config.BinanceChainContext) func(*cobra.Comman
 		if err != nil {
 			return err
 		}
+
+		config := sdk.GetConfig()
+		config.SetBech32PrefixForAccount(context.Bech32PrefixAccAddr, context.Bech32PrefixAccPub)
+		config.SetBech32PrefixForValidator(context.Bech32PrefixValAddr, context.Bech32PrefixValPub)
+		config.SetBech32PrefixForConsensusNode(context.Bech32PrefixConsAddr, context.Bech32PrefixConsPub)
+		config.Seal()
 
 		// TODO: add config for logging to stdout for debug sake
 		logger := newLogger(context)

--- a/cmd/bnbchaind/init/init.go
+++ b/cmd/bnbchaind/init/init.go
@@ -34,13 +34,11 @@ import (
 )
 
 const (
-	flagWithTxs      = "with-txs"
 	flagOverwrite    = "overwrite"
 	flagClientHome   = "home-client"
 	flagOverwriteKey = "overwrite-key"
-	flagSkipGenesis  = "skip-genesis"
 	flagMoniker      = "moniker"
-	FlagGenTxs       = "gen-txs"
+	flagAccPrefix    = "acc-prefix"
 )
 
 type initConfig struct {
@@ -125,7 +123,10 @@ enabled, and the genesis file will not be generated.
 	cmd.Flags().BoolP(flagOverwrite, "o", false, "overwrite the genesis.json file")
 	cmd.Flags().String(client.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
 	cmd.Flags().String(flagMoniker, "", "overrides --name flag and set the validator's moniker to a different value; ignored if it runs without the --with-txs flag")
+	cmd.Flags().StringVar(&app.ServerContext.Bech32PrefixAccAddr, flagAccPrefix, "bnb", "bech32 prefix for AccAddress")
+	app.ServerContext.BindPFlag("addr.bech32PrefixAccAddr", cmd.Flags().Lookup(flagAccPrefix))
 	cmd.MarkFlagRequired(flagMoniker)
+
 	return cmd
 }
 

--- a/cmd/bnbchaind/init/testnet.go
+++ b/cmd/bnbchaind/init/testnet.go
@@ -77,6 +77,9 @@ Example:
 
 	cmd.Flags().String(client.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
 
+	cmd.Flags().StringVar(&app.ServerContext.Bech32PrefixAccAddr, flagAccPrefix, "bnb", "bech32 prefix for AccAddress")
+	app.ServerContext.BindPFlag("addr.bech32PrefixAccAddr", cmd.Flags().Lookup(flagAccPrefix))
+
 	return cmd
 }
 func initTestnet(config *cfg.Config, cdc *codec.Codec, appInit server.AppInit) error {

--- a/cmd/bnbchaind/main.go
+++ b/cmd/bnbchaind/main.go
@@ -13,12 +13,10 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	"github.com/cosmos/cosmos-sdk/server"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/BiJie/BinanceChain/app"
 	bnbInit "github.com/BiJie/BinanceChain/cmd/bnbchaind/init"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/server"
 )
 
 func newApp(logger log.Logger, db dbm.DB, storeTracer io.Writer) abci.Application {
@@ -33,12 +31,6 @@ func exportAppStateAndTMValidators(logger log.Logger, db dbm.DB, storeTracer io.
 func main() {
 	cdc := app.Codec
 	ctx := app.ServerContext
-
-	config := sdk.GetConfig()
-	config.SetBech32PrefixForAccount(ctx.Bech32PrefixAccAddr, ctx.Bech32PrefixAccPub)
-	config.SetBech32PrefixForValidator(ctx.Bech32PrefixValAddr, ctx.Bech32PrefixValPub)
-	config.SetBech32PrefixForConsensusNode(ctx.Bech32PrefixConsAddr, ctx.Bech32PrefixConsPub)
-	config.Seal()
 
 	rootCmd := &cobra.Command{
 		Use:               "bnbchaind",


### PR DESCRIPTION
### Description

as titled. we can pass a parameter in the `InitCmd` and `TestnetCmd` to config the bech32 prefix

### Rationale

In testnet, we use `tbnb` as the prefix of AccAddress while in mainnet we will `bnb` instead

### Example

bnbchaind init --moniker node0 --acc-prefix tbnb

### Changes

Notable changes: 
* default prefix to bnb
* 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

