### PR TITLE
dex api: no markets returns empty array

### DIFF
--- a/plugins/dex/client/rest/getpairs.go
+++ b/plugins/dex/client/rest/getpairs.go
@@ -84,6 +84,10 @@ func GetPairsReqHandler(cdc *wire.Codec, ctx context.CLIContext) http.HandlerFun
 			throw(w, http.StatusInternalServerError, err)
 			return
 		}
+		if pairs == nil {
+			// assume this was an offset parse issue
+			pairs = make([]types.TradingPair, 0)
+		}
 
 		output, err := cdc.MarshalJSON(pairs)
 		if err != nil {


### PR DESCRIPTION
### Description

Right now we get a 500 error with the response `unable to parse offset` when there are no markets, as it was assumed that this is a rare case that would _never_ happen. 

However, we've seen this for 2 days on the testnet now during upgrades.

So... this PR makes that call return a success and `[]` when there are no markets

### Rationale

500s suck

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)
