### PR TITLE
build both bnbcli and tbnbcli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 COMMIT_HASH := $(shell git rev-parse --short HEAD)
 BUILD_TAGS = netgo
 BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags "-X github.com/BiJie/BinanceChain/version.GitCommit=${COMMIT_HASH}"
+BUILD_TESTNET_FLAGS = ${BUILD_FLAGS} -ldflags "-X github.com/BiJie/BinanceChain/app.Bech32PrefixAccAddr=tbnb"
 
 all: get_vendor_deps format build
 
@@ -16,12 +17,14 @@ ci: get_vendor_deps build
 build:
 ifeq ($(OS),Windows_NT)
 	go build $(BUILD_FLAGS) -o build/bnbcli.exe ./cmd/bnbcli
+	go build $(BUILD_TESTNET_FLAGS) -o build/tbnbcli.exe ./cmd/bnbcli
 	go build $(BUILD_FLAGS) -o build/bnbchaind.exe ./cmd/bnbchaind
 	go build $(BUILD_FLAGS) -o build/bnbsentry.exe ./cmd/bnbsentry
-	go build $(BUILD_FLAGS) -o build/pressuremaker.exe ./cmd/pressuremaker.exe
+	go build $(BUILD_FLAGS) -o build/pressuremaker.exe ./cmd/pressuremaker
 	go build $(BUILD_FLAGS) -o build/lightd.exe ./cmd/lightd
 else
 	go build $(BUILD_FLAGS) -o build/bnbcli ./cmd/bnbcli
+	go build $(BUILD_TESTNET_FLAGS) -o build/tbnbcli ./cmd/bnbcli
 	go build $(BUILD_FLAGS) -o build/bnbchaind ./cmd/bnbchaind
 	go build $(BUILD_FLAGS) -o build/bnbsentry ./cmd/bnbsentry
 	go build $(BUILD_FLAGS) -o build/pressuremaker ./cmd/pressuremaker

--- a/app/app.go
+++ b/app/app.go
@@ -51,6 +51,7 @@ const (
 var (
 	DefaultCLIHome  = os.ExpandEnv("$HOME/.bnbcli")
 	DefaultNodeHome = os.ExpandEnv("$HOME/.bnbchaind")
+	Bech32PrefixAccAddr string
 )
 
 // BinanceChain implements ChainApp

--- a/cmd/bnbcli/main.go
+++ b/cmd/bnbcli/main.go
@@ -42,6 +42,9 @@ func main() {
 	ctx := app.ServerContext
 
 	config := sdk.GetConfig()
+	if app.Bech32PrefixAccAddr != "" {
+		ctx.Bech32PrefixAccAddr = app.Bech32PrefixAccAddr
+	}
 	config.SetBech32PrefixForAccount(ctx.Bech32PrefixAccAddr, ctx.Bech32PrefixAccPub)
 	config.SetBech32PrefixForValidator(ctx.Bech32PrefixValAddr, ctx.Bech32PrefixValPub)
 	config.SetBech32PrefixForConsensusNode(ctx.Bech32PrefixConsAddr, ctx.Bech32PrefixConsPub)


### PR DESCRIPTION
### Description

make build will generate two clients, bnbcli and tbnbcli. The tbnbcli uses the `tbnb` as the address prefix 

### Rationale

bnbcli does not depend on any config files. It's the easiest way to build two different cli for testnet and mainnet.

### Example

### Changes

Notable changes: 
* 
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

