### PR TITLE
LotSize is too small for a very low price

### DIFF
--- a/plugins/dex/utils/pair.go
+++ b/plugins/dex/utils/pair.go
@@ -7,14 +7,22 @@ import (
 )
 
 // CalcTickSizeAndLotSize calculate TickSize and LotSize
+
+//Price		≥1e8	≥1e7	≥1e6	≥1e5	≥1e4	≥1e3	≥1e2	≥1e1	≥1
+//TickSize	1e3		1e2		1e1		1		1		1		1		1		1
+//LotSize	1e5		1e6		1e7		1e8		1e9		1e10	1e11	1e12	1e13
+
+//Price		≥1e9	≥1e10	≥1e11	≥1e12	≥1e13	≥1e14	≥1e15	≥1e16	≥1e17
+//TickSize	1e4		1e5		1e6		1e7		1e8		1e9		1e10	1e11	1e12
+//LotSize	1e4		1e3		1e2		1e1		1		1		1		1		1
 func CalcTickSizeAndLotSize(price int64) (tickSize, lotSize int64) {
 	if price <= 0 {
-		return 1, 1e8
+		return 1, 1e13
 	}
 
 	priceDigits := int64(math.Floor(math.Log10(float64(price))))
 	tickSizeDigits := int64(math.Max(float64(priceDigits-5), 0))
-	lotSizeDigits := int64(math.Max(float64(8-tickSizeDigits), 0))
+	lotSizeDigits := int64(math.Max(float64(13-priceDigits), 0))
 
 	return int64(math.Pow(10, float64(tickSizeDigits))), int64(math.Pow(10, float64(lotSizeDigits)))
 }

--- a/plugins/dex/utils/pair_test.go
+++ b/plugins/dex/utils/pair_test.go
@@ -18,9 +18,9 @@ func TestCalcLotSizeAndCalcTickSize(t *testing.T) {
 		lotSize  int64
 		tickSize int64
 	}{
-		{-1, 1e8, 1},
-		{0, 1e8, 1},
-		{1e2, 1e8, 1},
+		{-1, 1e13, 1},
+		{0, 1e13, 1},
+		{1e2, 1e11, 1},
 		{1e8, 1e5, 1e3},
 		{1e17, 1, 1e12},
 	}


### PR DESCRIPTION
### Description

if the price is less than 1e6, then in the current logic, the tick_size and lot_size are always 1 and 1e8.
when calculating the trading fee, we may get 0.
For example, the price is 1e2, the lot size is 1e8, the fee rate is 4%%, then the fee is 0.
So we need to promote the lot size, like 1e11.

### Rationale
 

### Example
 

### Changes

Notable changes: 
* 
*  

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

