### PR TITLE
[R4R]add light client node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,13 @@ ifeq ($(OS),Windows_NT)
 	go build $(BUILD_FLAGS) -o build/bnbchaind.exe ./cmd/bnbchaind
 	go build $(BUILD_FLAGS) -o build/bnbsentry.exe ./cmd/bnbsentry
 	go build $(BUILD_FLAGS) -o build/pressuremaker.exe ./cmd/pressuremaker.exe
+	go build $(BUILD_FLAGS) -o build/lightd.exe ./cmd/lightd
 else
 	go build $(BUILD_FLAGS) -o build/bnbcli ./cmd/bnbcli
 	go build $(BUILD_FLAGS) -o build/bnbchaind ./cmd/bnbchaind
 	go build $(BUILD_FLAGS) -o build/bnbsentry ./cmd/bnbsentry
 	go build $(BUILD_FLAGS) -o build/pressuremaker ./cmd/pressuremaker
+	go build $(BUILD_FLAGS) -o build/lightd ./cmd/lightd
 endif
 
 build-linux:

--- a/cmd/lightd/main.go
+++ b/cmd/lightd/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	cmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
+)
+
+func main() {
+	if err := cmd.LiteCmd.Execute(); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
### Description

Light client is a program that connect to a full node to help users access and interact with Binance chain in a secure and decentralized manner without having to sync the full blockchain.

### Rationale
serveral api is registered:
```
		// Subscribe/unsubscribe are reserved for websocket events.
		// We can just use the core tendermint impl, which uses the
		// EventSwitch we registered in NewWebsocketManager above
		"subscribe":   rpc.NewWSRPCFunc(core.Subscribe, "query"),
		"unsubscribe": rpc.NewWSRPCFunc(core.Unsubscribe, "query"),

		// info API
		"status":     rpc.NewRPCFunc(c.Status, ""),
		"blockchain": rpc.NewRPCFunc(c.BlockchainInfo, "minHeight,maxHeight"),
		"genesis":    rpc.NewRPCFunc(c.Genesis, ""),
		"block":      rpc.NewRPCFunc(c.Block, "height"),
		"commit":     rpc.NewRPCFunc(c.Commit, "height"),
		"tx":         rpc.NewRPCFunc(c.Tx, "hash,prove"),
		"validators": rpc.NewRPCFunc(c.Validators, ""),

		// broadcast API
		"broadcast_tx_commit": rpc.NewRPCFunc(c.BroadcastTxCommit, "tx"),
		"broadcast_tx_sync":   rpc.NewRPCFunc(c.BroadcastTxSync, "tx"),
		"broadcast_tx_async":  rpc.NewRPCFunc(c.BroadcastTxAsync, "tx"),

		// abci API
		"abci_query": rpc.NewRPCFunc(c.ABCIQuery, "path,data,prove"),
		"abci_info":  rpc.NewRPCFunc(c.ABCIInfo, ""),
	}
```


### Example
To start light client node:
```
./lightd --chain-id "chain-bnb"    --node tcp://a50b0eca509a411e9a951063f6065739-901254989.ap-northeast-1.elb.amazonaws.com:26657  > node.log  &  
```

To broad cast a transactions:
```
curl 'localhost:8888/broadcast_tx_commit?tx=0xe001f0625dee0a68ce6dc0430a147a65bf673541827df2b5d0251b7469f05fb71b32122e374136354246363733353431383237444632423544303235314237343639463035464237314233322d31373531331a0b4e4e422d3333385f424e42200428023080ac859908388084af5f4002126e0a26eb5ae98721025dee66010965349bb7d7635a3b49ad64782333d185a8115fb52e4f5659178b371240782b25de4b954db399e6628db33fac97d61f287faed7fb33443f509209f6a92c56b5928397bc7f068d908552b219b6adf9887f21e19948010abe69b9defd5cfc20d091022002'
```

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

