### PR TITLE
[R4R] #499 failed blocking should not be regarded as closed order

### DIFF
--- a/cmd/pressuremaker/utils/utils.go
+++ b/cmd/pressuremaker/utils/utils.go
@@ -59,8 +59,8 @@ func (mg *MessageGenerator) OneOnOneMessages(height int, timeNow time.Time) (tra
 		mg.OrderChangeMap[buyOrder.Id] = &buyOrder
 		mg.OrderChangeMap[sellOrder.Id] = &sellOrder
 
-		orderChanges[i*2] = orderPkg.OrderChange{buyOrder.Id, orderPkg.Ack}
-		orderChanges[i*2+1] = orderPkg.OrderChange{sellOrder.Id, orderPkg.Ack}
+		orderChanges[i*2] = orderPkg.OrderChange{buyOrder.Id, orderPkg.Ack, nil}
+		orderChanges[i*2+1] = orderPkg.OrderChange{sellOrder.Id, orderPkg.Ack, nil}
 
 		tradesToPublish[i] = makeTradeToPub(fmt.Sprintf("%d-%d", height, i), sellOrder.Id, buyOrder.Id, mg.sellerAddrs[i].String(), mg.buyerAddrs[i].String(), price, amount)
 
@@ -88,7 +88,7 @@ func (mg *MessageGenerator) TwoOnOneMessages(height int, timeNow time.Time) (tra
 		for i := 0; i < mg.NumOfTradesPerBlock; i++ {
 			buyOrder := makeOrderInfo(mg.buyerAddrs[i], 1, int64(height), 100000000, 100000000, 0, timePub)
 			mg.OrderChangeMap[buyOrder.Id] = &buyOrder
-			orderChanges[i] = orderPkg.OrderChange{buyOrder.Id, orderPkg.Ack}
+			orderChanges[i] = orderPkg.OrderChange{buyOrder.Id, orderPkg.Ack, nil}
 		}
 	} else {
 		// place big sell orders
@@ -106,7 +106,7 @@ func (mg *MessageGenerator) TwoOnOneMessages(height int, timeNow time.Time) (tra
 			}
 			sellOrder := makeOrderInfo(mg.sellerAddrs[i/2], 2, int64(height), 100000000, 200000000, cumQty, timePub)
 			if i%2 == 0 {
-				orderChanges[i/2] = orderPkg.OrderChange{sellOrder.Id, orderPkg.Ack}
+				orderChanges[i/2] = orderPkg.OrderChange{sellOrder.Id, orderPkg.Ack, nil}
 			}
 			tradesToPublish[i] = makeTradeToPub(fmt.Sprintf("%d-%d", height, i), buyOrder.Id, sellOrder.Id, mg.sellerAddrs[i].String(),
 				mg.buyerAddrs[i].String(), 100000000, 100000000)
@@ -134,7 +134,7 @@ func (mg *MessageGenerator) ExpireMessages(height int, timeNow time.Time) (trade
 	for i := 0; i < 100000; i++ {
 		o := makeOrderInfo(mg.buyerAddrs[0], 1, int64(height), 1000000000, 1000000000, 500000000, timePub)
 		mg.OrderChangeMap[fmt.Sprintf("%d", i)] = &o
-		orderChanges = append(orderChanges, orderPkg.OrderChange{fmt.Sprintf("%d", i), orderPkg.Expired})
+		orderChanges = append(orderChanges, orderPkg.OrderChange{fmt.Sprintf("%d", i), orderPkg.Expired, nil})
 	}
 	return
 }

--- a/plugins/dex/order/handler.go
+++ b/plugins/dex/order/handler.go
@@ -199,7 +199,7 @@ func handleCancelOrder(
 		//remove order from cache and order book
 		err := keeper.RemoveOrder(origOrd.Id, origOrd.Symbol, func(ord me.OrderPart) {
 			if keeper.CollectOrderInfoForPublish {
-				change := OrderChange{msg.RefId, Canceled}
+				change := OrderChange{msg.RefId, Canceled, nil}
 				keeper.OrderChanges = append(keeper.OrderChanges, change)
 				keeper.updateRoundOrderFee(string(msg.Sender), fee)
 			}

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -139,7 +139,7 @@ func (kp *Keeper) AddOrder(info OrderInfo, isRecovery bool) (err error) {
 	}
 
 	if kp.CollectOrderInfoForPublish {
-		change := OrderChange{info.Id, Ack}
+		change := OrderChange{info.Id, Ack, nil}
 		// deliberately not add this message to orderChanges
 		if !isRecovery {
 			kp.OrderChanges = append(kp.OrderChanges, change)
@@ -273,8 +273,7 @@ func (kp *Keeper) matchAndDistributeTradesForSymbol(symbol string, height, times
 			// order status change outs.
 			if kp.CollectOrderInfoForPublish {
 				kp.OrderChangesMtx.Lock()
-				kp.OrderChanges = append(kp.OrderChanges, OrderChange{id, FailedMatching})
-				kp.OrderInfosForPub[id] = msg
+				kp.OrderChanges = append(kp.OrderChanges, OrderChange{id, FailedMatching, nil})
 				kp.OrderChangesMtx.Unlock()
 			}
 		}


### PR DESCRIPTION
### Description

failed blocking should not be regarded as closed order

### Rationale

#499 

### Example

N/A

### Changes
1. don't delete order in `dexkeeper.orderInfoForPub` for failedblocking
2. change payload of failedblocking order to failed message (not rely on `orderInfoForPub` anymore)
3. cleaner and safer code to maintain closed and open order. The closed concept is consistent with QS
4. fix new added order status field is not correctly involved in orderbook calculation

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#499 
