### PR TITLE
[R4R] change makefile to support cleveldb backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ TENDER_RELEASE := $(shell grep "github.com/binance-chain/bnc-tendermint" Gopkg.t
 
 BUILD_TAGS = netgo
 BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags "-X github.com/binance-chain/node/version.GitCommit=${COMMIT_HASH} -X github.com/binance-chain/node/version.CosmosRelease=${COSMOS_RELEASE} -X github.com/binance-chain/node/version.TendermintRelease=${TENDER_RELEASE}"
+# Without -lstdc++ on CentOS we will encounter link error, solution comes from: https://stackoverflow.com/a/29285011/1147187
+BUILD_CGOFLAGS = CGO_ENABLED=1 CGO_LDFLAGS="-lstdc++"
+BUILD_CFLAGS = ${BUILD_FLAGS} -tags "gcc"
 BUILD_TESTNET_FLAGS = ${BUILD_FLAGS} -ldflags "-X github.com/binance-chain/node/app.Bech32PrefixAccAddr=tbnb"
 
 all: get_vendor_deps format build
@@ -35,14 +38,42 @@ else
 	go build $(BUILD_FLAGS) -o build/lightd ./cmd/lightd
 endif
 
+build_c:
+ifeq ($(OS),Windows_NT)
+	go build $(BUILD_FLAGS) -o build/bnbcli.exe ./cmd/bnbcli
+	go build $(BUILD_TESTNET_FLAGS) -o build/tbnbcli.exe ./cmd/bnbcli
+	$(BUILD_CGOFLAGS) go build $(BUILD_CFLAGS) -o build/bnbchaind.exe ./cmd/bnbchaind
+	$(BUILD_CGOFLAGS) go build $(BUILD_CFLAGS) -o build/bnbsentry.exe ./cmd/bnbsentry
+	go build $(BUILD_FLAGS) -o build/pressuremaker.exe ./cmd/pressuremaker
+	$(BUILD_CGOFLAGS) go build $(BUILD_CFLAGS) -o build/lightd.exe ./cmd/lightd
+else
+	go build $(BUILD_FLAGS) -o build/bnbcli ./cmd/bnbcli
+	go build $(BUILD_TESTNET_FLAGS) -o build/tbnbcli ./cmd/bnbcli
+	$(BUILD_CGOFLAGS) go build $(BUILD_CFLAGS) -o build/bnbchaind ./cmd/bnbchaind
+	$(BUILD_CGOFLAGS) go build $(BUILD_CFLAGS) -o build/bnbsentry ./cmd/bnbsentry
+	go build $(BUILD_FLAGS) -o build/pressuremaker ./cmd/pressuremaker
+	$(BUILD_CGOFLAGS) go build $(BUILD_CFLAGS) -o build/lightd ./cmd/lightd
+endif
+
 build-linux:
 	LEDGER_ENABLED=false GOOS=linux GOARCH=amd64 $(MAKE) build
+
+build-linux_c:
+	LEDGER_ENABLED=false GOOS=linux GOARCH=amd64 $(MAKE) build_c
 
 build-alpine:
 	LEDGER_ENABLED=false GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(MAKE) build
 
+build-alpine_c:
+    LEDGER_ENABLED=false GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(MAKE) build_c
+
 install:
 	go install $(BUILD_FLAGS) ./cmd/bnbchaind
+	go install $(BUILD_FLAGS) ./cmd/bnbcli
+	go install $(BUILD_FLAGS) ./cmd/bnbsentry
+
+install_c:
+	$(BUILD_CGOFLAGS) go install $(BUILD_CFLAGS) ./cmd/bnbchaind
 	go install $(BUILD_FLAGS) ./cmd/bnbcli
 	go install $(BUILD_FLAGS) ./cmd/bnbsentry
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ $ make get_vendor_deps
 $ make install
 ```
 
+> If you want run bnbchaind with cleveldb as backend, please ensure leveldb is installed: https://github.com/google/leveldb#building, 
+> and change `make install` to `make install_c`
+> For mac, `brew install leveldb` would help. For linux, you can build from source
+
+
 **Windows**
 
 If you are working on windows, `GOPATH` and `PATH` should already be set when you install golang.


### PR DESCRIPTION
### Description

add build task support build cleveldb backend bnbchaind

discussion with tendermint raised here: https://github.com/tendermint/tendermint/issues/1162#issuecomment-468111422

### Rationale


### Example

In config.toml
`db_backend = "cleveldb"`

To build in GoLand, please set build settings as follow (you can open `c_level_db.go` to see whether it is included in build by GoLand:

![image](https://user-images.githubusercontent.com/1442921/53563927-7e314b80-3b90-11e9-8907-903b75a46f19.png)

### Changes


### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

