### PR TITLE
fees api: remove amino type tags from json

### DIFF
--- a/plugins/param/client/cli/command.go
+++ b/plugins/param/client/cli/command.go
@@ -15,7 +15,9 @@ func AddCommands(cmd *cobra.Command, cdc *wire.Codec) {
 	}
 	dexCmd.AddCommand(
 		client.PostCommands(
-			GetCmdSubmitFeeChangeProposal(cdc))...)
-
+			SubmitFeeChangeProposalCmd(cdc))...)
+	dexCmd.AddCommand(
+		client.GetCommands(
+			ShowFeeParamsCmd(cdc))...)
 	cmd.AddCommand(dexCmd)
 }

--- a/plugins/param/types/types.go
+++ b/plugins/param/types/types.go
@@ -12,6 +12,9 @@ const (
 	OperateFeeType  = "operate"
 	TransferFeeType = "transfer"
 	DexFeeType      = "dex"
+
+	JSONFORMAT  = "json"
+	AMINOFORMAT = "amino"
 )
 
 type LastProposalID struct {
@@ -35,12 +38,14 @@ type FeeParam interface {
 }
 
 var _ FeeParam = MsgFeeParams(nil)
+
 type MsgFeeParams interface {
 	FeeParam
 	GetMsgType() string
 }
 
 var _ MsgFeeParams = (*FixedFeeParams)(nil)
+
 type FixedFeeParams struct {
 	MsgType string                  `json:"msg_type"`
 	Fee     int64                   `json:"fee"`
@@ -67,6 +72,7 @@ func (p *FixedFeeParams) Check() error {
 }
 
 var _ MsgFeeParams = (*TransferFeeParam)(nil)
+
 type TransferFeeParam struct {
 	FixedFeeParams
 	MultiTransferFee  int64 `json:"multi_transfer_fee"`


### PR DESCRIPTION
The `/api/v1/fees` response currently contains some amino type information that we don't need:

```json
[
   {
      "type" : "params/FixedFeeParams",
      "value" : {
         "fee_for" : 1,
         "msg_type" : "submit_proposal",
         "fee" : "1000000000"
      }
   },
```

After this change, this API response will be consistent with other API responses:

```json
[
   {
      "fee_for" : 1,
      "fee" : 1000000000,
      "msg_type" : "submit_proposal"
   },
```
