### PR TITLE
check length of signer addresses

### DIFF
--- a/common/tx/ante.go
+++ b/common/tx/ante.go
@@ -205,8 +205,14 @@ func validateBasic(tx auth.StdTx) (err sdk.Error) {
 	}
 
 	// Assert that number of signatures is correct.
-	if signerAddrs := tx.GetSigners(); len(sigs) != len(signerAddrs) {
+	signerAddrs := tx.GetSigners()
+	if len(sigs) != len(signerAddrs) {
 		return sdk.ErrUnauthorized("wrong number of signers")
+	}
+	for _, signerAddr := range signerAddrs {
+		if len(signerAddr) != sdk.AddrLen {
+			return sdk.ErrInvalidAddress("contains invalid signer address")
+		}
 	}
 
 	if data := tx.GetData(); len(data) > 0 {


### PR DESCRIPTION
### Description

verify the signer addresses in ante handler

### Rationale

we should limit the address length to 20

### Example

### Changes

Notable changes: 
* 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

