### PR TITLE
[R4R] #447 replay transactions need take transaction result into consideration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -229,7 +229,7 @@ func (app *BinanceChain) initDex() {
 	}
 	// count back to days in config.
 	app.DexKeeper.InitOrderBook(app.CheckState.Ctx, app.baseConfig.BreatheBlockDaysCountBack,
-		baseapp.LoadBlockDB(), app.LastBlockHeight(), app.TxDecoder)
+		baseapp.LoadBlockDB(), baseapp.LoadTxDB(), app.LastBlockHeight(), app.TxDecoder)
 }
 
 func (app *BinanceChain) initPlugins() {

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -156,7 +156,7 @@ func (app *BinanceChain) processErrAbciResponseForPub(txBytes []byte) {
 			switch msg := msgs[0].(type) {
 			case order.NewOrderMsg:
 				app.Logger.Error("failed to process NewOrderMsg", "oid", msg.Id)
-				keeper.OrderInfosForPub[msg.Id] = &order.OrderInfo{NewOrderMsg: msg, TxHash: txHash}
+				app.DexKeeper.OrderInfosForPub[msg.Id] = &order.OrderInfo{NewOrderMsg: msg, TxHash: txHash}
 				app.DexKeeper.OrderChanges = append(app.DexKeeper.OrderChanges, order.OrderChange{msg.Id, order.FailedBlocking})
 			case order.CancelOrderMsg:
 				app.Logger.Error("failed to process CancelOrderMsg", "oid", msg.RefId)

--- a/plugins/dex/order/keeper_test.go
+++ b/plugins/dex/order/keeper_test.go
@@ -433,7 +433,7 @@ func TestKeeper_ReplayOrdersFromBlock(t *testing.T) {
 	keeper.PairMapper.AddTradingPair(ctx, tradingPair)
 	keeper.AddEngine(tradingPair)
 
-	err := keeper.ReplayOrdersFromBlock(ctx, blockStore, int64(3), int64(1), auth.DefaultTxDecoder(cdc))
+	err := keeper.ReplayOrdersFromBlock(ctx, blockStore, db.NewMemDB(), int64(3), int64(1), auth.DefaultTxDecoder(cdc))
 	assert.Nil(err)
 	buys, sells := keeper.engines["XYZ-000_BNB"].Book.GetAllLevels()
 	assert.Equal(2, len(buys))
@@ -460,7 +460,7 @@ func TestKeeper_InitOrderBookDay1(t *testing.T) {
 	keeper2 := MakeKeeper(cdc)
 	ctx = sdk.NewContext(cms, abci.Header{}, sdk.RunTxModeCheck, logger)
 	keeper2.PairMapper.AddTradingPair(ctx, tradingPair)
-	keeper2.InitOrderBook(ctx, 7, memDB, 3, auth.DefaultTxDecoder(cdc))
+	keeper2.InitOrderBook(ctx, 7, memDB, db.NewMemDB(), 3, auth.DefaultTxDecoder(cdc))
 	buys, sells := keeper2.engines["XYZ-000_BNB"].Book.GetAllLevels()
 	assert.Equal(2, len(buys))
 	assert.Equal(1, len(sells))


### PR DESCRIPTION
### Description

replay transactions need take transaction result into consideration
cosmos: https://github.com/binance-chain/bnc-cosmos-sdk/pull/67

### Rationale

#447 

### Example
Will have an Info log for invalid transaciton.
```
I[2019-02-17|18:13:57.116] does not recover invalid tx                  module=dex txHash=2F9EFB485DF4568B03E9B7257C1790F94D1062E2770196FA732E8B7DE8DC31E8 err="{\"codespace\":1,\"code\":3,\"abci_code\":65539,\"message\":\"Invalid sequence. Got 11, expected 10\"}"
```

If later on a valid transaction (with same hash) added to later block, we can still recover to correct state.

### Changes

load tx_index store on node recover

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#447 
