### PR TITLE
fix account api in api-server

### DIFF
--- a/plugins/api/handlers/account.go
+++ b/plugins/api/handlers/account.go
@@ -81,16 +81,16 @@ func AccountReqHandler(cdc *wire.Codec, ctx context.CLIContext) http.HandlerFunc
 }
 
 func toTokenBalances(acc *types.AppAccount) []tkclient.TokenBalance {
-	balances := make(map[string]tkclient.TokenBalance)
+	balances := make(map[string]*tkclient.TokenBalance)
 	for _, coin := range acc.GetCoins() {
-		balances[coin.Denom] = tkclient.TokenBalance{Symbol: coin.Denom, Free: utils.Fixed8(coin.Amount)}
+		balances[coin.Denom] = &tkclient.TokenBalance{Symbol: coin.Denom, Free: utils.Fixed8(coin.Amount)}
 	}
 
 	for _, coin := range acc.GetLockedCoins() {
 		if balance, ok := balances[coin.Denom]; ok {
 			balance.Locked = utils.Fixed8(coin.Amount)
 		} else {
-			balances[coin.Denom] = tkclient.TokenBalance{Symbol: coin.Denom, Locked: utils.Fixed8(coin.Amount)}
+			balances[coin.Denom] = &tkclient.TokenBalance{Symbol: coin.Denom, Locked: utils.Fixed8(coin.Amount)}
 		}
 	}
 
@@ -98,14 +98,14 @@ func toTokenBalances(acc *types.AppAccount) []tkclient.TokenBalance {
 		if balance, ok := balances[coin.Denom]; ok {
 			balance.Frozen = utils.Fixed8(coin.Amount)
 		} else {
-			balances[coin.Denom] = tkclient.TokenBalance{Symbol: coin.Denom, Frozen: utils.Fixed8(coin.Amount)}
+			balances[coin.Denom] = &tkclient.TokenBalance{Symbol: coin.Denom, Frozen: utils.Fixed8(coin.Amount)}
 		}
 	}
 
 	res := make([]tkclient.TokenBalance, len(balances), len(balances))
 	i := 0
 	for _, balance := range balances {
-		res[i] = balance
+		res[i] = *balance
 		i++
 	}
 	return res

--- a/plugins/api/handlers/account_test.go
+++ b/plugins/api/handlers/account_test.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+
+	"github.com/binance-chain/node/common/testutils"
+	"github.com/binance-chain/node/common/types"
+	"github.com/binance-chain/node/plugins/tokens/client/rest"
+)
+
+func TestAccount_ToBalances(t *testing.T) {
+	privKey, addr := testutils.PrivAndAddr()
+	acc := &types.AppAccount{
+		BaseAccount: auth.BaseAccount{
+			Address: addr,
+			Coins: nil,
+			PubKey: privKey.PubKey(),
+			AccountNumber: 1,
+			Sequence :1,
+		},
+	}
+	balances := toTokenBalances(acc)
+	require.Equal(t, []rest.TokenBalance{}, balances)
+	acc.SetCoins(sdk.Coins{sdk.NewCoin(types.NativeTokenSymbol, 10e8)})
+	balances = toTokenBalances(acc)
+	require.Equal(t, 1, len(balances))
+	require.Equal(t, int64(10e8), balances[0].Free.ToInt64())
+	require.Equal(t, int64(0), balances[0].Locked.ToInt64())
+	require.Equal(t, int64(0), balances[0].Frozen.ToInt64())
+
+	acc.SetCoins(sdk.Coins{})
+	acc.SetLockedCoins(sdk.Coins{sdk.NewCoin(types.NativeTokenSymbol, 1e8)})
+	balances = toTokenBalances(acc)
+	require.Equal(t, 1, len(balances))
+	require.Equal(t, int64(0), balances[0].Free.ToInt64())
+	require.Equal(t, int64(1e8), balances[0].Locked.ToInt64())
+	require.Equal(t, int64(0), balances[0].Frozen.ToInt64())
+
+	acc.SetFrozenCoins(sdk.Coins{sdk.NewCoin(types.NativeTokenSymbol, 1e8)})
+	balances = toTokenBalances(acc)
+	require.Equal(t, 1, len(balances))
+	require.Equal(t, int64(0), balances[0].Free.ToInt64())
+	require.Equal(t, int64(1e8), balances[0].Locked.ToInt64())
+	require.Equal(t, int64(1e8), balances[0].Frozen.ToInt64())
+}


### PR DESCRIPTION
### Description

fix the bug that the account api always return 0 locked and 0 frozen balances.

### Rationale
### Example

### Changes

Notable changes: 
* 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

