### PR TITLE
[R4R] upgrade logic for splitting validator address

### DIFF
--- a/app/fee_distribution.go
+++ b/app/fee_distribution.go
@@ -8,6 +8,7 @@ import (
 	"github.com/binance-chain/node/common/fees"
 	"github.com/binance-chain/node/common/log"
 	"github.com/binance-chain/node/common/types"
+	"github.com/binance-chain/node/common/upgrade"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
@@ -15,10 +16,15 @@ import (
 )
 
 func NewValAddrCache(stakeKeeper stake.Keeper) *ValAddrCache {
-	return &ValAddrCache{
+	cache := &ValAddrCache{
 		cache:       make(map[string]sdk.AccAddress),
 		stakeKeeper: stakeKeeper,
 	}
+
+	upgrade.Mgr.RegisterBeginBlocker(sdk.UpgradeSeparateValAddrName, func(ctx sdk.Context) {
+		cache.ClearCache()
+	})
+	return cache
 }
 
 type ValAddrCache struct {

--- a/common/upgrade/upgrade.go
+++ b/common/upgrade/upgrade.go
@@ -10,26 +10,10 @@ var Mgr = sdk.UpgradeMgr
 const FixOrderSeqInPriceLevelName = "fixOrderSeqInPriceLevel"
 const FixDropFilledOrderSeqName = "fixDropFilledOrderSeq"
 
-func Upgrade(name string, before func(), in func(), after func()) {
-	if sdk.IsUpgradeHeight(name) {
-		if in != nil {
-			in()
-		}
-	} else if sdk.IsUpgrade(name) {
-		if after != nil {
-			after()
-		}
-	} else {
-		if before != nil {
-			before()
-		}
-	}
-}
-
 func FixOrderSeqInPriceLevel(before func(), in func(), after func()) {
-	Upgrade(FixOrderSeqInPriceLevelName, before, in, after)
+	sdk.Upgrade(FixOrderSeqInPriceLevelName, before, in, after)
 }
 
 func FixDropFilledOrderSeq(before func(), after func()) {
-	Upgrade(FixDropFilledOrderSeqName, before, nil, after)
+	sdk.Upgrade(FixDropFilledOrderSeqName, before, nil, after)
 }


### PR DESCRIPTION
### Description

clear val cache when reach the UpgradeHeight

### Rationale

### Example

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

