### PR TITLE
[R4R] #476 write order id to file for large expire message

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,20 @@
 
 
 [[projects]]
-  digest = "1:66b8ed452b31eb9075bc53295952487c333a9cb555de57ed61f5664c058d9050"
+  digest = "1:ed77032e4241e3b8329c9304d66452ed196e795876e14be677a546f36b94e67a"
+  name = "github.com/DataDog/zstd"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c7161f8c63c045cbc7ca051dcc969dd0e4054de2"
+  version = "v1.3.5"
+
+[[projects]]
+  digest = "1:82a18170c9c41e36939cb5d26da1546b2cfa786aa030a978d3bf183519849230"
   name = "github.com/Shopify/sarama"
   packages = ["."]
   pruneopts = "UT"
-  revision = "35324cf48e33d8260e1c7c18854465a904ade249"
-  version = "v1.17.0"
+  revision = "4602b5a8c6e826f9e0737865818dd43b2339a092"
+  version = "v1.21.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,7 +54,7 @@
 
 [[constraint]]
   name = "github.com/Shopify/sarama"
-  version = "1.17.0"
+  version = "1.21.0"
 
 [[constraint]]
   name = "github.com/linkedin/goavro"

--- a/app/app.go
+++ b/app/app.go
@@ -171,7 +171,7 @@ func NewBinanceChain(logger log.Logger, db dbm.DB, traceStore io.Writer, baseApp
 
 		publishers := make([]pub.MarketDataPublisher, 0, 1)
 		if app.publicationConfig.PublishKafka {
-			publishers = append(publishers, pub.NewKafkaMarketDataPublisher(app.Logger))
+			publishers = append(publishers, pub.NewKafkaMarketDataPublisher(app.Logger, ServerContext.Config.DBDir()))
 		}
 		if app.publicationConfig.PublishLocal {
 			publishers = append(publishers, pub.NewLocalMarketDataPublisher(ServerContext.Config.RootDir, app.Logger, app.publicationConfig))
@@ -459,7 +459,7 @@ func (app *BinanceChain) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) a
 	if app.publicationConfig.ShouldPublishAny() &&
 		pub.IsLive {
 		if height >= app.publicationConfig.FromHeightInclusive {
-			app.publish(tradesToPublish, &proposals, blockFee, ctx, height, blockTime.Unix())
+			app.publish(tradesToPublish, &proposals, blockFee, ctx, height, blockTime.UnixNano())
 		}
 
 		// clean up intermediate cached data

--- a/app/pub/msgs.go
+++ b/app/pub/msgs.go
@@ -3,6 +3,7 @@ package pub
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -43,6 +44,30 @@ type AvroOrJsonMsg interface {
 	String() string
 }
 
+// EssMsg is a type when AvroOrJsonMsg failed to publish
+// Not all AvroOrJsonMsg implemented Ess because:
+//
+// for transfer:
+//
+// 1. qs doesn't subscribe to its topic (risk control is relying on that)
+// 2. risk control can recover from explorer indexed transfers (pull mode)
+// 3. we don't have a unique representation of transfer like order-id (we didn't save txhash in message)
+//
+// for trade:
+// the problem is same with above point 3, (trade id is only generated during publication, not persisted anywhere).
+// If we keep qty, price, sid, bid for a trade, it would be too much,
+// in this case we should recover from local publisher
+type EssMsg interface {
+	AvroOrJsonMsg
+
+	// a string that carry essential msg used to make up downstream service on kafka issue
+	// this string would be persisted into file
+	EssentialMsg() string
+
+	// an empty message of original `AvroOrJsonMsg` to make downstream logic not broken
+	EmptyCopy() AvroOrJsonMsg
+}
+
 type ExecutionResults struct {
 	Height    int64
 	Timestamp int64 // milli seconds since Epoch
@@ -73,6 +98,25 @@ func (msg *ExecutionResults) ToNativeMap() map[string]interface{} {
 	return native
 }
 
+func (msg *ExecutionResults) EssentialMsg() string {
+	// mainly used to recover for large breathe block expiring message, there should be no trade on breathe block
+	orders := msg.Orders.EssentialMsg()
+	proposals := msg.Proposals.EssentialMsg()
+	return fmt.Sprintf("height:%d\norders:%s\nproposals:%s\n", msg.Height, orders, proposals)
+}
+
+func (msg *ExecutionResults) EmptyCopy() AvroOrJsonMsg {
+	return &ExecutionResults{
+		msg.Height,
+		msg.Timestamp,
+		msg.NumOfMsgs,
+		trades{},
+		Orders{},
+		Proposals{},
+	}
+}
+
+// deliberated not implemented Ess
 type trades struct {
 	NumOfMsgs int
 	Trades    []*Trade
@@ -158,6 +202,21 @@ func (msg *Orders) ToNativeMap() map[string]interface{} {
 	return native
 }
 
+func (msg *Orders) EssentialMsg() string {
+	stat := make(map[orderPkg.ChangeType]*strings.Builder, 0) // ChangeType -> OrderIds splited by EOL
+	for _, order := range msg.Orders {
+		if _, ok := stat[order.Status]; !ok {
+			stat[order.Status] = &strings.Builder{}
+		}
+		fmt.Fprintf(stat[order.Status], "\n%s", order.OrderId)
+	}
+	var result strings.Builder
+	for changeType, str := range stat {
+		fmt.Fprintf(&result, "%d:%s\n", changeType, str.String())
+	}
+	return result.String()
+}
+
 type Order struct {
 	Symbol               string
 	Status               orderPkg.ChangeType
@@ -240,6 +299,21 @@ func (msg *Proposals) ToNativeMap() map[string]interface{} {
 	return native
 }
 
+func (msg *Proposals) EssentialMsg() string {
+	stat := make(map[ProposalStatus]*strings.Builder, 0) // ProposalStatus -> OrderIds splited by EOL
+	for _, proposal := range msg.Proposals {
+		if _, ok := stat[proposal.Status]; !ok {
+			stat[proposal.Status] = &strings.Builder{}
+		}
+		fmt.Fprintf(stat[proposal.Status], "\n%d", proposal.Id)
+	}
+	var result strings.Builder
+	for proposalStatus, str := range stat {
+		fmt.Fprintf(&result, "%d:%s\n", proposalStatus, str.String())
+	}
+	return result.String()
+}
+
 type ProposalStatus uint8
 
 const (
@@ -316,6 +390,7 @@ func (msg *OrderBookDelta) ToNativeMap() map[string]interface{} {
 	return native
 }
 
+// deliberated not implemented Ess
 type Books struct {
 	Height    int64
 	Timestamp int64
@@ -419,6 +494,24 @@ func (msg *Accounts) ToNativeMap() map[string]interface{} {
 	return native
 }
 
+func (msg *Accounts) EssentialMsg() string {
+	builder := strings.Builder{}
+	fmt.Fprintf(&builder, "height:%d\n", msg.Height)
+	for _, acc := range msg.Accounts {
+		fmt.Fprintf(&builder, "%s\n", sdk.AccAddress(acc.Owner).String())
+	}
+	return builder.String()
+}
+
+func (msg *Accounts) EmptyCopy() AvroOrJsonMsg {
+	return &Accounts{
+		msg.Height,
+		0,
+		[]Account{},
+	}
+}
+
+// deliberated not implemented Ess
 type BlockFee struct {
 	Height     int64
 	Fee        string
@@ -512,6 +605,7 @@ func (msg Transfer) ToNativeMap() map[string]interface{} {
 	return native
 }
 
+// deliberated not implemented Ess
 type Transfers struct {
 	Height    int64
 	Num       int

--- a/app/pub/publisher_mock.go
+++ b/app/pub/publisher_mock.go
@@ -11,7 +11,7 @@ type MockMarketDataPublisher struct {
 	BooksPublished            []*Books
 	ExecutionResultsPublished []*ExecutionResults
 	BlockFeePublished         []BlockFee
-	TransferPublished         []Transfer
+	TransferPublished         []Transfers
 
 	Lock             *sync.Mutex // as mock publisher is only used in testing, its no harm to have this granularity Lock
 	MessagePublished uint32      // atomic integer used to determine the published messages
@@ -31,7 +31,7 @@ func (publisher *MockMarketDataPublisher) publish(msg AvroOrJsonMsg, tpe msgType
 	case blockFeeTpe:
 		publisher.BlockFeePublished = append(publisher.BlockFeePublished, msg.(BlockFee))
 	case transferType:
-		publisher.TransferPublished = append(publisher.TransferPublished, msg.(Transfer))
+		publisher.TransferPublished = append(publisher.TransferPublished, msg.(Transfers))
 	default:
 		panic(fmt.Errorf("does not support type %s", tpe.String()))
 	}
@@ -54,7 +54,7 @@ func NewMockMarketDataPublisher() (publisher *MockMarketDataPublisher) {
 		make([]*Books, 0),
 		make([]*ExecutionResults, 0),
 		make([]BlockFee, 0),
-		make([]Transfer, 0),
+		make([]Transfers, 0),
 		&sync.Mutex{},
 		0,
 	}

--- a/app/pub/schema_test.go
+++ b/app/pub/schema_test.go
@@ -18,7 +18,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestExecutionResultsMarshaling(t *testing.T) {
-	publisher := NewKafkaMarketDataPublisher(Logger)
+	publisher := NewKafkaMarketDataPublisher(Logger, "")
 	trades := trades{
 		NumOfMsgs: 1,
 		Trades: []*Trade{{
@@ -58,7 +58,7 @@ func TestExecutionResultsMarshaling(t *testing.T) {
 }
 
 func TestBooksMarshaling(t *testing.T) {
-	publisher := NewKafkaMarketDataPublisher(Logger)
+	publisher := NewKafkaMarketDataPublisher(Logger, "")
 	book := OrderBookDelta{"NNB_BNB", []PriceLevel{{100, 100}}, []PriceLevel{{100, 100}}}
 	msg := Books{42, 100, 1, []OrderBookDelta{book}}
 	_, err := publisher.marshal(&msg, booksTpe)
@@ -68,7 +68,7 @@ func TestBooksMarshaling(t *testing.T) {
 }
 
 func TestAccountsMarshaling(t *testing.T) {
-	publisher := NewKafkaMarketDataPublisher(Logger)
+	publisher := NewKafkaMarketDataPublisher(Logger, "")
 	accs := []Account{{"b-1", "BNB:1000;BTC:10", []*AssetBalance{{Asset: "BNB", Free: 100}}}}
 	msg := Accounts{42, 2, accs}
 	_, err := publisher.marshal(&msg, accountsTpe)
@@ -78,7 +78,7 @@ func TestAccountsMarshaling(t *testing.T) {
 }
 
 func TestBlockFeeMarshaling(t *testing.T) {
-	publisher := NewKafkaMarketDataPublisher(Logger)
+	publisher := NewKafkaMarketDataPublisher(Logger, "")
 	msg := BlockFee{1, "BNB:1000;BTC:10", []string{"bnc1", "bnc2", "bnc3"}}
 	_, err := publisher.marshal(&msg, blockFeeTpe)
 	if err != nil {
@@ -87,7 +87,7 @@ func TestBlockFeeMarshaling(t *testing.T) {
 }
 
 func TestTransferMarshaling(t *testing.T) {
-	publisher := NewKafkaMarketDataPublisher(Logger)
+	publisher := NewKafkaMarketDataPublisher(Logger, "")
 	msg := Transfers{42, 20, 1000, []Transfer{{From: "", To: []Receiver{Receiver{"bnc1", []Coin{{"BNB", 100}, {"BTC", 100}}}, Receiver{"bnc2", []Coin{{"BNB", 200}, {"BTC", 200}}}}}}}
 	_, err := publisher.marshal(&msg, transferType)
 	if err != nil {

--- a/cmd/pressuremaker/utils/utils.go
+++ b/cmd/pressuremaker/utils/utils.go
@@ -131,7 +131,7 @@ func (mg *MessageGenerator) ExpireMessages(height int, timeNow time.Time) (trade
 	orderChanges = make(orderPkg.OrderChanges, 0, 100000)
 	accounts = make(map[string]pub.Account)
 
-	for i := 0; i < 100000; i++ {
+	for i := 0; i < 1000000; i++ {
 		o := makeOrderInfo(mg.buyerAddrs[0], 1, int64(height), 1000000000, 1000000000, 500000000, timePub)
 		mg.OrderChangeMap[fmt.Sprintf("%d", i)] = &o
 		orderChanges = append(orderChanges, orderPkg.OrderChange{fmt.Sprintf("%d", i), orderPkg.Expired})

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -673,12 +673,6 @@ func (kp *Keeper) expireOrders(ctx sdk.Context, blockTime time.Time) []chan Tran
 		return nil
 	}
 
-	//!!!!!!!!!!!!!!!!!!!! DELETE BEFORE MERGE
-	//if ctx.BlockHeight() > 300 {
-	//	expireHeight = ctx.BlockHeight() - 300
-	//}
-	//!!!!!!!!!!!!!!!!!!!! DELETE BEFORE MERGE
-
 	channelSize := size >> kp.poolSize
 	concurrency := 1 << kp.poolSize
 	if size%concurrency != 0 {


### PR DESCRIPTION
# Make sure Jack or Erheng modify db timestamp column to persist correct date format
# Make sure Zongjiang's ws trade timestamp changed from multiply 1000 to divide 10 ^ 6 

### Description

write order id to file for large expire message

### Rationale

#476 

wiki update : https://github.com/binance-chain/docs-internal/wiki/qa_runbook#publication-error

### Example
will keep a file at `/Users/zhaocong/.bnbchaind_publisher/data/essential/3087_ExecutionResults.log`

Duplicated order id is because the trade-id on order is different (capture this log on non-breathe block)
```
height:3087
orders:
0:
D01E89F25E05DD00382DDAF4541E754B7DAEB9BE-1318
5:
E00476F64BA73E5FE3E2E7D20D1C64706B2F7915-1299
D01E89F25E05DD00382DDAF4541E754B7DAEB9BE-1318
E00476F64BA73E5FE3E2E7D20D1C64706B2F7915-1298
D01E89F25E05DD00382DDAF4541E754B7DAEB9BE-1318
E00476F64BA73E5FE3E2E7D20D1C64706B2F7915-1297
D01E89F25E05DD00382DDAF4541E754B7DAEB9BE-1318
D01E89F25E05DD00382DDAF4541E754B7DAEB9BE-1318
4:
E00476F64BA73E5FE3E2E7D20D1C64706B2F7915-1138

proposals:
```

`3087_Accounts.log`

```
height:3087
bnb1uqz8dajt5ul9lclzulfq68rywp4j77g46gn3q5
bnb16q0gnuj7qhwsqwpdmt69g8n4fd76awd7p8hgcu
```

### Changes

1. dump large expire and send an empty msg keep qs is running
2. upgrade kafka sarama lib
3. change publish acknowledge level to local (we won't be blocked during upgrade kafka)

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#476 

