### PR TITLE
[R4R] #357 recover recent price on state sync

### DIFF
--- a/app/statesync_helper.go
+++ b/app/statesync_helper.go
@@ -179,10 +179,12 @@ func (app *BinanceChain) EndRecovery(height int64) error {
 	app.Logger.Info("commit by state reactor", "version", commitId.Version, "hash", hashHex)
 
 	// simulate we just "Commit()" :P
-	app.SetCheckState(abci.Header{})
+	app.SetCheckState(abci.Header{Height: height})
 	app.DeliverState = nil
 
-	//TODO: figure out how to get block time here to get rid of time.Now() :(
+	// TODO: sync the breathe block on state sync and just call app.DexKeeper.Init() to recover order book and recentPrices to memory
+	app.DexKeeper.InitRecentPrices(app.CheckState.Ctx)
+	// TODO: figure out how to get block time here to get rid of time.Now() :(
 	_, err = app.DexKeeper.LoadOrderBookSnapshot(app.CheckState.Ctx, height, time.Now(), app.baseConfig.BreatheBlockInterval, app.baseConfig.BreatheBlockDaysCountBack)
 	if err != nil {
 		panic(err)

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -88,6 +88,10 @@ func NewKeeper(key sdk.StoreKey, am auth.AccountKeeper, tradingPairMapper store.
 
 func (kp *Keeper) Init(ctx sdk.Context, blockInterval, daysBack int, blockDB dbm.DB, txDB dbm.DB, lastHeight int64, txDecoder sdk.TxDecoder) {
 	kp.initOrderBook(ctx, blockInterval, daysBack, blockDB, txDB, lastHeight, txDecoder)
+	kp.InitRecentPrices(ctx)
+}
+
+func (kp *Keeper) InitRecentPrices(ctx sdk.Context) {
 	kp.recentPrices = kp.PairMapper.GetRecentPrices(ctx, pricesStoreEvery, numPricesStored)
 }
 


### PR DESCRIPTION
### Description

recover recent price to make sure tick and lot size calculation is consistent after state sync

### Rationale

missed tick/lot size change in state sync implementation (two separate work merge together)

### Example

N/A

### Changes


### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#357 
