### PR TITLE
R4R: Move the showOrderBook command under query category

### DIFF
--- a/plugins/dex/client/cli/commands.go
+++ b/plugins/dex/client/cli/commands.go
@@ -23,10 +23,10 @@ func AddCommands(cmd *cobra.Command, cdc *wire.Codec) {
 			listTradingPairCmd(cdc),
 			client.LineBreak,
 			newOrderCmd(cdc),
-			showOrderBookCmd(cdc),
 			cancelOrderCmd(cdc))...)
-	// dexCmd.AddCommand(
-	// 	client.GetCommands()...)
+	dexCmd.AddCommand(
+	 	client.GetCommands(
+	 		showOrderBookCmd(cdc))...)
 
 	dexCmd.AddCommand(client.LineBreak)
 	cmd.AddCommand(dexCmd)


### PR DESCRIPTION
### Description

The command to show order book is a query command, but now it is under post command which is confusing.

### Rationale

Move the showOrderBook command under query command category.

### Example

```
bnbcli dex show --trust-node
```

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

