### PR TITLE
[R4R] Recover from last running mode when restarts

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -34,7 +34,7 @@ func GetHandler(config *config.Config) types.AbciQueryHandler {
 			}
 			res := abci.ResponseQuery{
 				Code:  uint32(sdk.ABCICodeOK),
-				Value: []byte{uint8(runtime.RunningMode)},
+				Value: []byte{uint8(runtime.GetRunningMode())},
 			}
 			return &res
 		}
@@ -47,20 +47,26 @@ func GetHandler(config *config.Config) types.AbciQueryHandler {
 			return &res
 		}
 
+		var runningMode runtime.Mode
 		if mode == "0" {
-			runtime.RunningMode = runtime.NormalMode
+			runningMode = runtime.NormalMode
 		} else if mode == "1" {
-			runtime.RunningMode = runtime.TransferOnlyMode
+			runningMode = runtime.TransferOnlyMode
 		} else if mode == "2" {
-			runtime.RunningMode = runtime.RecoverOnlyMode
+			runningMode = runtime.RecoverOnlyMode
 		} else {
 			res := sdk.ErrUnknownRequest("invalid mode").QueryResult()
+			return &res
+		}
+		err = runtime.UpdateRunningMode(config, runningMode)
+		if err != nil {
+			res := sdk.ErrUnknownRequest(err.Error()).QueryResult()
 			return &res
 		}
 
 		res := abci.ResponseQuery{
 			Code:  uint32(sdk.ABCICodeOK),
-			Value: []byte{uint8(runtime.RunningMode)},
+			Value: []byte{uint8(runtime.GetRunningMode())},
 		}
 		return &res
 	}

--- a/admin/tx.go
+++ b/admin/tx.go
@@ -29,24 +29,25 @@ var TxBlackList = map[runtime.Mode][]string{
 }
 
 func TxNotAllowedError() sdk.Error {
-	return sdk.ErrInternal(fmt.Sprintf("The tx is not allowed, RunningMode: %v", runtime.RunningMode))
+	return sdk.ErrInternal(fmt.Sprintf("The tx is not allowed, RunningMode: %v", runtime.GetRunningMode()))
 }
 
 func IsTxAllowed(tx sdk.Tx) bool {
-	if runtime.RunningMode == runtime.NormalMode {
+	mode := runtime.GetRunningMode()
+	if mode == runtime.NormalMode {
 		return true
 	}
 
 	for _, msg := range tx.GetMsgs() {
-		if !isMsgAllowed(msg) {
+		if !isMsgAllowed(msg, mode) {
 			return false
 		}
 	}
 	return true
 }
 
-func isMsgAllowed(msg sdk.Msg) bool {
-	for _, msgType := range TxBlackList[runtime.RunningMode] {
+func isMsgAllowed(msg sdk.Msg, mode runtime.Mode) bool {
+	for _, msgType := range TxBlackList[mode] {
 		if msgType == msg.Type() {
 			return false
 		}

--- a/cmd/bnbchaind/main.go
+++ b/cmd/bnbchaind/main.go
@@ -46,8 +46,6 @@ func main() {
 	server.AddCommands(ctx.ToCosmosServerCtx(), cdc, rootCmd, exportAppStateAndTMValidators)
 	startCmd := server.StartCmd(ctx.ToCosmosServerCtx(), newApp)
 	startCmd.Flags().Int64VarP(&ctx.PublicationConfig.FromHeightInclusive, "fromHeight", "f", 1, "from which height (inclusive) we want publish market data")
-	startCmd.Flags().Uint8Var(&ctx.BaseConfig.StartMode, "mode", uint8(0), "running mode when start up")
-	ctx.Viper.BindPFlag("base.startMode", startCmd.Flags().Lookup("mode"))
 	rootCmd.AddCommand(startCmd)
 
 	// prepare and add flags

--- a/common/runtime/recover.go
+++ b/common/runtime/recover.go
@@ -1,0 +1,56 @@
+package runtime
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/tendermint/tendermint/libs/common"
+
+	"github.com/binance-chain/node/common/log"
+)
+
+const fileName = "recover_params.json"
+
+type runtimeParams struct {
+	Mode Mode `json:"mode"`
+}
+
+func RecoverFromFile(homeDir string, defaultStartMode Mode) error {
+	path := filepath.Join(homeDir, "config", fileName)
+	var mode Mode
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Debug("path does not exist", "path", path)
+		mode = defaultStartMode
+	} else {
+		params := mustReadFromFile(path)
+		mode = params.Mode
+	}
+
+	return setRunningMode(mode)
+}
+
+func mustSaveToFile(path string, params *runtimeParams) {
+	contents, err := json.MarshalIndent(params, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	err = common.WriteFileAtomic(path, contents, 0600)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func mustReadFromFile(path string) *runtimeParams {
+	contents, err := common.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+
+	var res runtimeParams
+	err = json.Unmarshal(contents, &res)
+	if err != nil {
+		panic(err)
+	}
+	return &res
+}


### PR DESCRIPTION
### Description

Persistent the running mode to file when update. So we can recover from it when restarts.


### Rationale

After setting to recovery mode, we would do some fix and restart the node, the node needs to run still in recovery mode when started. 
Before this PR, we use a param in `StartCmd` to manually specify the mode. It's not friendly to our deployment scripts.

### Example


### Changes

Notable changes: 
* 
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

