### PR TITLE
Partial cancel caused an error log when calc fee

### DIFF
--- a/plugins/dex/order/handler.go
+++ b/plugins/dex/order/handler.go
@@ -183,10 +183,13 @@ func handleCancelOrder(
 	if sdkError != nil {
 		return sdkError.Result()
 	}
-	acc := keeper.am.GetAccount(ctx, msg.Sender)
-	fee := keeper.FeeManager.CalcFixedFee(acc.GetCoins(), transfer.eventType, transfer.inAsset, keeper.engines)
-	acc.SetCoins(acc.GetCoins().Minus(fee.Tokens))
-	keeper.am.SetAccount(ctx, acc)
+	fee := common.Fee{}
+	if !transfer.FeeFree() {
+		acc := keeper.am.GetAccount(ctx, msg.Sender)
+		fee = keeper.FeeManager.CalcFixedFee(acc.GetCoins(), transfer.eventType, transfer.inAsset, keeper.engines)
+		acc.SetCoins(acc.GetCoins().Minus(fee.Tokens))
+		keeper.am.SetAccount(ctx, acc)
+	}
 
 	// this is done in memory! we must not run this block in checktx or simulate!
 	if ctx.IsDeliverTx() {


### PR DESCRIPTION
### Description

Each partial cancel will produce the following ERROR log.
> "Invalid expire eventType                     module=dexkeeper eventType=6"

### Rationale

clean up the error log

### Example

### Changes

Notable changes: 
* 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

