### PR TITLE
use ethereum's libsecp256k1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -154,10 +154,10 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:fed20bf7f0da387c96d4cfc140a95572e5aba4bb984beb7de910e090ae39849b"
+  digest = "1:1530d06761f464b62ab3dfc2fa5b16303901d87ff219100a1447ba216d2e52be"
   name = "github.com/ethereum/go-ethereum"
   packages = ["crypto/secp256k1"]
-  pruneopts = "UT"
+  pruneopts = "T"
   revision = "c942700427557e3ff6de3aaf6b916e2f056c1ec2"
   version = "v1.8.23"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -69,6 +69,17 @@
   source = "https://github.com/tendermint/crypto"
   revision = "3764759f34a542a3aef74d6b02e35be7ab893bba"
 
+# we use the secp256k1 implementation:
+[[override]]
+  name = "github.com/ethereum/go-ethereum"
+  version = "^v1.8.21"
+
+   # Prevent dep from pruning build scripts and codegen templates
+   # note: this leaves the whole go-ethereum package in vendor
+   # can be removed when https://github.com/golang/dep/issues/1847 is resolved
+   [[prune.project]]
+     name = "github.com/ethereum/go-ethereum"
+     unused-packages = false
 
 [prune]
   go-tests = true

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_TAGS = netgo
 BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags "-X github.com/binance-chain/node/version.GitCommit=${COMMIT_HASH} -X github.com/binance-chain/node/version.CosmosRelease=${COSMOS_RELEASE} -X github.com/binance-chain/node/version.TendermintRelease=${TENDER_RELEASE}"
 # Without -lstdc++ on CentOS we will encounter link error, solution comes from: https://stackoverflow.com/a/29285011/1147187
 BUILD_CGOFLAGS = CGO_ENABLED=1 CGO_LDFLAGS="-lleveldb -lsnappy -lstdc++"
-BUILD_CFLAGS = ${BUILD_FLAGS} -tags "gcc"
+BUILD_CFLAGS = ${BUILD_FLAGS} -tags "gcc libsecp256k1"
 BUILD_TESTNET_FLAGS = ${BUILD_FLAGS} -ldflags "-X github.com/binance-chain/node/app.Bech32PrefixAccAddr=tbnb"
 
 UNAME_S := $(shell uname -s)


### PR DESCRIPTION
### Description

as titled

### Rationale


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* set prune unused-package to false for ethereum package
* ...

### Preflight checks

- [x] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

