### PR TITLE
limit the length of token symbol >= 3

### DIFF
--- a/common/types/token.go
+++ b/common/types/token.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	TokenSymbolMaxLen          = 8
+	TokenSymbolMinLen		   = 3
 	TokenSymbolTxHashSuffixLen = 3 // probably enough. if it collides (unlikely) the issuer can just use another tx.
 	TokenSymbolDotBSuffix      = ".B"
 
@@ -81,8 +82,8 @@ func ValidateIssueMsgTokenSymbol(symbol string) error {
 	}
 
 	// check len without .B suffix
-	if len(symbol) > TokenSymbolMaxLen {
-		return errors.New("token symbol is too long")
+	if symbolLen := len(symbol); symbolLen > TokenSymbolMaxLen || symbolLen < TokenSymbolMinLen {
+		return errors.New("length of token symbol is limited to 3~8")
 	}
 
 	if !utils.IsAlphaNum(symbol) {
@@ -121,6 +122,9 @@ func ValidateMapperTokenSymbol(symbol string) error {
 	}
 
 	// check len without .B suffix
+	if len(symbolPart) < TokenSymbolMinLen {
+		return fmt.Errorf("token symbol part is too short, got %d chars", len(symbolPart))
+	}
 	if len(symbolPart) > TokenSymbolMaxLen {
 		return fmt.Errorf("token symbol part is too long, got %d chars", len(symbolPart))
 	}

--- a/common/types/token_test.go
+++ b/common/types/token_test.go
@@ -19,6 +19,8 @@ var issueMsgSymbolTestCases = []struct {
 	{"XYZ45678", true},
 	{"XYZ45678.B", true}, // still ok - .B suffix extends max len by suffix len
 	// sad
+	{"XY", false},
+	{"XY.B", false},
 	{"#@#$", false},
 	{"#@#$.B", false},
 	{"XYZ.B.B", false},
@@ -42,6 +44,8 @@ var tokenMapperSymbolTestCases = []struct {
 	// sad
 	{types.NativeTokenSymbol + "-000", false}, // no tx hash suffix for native token
 	{types.NativeTokenSymbolDotBSuffixed + "-000", false},
+	{"XY-000", false},
+	{"XY.B-000", false},
 	{"#@#$-000", false},
 	{"#@#$.B-000", false},
 	{"XYZ.B.B-000", false},


### PR DESCRIPTION
### Description

As titled. Will change the doc correspondingly

### Rationale

we check the symbol in `sdk.ParseCoins` in commands. 

### Example

### Changes

Notable changes: 
* 
* 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

