### PR TITLE
[R4R] #528 include txhash in published transfers

### DIFF
--- a/app/pub/helpers.go
+++ b/app/pub/helpers.go
@@ -45,6 +45,7 @@ func GetTransferPublished(pool *sdk.Pool, height, blockTime int64) *Transfers {
 	transferToPublish := make([]Transfer, 0, 0)
 	txs := pool.GetTxs()
 	txs.Range(func(key, value interface{}) bool {
+		txhash := key.(string)
 		t := value.(sdk.Tx)
 		msgs := t.GetMsgs()
 		for _, m := range msgs {
@@ -60,7 +61,7 @@ func GetTransferPublished(pool *sdk.Pool, height, blockTime int64) *Transfers {
 				}
 				receivers = append(receivers, Receiver{Addr: o.Address.String(), Coins: coins})
 			}
-			transferToPublish = append(transferToPublish, Transfer{From: msg.Inputs[0].Address.String(), To: receivers})
+			transferToPublish = append(transferToPublish, Transfer{TxHash: txhash, From: msg.Inputs[0].Address.String(), To: receivers})
 		}
 		return true
 	})

--- a/app/pub/msgs.go
+++ b/app/pub/msgs.go
@@ -596,8 +596,9 @@ func (msg Receiver) ToNativeMap() map[string]interface{} {
 }
 
 type Transfer struct {
-	From string
-	To   []Receiver
+	TxHash string
+	From   string
+	To     []Receiver
 }
 
 func (msg Transfer) String() string {
@@ -606,6 +607,7 @@ func (msg Transfer) String() string {
 
 func (msg Transfer) ToNativeMap() map[string]interface{} {
 	var native = make(map[string]interface{})
+	native["txhash"] = msg.TxHash
 	native["from"] = msg.From
 	to := make([]map[string]interface{}, len(msg.To), len(msg.To))
 	for idx, t := range msg.To {

--- a/app/pub/schema_test.go
+++ b/app/pub/schema_test.go
@@ -88,7 +88,7 @@ func TestBlockFeeMarshaling(t *testing.T) {
 
 func TestTransferMarshaling(t *testing.T) {
 	publisher := NewKafkaMarketDataPublisher(Logger, "")
-	msg := Transfers{42, 20, 1000, []Transfer{{From: "", To: []Receiver{Receiver{"bnc1", []Coin{{"BNB", 100}, {"BTC", 100}}}, Receiver{"bnc2", []Coin{{"BNB", 200}, {"BTC", 200}}}}}}}
+	msg := Transfers{42, 20, 1000, []Transfer{{TxHash: "123456ABCDE", From: "", To: []Receiver{Receiver{"bnc1", []Coin{{"BNB", 100}, {"BTC", 100}}}, Receiver{"bnc2", []Coin{{"BNB", 200}, {"BTC", 200}}}}}}}
 	_, err := publisher.marshal(&msg, transferType)
 	if err != nil {
 		t.Fatal(err)

--- a/app/pub/schemas.go
+++ b/app/pub/schemas.go
@@ -216,7 +216,8 @@ const (
 						"name": "Transfer",
 						"namespace": "com.company",
 						"fields": [
-							{ "name": "from", "type": "string"},
+							{ "name": "txhash", "type": "string" },
+							{ "name": "from", "type": "string" },
 							{ "name": "to", 
                   				"type": {
  									"type": "array",

--- a/networks/publisher/setup.sh
+++ b/networks/publisher/setup.sh
@@ -47,6 +47,7 @@ sed -i -e "s/publishOrderUpdates = false/publishOrderUpdates = true/g" ${deamonh
 sed -i -e "s/publishAccountBalance = false/publishAccountBalance = true/g" ${deamonhome}/config/app.toml
 sed -i -e "s/publishOrderBook = false/publishOrderBook = true/g" ${deamonhome}/config/app.toml
 sed -i -e "s/publishBlockFee = false/publishBlockFee = true/g" ${deamonhome}/config/app.toml
+sed -i -e "s/publishTransfer = false/publishTransfer = true/g" ${deamonhome}/config/app.toml
 sed -i -e "s/publishLocal = false/publishLocal = true/g" ${deamonhome}/config/app.toml
 sed -i -e 's/"voting_period": "1209600000000000"/"voting_period": "5000000000"/g' ${deamonhome}/config/genesis.json
 

--- a/plugins/dex/matcheng/match.go
+++ b/plugins/dex/matcheng/match.go
@@ -273,7 +273,7 @@ func allocateResidual(toAlloc *int64, orders []OrderPart, lotSize int64) bool {
 // totalLot * orderLeft / totalLeft, orderLeft <= totalLeft
 func calcNumOfLot(totalLot, orderLeft, totalLeft int64) int64 {
 	if tmp, ok := utils.Mul64(totalLot, orderLeft); ok {
-		return tmp/totalLeft
+		return tmp / totalLeft
 	} else {
 		var res big.Int
 		res.Quo(res.Mul(big.NewInt(totalLot), big.NewInt(orderLeft)), big.NewInt(totalLeft))

--- a/plugins/dex/matcheng/match_test.go
+++ b/plugins/dex/matcheng/match_test.go
@@ -58,7 +58,7 @@ func Test_prepareMatch_overflow(t *testing.T) {
 		{Price: 961, SellOrders: []OrderPart{{"6.1", 101, 400e16, 0, 0}}},
 	}
 	execs := []int64{300e16, 400e16, 600e16, math.MaxInt64, 700e16, 400e16}
-	surpluses := []int64{300e16 - math.MaxInt64, 400e16 - math.MaxInt64, 600e16 - math.MaxInt64, 0, math.MaxInt64-700e16, math.MaxInt64-400e16}
+	surpluses := []int64{300e16 - math.MaxInt64, 400e16 - math.MaxInt64, 600e16 - math.MaxInt64, 0, math.MaxInt64 - 700e16, math.MaxInt64 - 400e16}
 	assert.Equal(6, prepareMatch(&overlap))
 	for i, e := range execs {
 		assert.Equal(e, overlap[i].AccumulatedExecutions, fmt.Sprintf("overlap number %d", i))

--- a/plugins/dex/utils/numbers.go
+++ b/plugins/dex/utils/numbers.go
@@ -13,7 +13,7 @@ func CalBigNotionalInt64(price, qty int64) int64 {
 	res, ok := utils.Mul64(price, qty)
 	if ok {
 		// short cut
-		return res/1e8
+		return res / 1e8
 	}
 
 	var bi big.Int

--- a/plugins/dex/utils/pair.go
+++ b/plugins/dex/utils/pair.go
@@ -40,7 +40,7 @@ func CalcPriceWMA(prices *utils.FixedSizeRing) int64 {
 
 	weightedSum := big.NewInt(0)
 	lenPrices := len(elements)
-	for i:=0; i < lenPrices; i++ {
+	for i := 0; i < lenPrices; i++ {
 		var weightedPrice big.Int
 		weightedPrice.Mul(big.NewInt(int64(i+1)), big.NewInt(elements[i].(int64)))
 		weightedSum.Add(weightedSum, &weightedPrice)


### PR DESCRIPTION
### Description

include txhash in published transfers

### Rationale

#528 

### Example
```
{"Height":93,"Num":1,"Timestamp":1554345222516747000,"Transfers":[{"TxHash":"DD12CA4F879F5B094CA5A7C80458A34B01AC1458F6043EDA53DB60F2CDACA261","From":"bnb1kvw957xqs0heqppua7ccns2cmjzehdjctmxsu9","To":[{"Addr":"bnb1knf0cn0te3nj26xd5jtznddcfxkjukfpawxvdp","Coins":[{"denom":"BNB","amount":1000000000000000}]}]}]}
```

### Changes

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

#528 
