### PR TITLE
[R4R]: check overflow in multi send

### DIFF
--- a/plugins/tokens/client/cli/multi_send.go
+++ b/plugins/tokens/client/cli/multi_send.go
@@ -4,15 +4,16 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/utils"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	txbuilder "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
 	"github.com/cosmos/cosmos-sdk/x/bank"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/binance-chain/node/wire"
 )
@@ -94,11 +95,16 @@ func MultiSendCmd(cdc *wire.Codec) *cobra.Command {
 				fromCoins = fromCoins.Plus(toCoin)
 			}
 
+			if !fromCoins.IsPositive() {
+				return errors.Errorf("The number of coins you want to send(%s) should be positive!", fromCoins.String())
+			}
+
 			// ensure account has enough toCoins
 			account, err := ctx.GetAccount(from)
 			if err != nil {
 				return err
 			}
+
 			if !account.GetCoins().IsGTE(fromCoins) {
 				return errors.Errorf("Address %s doesn't have enough toCoins to pay for this transaction.", from)
 			}


### PR DESCRIPTION
### Description

Check overflow in multi send command.

### Rationale

tell us why we need these changes...

### Example

It will return an error if the inputs are not right:
```bash
➜  build git:(master) ✗ ./bnbcli token multi-send --home ./testnodecli --from alice --chain-id=bnbchain-1000 --transfers "[{\"to\":\"bnb1g5p04snezgpky203fq6da9qyjsy2k9kzr5yuhl\",\"amount\":\"4611686018427387904:BNB\"},{\"to\":\"bnb1l86xty0m55ryct9pnypz6chvtsmpyewmhrqwxw\",\"amount\":\"4611686018427387904:BNB\"}]" --json
ERROR: The number of coins you want to send(-9223372036854775808BNB) should be positive!
```

### Changes

Notable changes: 
* check overflow in multi send command


### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

