### PR TITLE
bump amino/cosmos-sdk/tendermint version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -56,7 +56,7 @@
   revision = "d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4"
 
 [[projects]]
-  digest = "1:6b5dfeec07f66e471ad2dd5b7a36854767b32e3bdc05deab3d044a7097b1a181"
+  digest = "1:8cfd1b75fb97d34d136819155bff993300493f8efb7aa840bbd7ead14deec245"
   name = "github.com/cosmos/cosmos-sdk"
   packages = [
     "baseapp",
@@ -92,8 +92,6 @@
     "x/gov/client",
     "x/gov/client/cli",
     "x/gov/tags",
-    "x/ibc",
-    "x/ibc/client/cli",
     "x/mock",
     "x/params",
     "x/params/subspace",
@@ -105,9 +103,9 @@
     "x/stake/types",
   ]
   pruneopts = "UT"
-  revision = "7685e982ed13470a2d78f8291cf04743bb008395"
+  revision = "e30be76717e63d73561dbfa858cbab4a432e02f8"
   source = "github.com/binance-chain/bnc-cosmos-sdk"
-  version = "v0.25.0-br3"
+  version = "v0.25.0-binance.4"
 
 [[projects]]
   digest = "1:e8a3550c8786316675ff54ad6f09d265d129c9d986919af7f541afba50d87ce2"
@@ -577,12 +575,13 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:ad9c4c1a4e7875330b1f62906f2830f043a23edb5db997e3a5ac5d3e6eadf80a"
+  digest = "1:a2318b27cf0fb75eb19db3a31039accaae12ab39786b609ed9d2f79ecbf4367d"
   name = "github.com/tendermint/go-amino"
   packages = ["."]
   pruneopts = "UT"
-  revision = "dc14acf9ef15f85828bfbc561ed9dd9d2a284885"
-  version = "v0.14.1"
+  revision = "b3a81203066cc46107dcf5e2ae6d78260ccc7c5a"
+  source = "github.com/binance-chain/bnc-go-amino"
+  version = "v0.14.1-binance.1"
 
 [[projects]]
   digest = "1:e1cc8dd891e64aab63b0c09f2f12456cbe2cd9cbd9d96dfae3281245f05c2428"
@@ -593,7 +592,7 @@
   version = "v0.12.0"
 
 [[projects]]
-  digest = "1:171062a60aed2126606047d1eb1db7bc3211f8558429c4933826a7b563f153bf"
+  digest = "1:12dacb81fc2047319e3f8c5ce012e3a71265893d0353a9e4ec14323919a06627"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
@@ -659,9 +658,9 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "e92d05af5852aacc17c0c3ae32c443753e032fd4"
+  revision = "b388137620746753c78c2f2ad42cdd47b9c6dceb"
   source = "github.com/binance-chain/bnc-tendermint"
-  version = "v0.29.1-br0"
+  version = "v0.29.1-binance.1"
 
 [[projects]]
   digest = "1:7886f86064faff6f8d08a3eb0e8c773648ff5a2e27730831e2bfbf07467f6666"
@@ -835,7 +834,6 @@
     "github.com/cosmos/cosmos-sdk/x/bank/client/rest",
     "github.com/cosmos/cosmos-sdk/x/gov",
     "github.com/cosmos/cosmos-sdk/x/gov/client/cli",
-    "github.com/cosmos/cosmos-sdk/x/ibc/client/cli",
     "github.com/cosmos/cosmos-sdk/x/mock",
     "github.com/cosmos/cosmos-sdk/x/params",
     "github.com/cosmos/cosmos-sdk/x/stake",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,8 @@
 
 [[override]]
   name = "github.com/tendermint/go-amino"
-  version = "=v0.14.1"
+  source = "github.com/binance-chain/bnc-go-amino"
+  version = "=v0.14.1-binance.1"
 
 [[override]]
   name = "github.com/tendermint/iavl"
@@ -35,12 +36,12 @@
 [[override]]
   name = "github.com/tendermint/tendermint"
   source = "github.com/binance-chain/bnc-tendermint"
-  version = "=v0.29.1-br0"
+  version = "=v0.29.1-binance.1"
 
 [[constraint]]
   name = "github.com/cosmos/cosmos-sdk"
   source = "github.com/binance-chain/bnc-cosmos-sdk"
-  version = "=v0.25.0-br3"
+  version = "=v0.25.0-binance.4"
 
 [[constraint]]
   name = "github.com/pkg/errors"

--- a/app/app.go
+++ b/app/app.go
@@ -137,7 +137,7 @@ func NewBinanceChain(logger log.Logger, db dbm.DB, traceStore io.Writer, baseApp
 	// legacy bank route (others moved to plugin init funcs)
 	app.Router().
 		AddRoute("bank", bank.NewHandler(app.CoinKeeper)).
-		AddRoute("stake", stake.NewHandler(app.stakeKeeper)).
+		AddRoute("stake", stake.NewHandler(app.stakeKeeper, app.govKeeper)).
 		AddRoute("gov", gov.NewHandler(app.govKeeper))
 
 	app.QueryRouter().AddRoute("gov", gov.NewQuerier(app.govKeeper))

--- a/app/app_pub_test.go
+++ b/app/app_pub_test.go
@@ -36,13 +36,15 @@ const (
 
 func prepareGenTx(cdc *codec.Codec, chainId string,
 	valOperAddr sdk.ValAddress, valPubKey crypto.PubKey) json.RawMessage {
-	msg := stake.NewMsgCreateValidator(
-		valOperAddr,
-		valPubKey,
-		DefaultSelfDelegationToken,
-		stake.NewDescription("pub", "", "", ""),
-		stake.NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
-	)
+	msg := stake.MsgCreateValidatorProposal{
+		MsgCreateValidator: stake.NewMsgCreateValidator(
+			valOperAddr,
+			valPubKey,
+			DefaultSelfDelegationToken,
+			stake.NewDescription("pub", "", "", ""),
+			stake.NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
+		),
+	}
 	tx := auth.NewStdTx([]sdk.Msg{msg}, nil, "", 0, nil)
 	txBytes, err := wire.MarshalJSONIndent(cdc, tx)
 	if err != nil {

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -99,7 +99,7 @@ func BinanceAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (appState 
 				"must provide genesis StdTx with exactly 1 CreateValidator message")
 			return
 		}
-		if msg, ok := msgs[0].(stake.MsgCreateValidator); !ok {
+		if msg, ok := msgs[0].(stake.MsgCreateValidatorProposal); !ok {
 			err = fmt.Errorf(
 				"genesis transaction %v does not contain a MsgCreateValidator", i)
 			return

--- a/cmd/bnbchaind/init/init.go
+++ b/cmd/bnbchaind/init/init.go
@@ -132,13 +132,15 @@ enabled, and the genesis file will not be generated.
 
 func prepareCreateValidatorTx(cdc *codec.Codec, chainId, name, memo string,
 	valOperAddr sdk.ValAddress, valPubKey crypto.PubKey) json.RawMessage {
-	msg := stake.NewMsgCreateValidator(
-		valOperAddr,
-		valPubKey,
-		app.DefaultSelfDelegationToken,
-		stake.NewDescription(name, "", "", ""),
-		stake.NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
-	)
+	msg := stake.MsgCreateValidatorProposal{
+		MsgCreateValidator:stake.NewMsgCreateValidator(
+			valOperAddr,
+			valPubKey,
+			app.DefaultSelfDelegationToken,
+			stake.NewDescription(name, "", "", ""),
+			stake.NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
+		),
+	}
 	tx := auth.NewStdTx([]sdk.Msg{msg}, []auth.StdSignature{}, memo, auth.DefaultSource, nil)
 	txBldr := authtx.NewTxBuilderFromCLI().WithChainID(chainId).WithMemo(memo)
 	signedTx, err := txBldr.SignStdTx(name, app.DefaultKeyPass, tx, false)


### PR DESCRIPTION
### Description

amino -> 0.14.1-binance.1
cosmos-sdk -> 0.25.0-binance.4
tendermint -> 0.29.1-binance.1

### Rationale

prepare testnet

### Example


### Changes

Notable changes: 
* 
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

