### PR TITLE
[R4R]fix light client abci_query failed

### DIFF
--- a/cmd/lightd/main.go
+++ b/cmd/lightd/main.go
@@ -1,11 +1,95 @@
 package main
 
 import (
-	cmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tendermint/iavl"
+	"github.com/tendermint/tendermint/cmd/tendermint/commands"
+	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/lite/proxy"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
+
+	"github.com/cosmos/cosmos-sdk/store"
 )
 
+var logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout))
+
 func main() {
-	if err := cmd.LiteCmd.Execute(); err != nil {
+	if err := LiteCmd.Execute(); err != nil {
 		panic(err)
 	}
+}
+
+// LiteCmd represents the base command when called without any subcommands
+var LiteCmd = &cobra.Command{
+	Use:   "lite",
+	Short: "Run lite-client proxy server, verifying binance rpc",
+	Long: `This node will run a secure proxy to a binance rpc server.
+
+All calls that can be tracked back to a block header by a proof
+will be verified before passing them back to the caller. Other that
+that it will present the same interface as a full binance node,
+just with added trust and running locally.`,
+	RunE:         runProxy,
+	SilenceUsage: true,
+}
+
+var (
+	listenAddr         string
+	nodeAddr           string
+	chainID            string
+	home               string
+	maxOpenConnections int
+	cacheSize          int
+)
+
+func init() {
+	LiteCmd.Flags().StringVar(&listenAddr, "laddr", "tcp://localhost:27147", "Serve the proxy on the given address")
+	LiteCmd.Flags().StringVar(&nodeAddr, "node", "tcp://localhost:27147", "Connect to a binance node at this address")
+	LiteCmd.Flags().StringVar(&chainID, "chain-id", "bnbchain", "Specify the binance chain ID")
+	LiteCmd.Flags().StringVar(&home, "home-dir", ".binance-lite", "Specify the home directory")
+	LiteCmd.Flags().IntVar(&maxOpenConnections, "max-open-connections", 900, "Maximum number of simultaneous connections (including WebSocket).")
+	LiteCmd.Flags().IntVar(&cacheSize, "cache-size", 10, "Specify the memory trust store cache size")
+}
+
+func runProxy(cmd *cobra.Command, args []string) error {
+	nodeAddr, err := commands.EnsureAddrHasSchemeOrDefaultToTCP(nodeAddr)
+	if err != nil {
+		return err
+	}
+	listenAddr, err := commands.EnsureAddrHasSchemeOrDefaultToTCP(listenAddr)
+	if err != nil {
+		return err
+	}
+
+	// First, connect a client
+	logger.Info("Connecting to source HTTP client...")
+	node := rpcclient.NewHTTP(nodeAddr, "/websocket")
+
+	logger.Info("Constructing Verifier...")
+	cert, err := proxy.NewVerifier(chainID, home, node, logger, cacheSize)
+	if err != nil {
+		return cmn.ErrorWrap(err, "constructing Verifier")
+	}
+	cert.SetLogger(logger)
+	sc := proxy.SecureClient(node, cert)
+	sc.RegisterOpDecoder(store.ProofOpMultiStore, store.MultiStoreProofOpDecoder)
+	sc.RegisterOpDecoder(
+		iavl.ProofOpIAVLValue,
+		iavl.IAVLValueOpDecoder,
+	)
+
+	logger.Info("Starting proxy...")
+	err = proxy.StartProxy(sc, listenAddr, logger, maxOpenConnections)
+	if err != nil {
+		return cmn.ErrorWrap(err, "starting proxy")
+	}
+
+	cmn.TrapSignal(func() {
+		// TODO: close up shop
+	})
+	return nil
 }


### PR DESCRIPTION
### Description
We get an error when query account , this pr is going to fix this.
```
time ./bnbcli account tbnb1mc0fnh394zv7ly4ry9fpdc2yeeuvy35stljrav --chain-id Binance-Chain-Nile --node tcp://localhost:26657 --trace
ERROR: Response error: RPC error -32603 - Internal error: runtime error: index out of range
github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/rpc/lib/client.unmarshalResponseBytes
  /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/rpc/lib/client/http_client.go:193
github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/rpc/lib/client.(*JSONRPCClient).Call ....
```
### Rationale
The main change is in pr https://github.com/binance-chain/bnc-tendermint/pull/46
this pr foucus on:
1. RegisterOpDecoder which is not in tendermint.
2. change `tendermint ` literal into `binance`

### Example
```
./tbnbcli tx 382915C3610861D8BFF7CF854EE4911ABFC13166CDC783C9792FDD8B0A501BD1  --node tcp://localhost:27147  --chain-id Binance-Chain-Nile  
{"hash":"382915C3610861D8BFF7CF854EE4911ABFC13166CDC783C9792FDD8B0A501BD1","height":"1666931","tx":{"type":"auth/StdTx","value":{"msg":[{"type":"cosmos-sdk/Send","value":{"inputs":[{"address":"tbnb138u9djee6fwphhd2a3628q2h0j5w97yx48zqex","coins":[{"denom":"BNB","amount":"20000000000"}]}],"outputs":[{"address":"tbnb17087epdkyuahyvfs4xeemxz7x856jmr9lv25ej","coins":[{"denom":"BNB","amount":"20000000000"}]}]}}],"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"A4q95eEn4cR1bbxVRqYc8pbLvKYyaMxjzaTSmkTJQUr6"},"signature":"Yl5gp4iXSYnNsndE75N+Da9XDT0em8Vvg8JJnFgarGoKAM2zc83p8YyMwA+dT1AQkLf8sTa5sBXcCy05g69VJw==","account_number":"71","sequence":"853"}],"memo":"","source":"0","data":null}},"result":{"log":"Msg 0: ","tags":[{"key":"c2VuZGVy","value":"dGJuYjEzOHU5ZGplZTZmd3BoaGQyYTM2MjhxMmgwajV3OTd5eDQ4enFleA=="},{"key":"cmVjaXBpZW50","value":"dGJuYjE3MDg3ZXBka3l1YWh5dmZzNHhlZW14ejd4ODU2am1yOWx2MjVlag=="},{"key":"YWN0aW9u","value":"c2VuZA=="}]}}
```

```
./tbnbcli account tbnb1mc0fnh394zv7ly4ry9fpdc2yeeuvy35stljrav  --node tcp://localhost:27147  --trace  --chain-id Binance-Chain-Nile
{"type":"bnbchain/Account","value":{"base":{"address":"tbnb1mc0fnh394zv7ly4ry9fpdc2yeeuvy35stljrav","coins":[{"denom":"BNB","amount":"139999170000"},{"denom":"BTC.B-9CE","amount":"515472"},{"denom":"KOGE-76B","amount":"10000000000000"},{"denom":"TBTS-893","amount":"100000000000000000"}],"public_key":{"type":"tendermint/PubKeySecp256k1","value":"AqrrQcGo6vkeyGWSp7C0JrxIakeaxPoPvrTrEjt+FAEF"},"account_number":"577","sequence":"9"},"name":"","frozen":null,"locked":[{"denom":"BNB","amount":"100000000"}]}}
```

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

