### PR TITLE
[WIP]: Add a upgrade to support new validator power rank key

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -55,8 +55,8 @@
   revision = "d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4"
 
 [[projects]]
-  branch = "develop"
-  digest = "1:a8717c218a5d09fe77c1e249f006ff0d55937b77c271445ed46aa8c7c4279aab"
+  branch = "haoyang/upgrade-validator-power-key"
+  digest = "1:134a36cb63edb8026c0d64428b6b12e14f60a21d2148ce63ca0dd94bdff208a8"
   name = "github.com/cosmos/cosmos-sdk"
   packages = [
     "baseapp",
@@ -103,7 +103,7 @@
     "x/stake/types",
   ]
   pruneopts = "UT"
-  revision = "5fa1ec76b2c684c859441fe6fef2da43e02d3f73"
+  revision = "22e2d78bb43c6ba96a1c01409b33013b39e0be94"
   source = "github.com/binance-chain/bnc-cosmos-sdk"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,7 +42,7 @@
 [[constraint]]
   name = "github.com/cosmos/cosmos-sdk"
   source = "github.com/binance-chain/bnc-cosmos-sdk"
-  branch = "develop"
+  branch = "haoyang/upgrade-validator-power-key"
 
 [[constraint]]
   name = "github.com/btcsuite/btcd"

--- a/app/app.go
+++ b/app/app.go
@@ -465,7 +465,12 @@ func (app *BinanceChain) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) a
 		app.DexKeeper.ClearOrderChanges()
 		app.DexKeeper.ClearRoundFee()
 	}
-
+	if sdk.IsUpgradeHeight(sdk.UpgradeChangeValidatorPowerKey) {
+		err := stake.RebuildPowerRankKeyForUpgrade(ctx, app.stakeKeeper)
+		if err != nil {
+			panic(err)
+		}
+	}
 	var validatorUpdates abci.ValidatorUpdates
 	// TODO: confirm with zz height == 1 is only to keep consistent with testnet (Binance Chain Commit: d1f295b; Cosmos Release: =v0.25.0-binance.5; Tendermint Release: =v0.29.1-binance.2;),
 	//  otherwise, apphash fail


### PR DESCRIPTION
### Description

Upgrade cosmos dependency to support new method to build validator power rank key

### Rationale

Please refer to https://github.com/cosmos/cosmos-sdk/issues/2909. There is a bug in current method to build validator power rank key. 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related PR

https://github.com/binance-chain/bnc-cosmos-sdk/pull/100

