### PR TITLE
[R4R] #357 clean up logic after state_sync

### DIFF
--- a/app/statesync_helper.go
+++ b/app/statesync_helper.go
@@ -183,16 +183,23 @@ func (app *BinanceChain) EndRecovery(height int64) error {
 	app.DeliverState = nil
 
 	// TODO: sync the breathe block on state sync and just call app.DexKeeper.Init() to recover order book and recentPrices to memory
-	app.DexKeeper.InitRecentPrices(app.CheckState.Ctx)
-	// TODO: figure out how to get block time here to get rid of time.Now() :(
-	_, err = app.DexKeeper.LoadOrderBookSnapshot(app.CheckState.Ctx, height, time.Now(), app.baseConfig.BreatheBlockInterval, app.baseConfig.BreatheBlockDaysCountBack)
-	if err != nil {
-		panic(err)
-	}
+	app.resetDexKeeper(height)
 
 	// init app cache
 	accountStore := stores.GetKVStore(common.AccountStoreKey)
 	app.SetAccountStoreCache(app.Codec, accountStore, app.baseConfig.AccountCacheSize)
 
 	return nil
+}
+
+func (app BinanceChain) resetDexKeeper(height int64) {
+	app.DexKeeper.ClearOrders()
+
+	// TODO: figure out how to get block time here to get rid of time.Now() :(
+	_, err := app.DexKeeper.LoadOrderBookSnapshot(app.CheckState.Ctx, height, time.Now(), app.baseConfig.BreatheBlockInterval, app.baseConfig.BreatheBlockDaysCountBack)
+	if err != nil {
+		panic(err)
+	}
+	app.DexKeeper.InitRecentPrices(app.CheckState.Ctx)
+
 }

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -805,3 +805,12 @@ func (kp *Keeper) updateRoundOrderFee(addr string, fee types.Fee) {
 func (kp *Keeper) ClearRoundFee() {
 	kp.RoundOrderFees = make(map[string]*types.Fee, 256)
 }
+
+// used by state sync to clear memory order book after we synced latest breathe block
+func (kp *Keeper) ClearOrders() {
+	kp.engines = make(map[string]*me.MatchEng)
+	kp.allOrders = make(map[string]map[string]*OrderInfo, 256)
+	kp.roundOrders = make(map[string][]string, 256)
+	kp.roundIOCOrders = make(map[string][]string, 256)
+	kp.OrderInfosForPub = make(OrderInfoForPublish)
+}


### PR DESCRIPTION
### Description

make clean up logic after state_sync more robust and cleaner

### Rationale

#357  #209 

### Example

N/A

### Changes

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#357 #209 
