### PR TITLE
[R4R] change order creatation time and lastupdate time to nanosecond

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -112,7 +112,7 @@
     "x/stake/types",
   ]
   pruneopts = "UT"
-  revision = "66938107ebd9339b51f3aaf7d235d9280fd7bac5"
+  revision = "cd11938ac61bbad08dfd4f1515d5fcd5023c7bab"
   source = "github.com/binance-chain/bnc-cosmos-sdk"
 
 [[projects]]

--- a/app/app.go
+++ b/app/app.go
@@ -245,7 +245,6 @@ func NewBinanceChain(logger log.Logger, db dbm.DB, traceStore io.Writer, baseApp
 func (app *BinanceChain) setUpgradeConfig() {
 	upgrade.Mgr.AddUpgradeHeight(upgrade.FixOrderSeqInPriceLevelName, app.upgradeConfig.FixOrderSeqInPriceLevelHeight)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.FixDropFilledOrderSeqName, app.upgradeConfig.FixDropFilledOrderSeqHeight)
-	upgrade.Mgr.AddUpgradeHeight(upgrade.FixOrderTimestampName, app.upgradeConfig.FixOrderTimestampHeight)
 }
 
 func (app *BinanceChain) initDex(pairMapper dex.TradingPairMapper) {

--- a/common/upgrade/upgrade.go
+++ b/common/upgrade/upgrade.go
@@ -9,7 +9,6 @@ var Mgr = sdk.UpgradeMgr
 // improvement: (maybe bip ?)
 const FixOrderSeqInPriceLevelName = "fixOrderSeqInPriceLevel"
 const FixDropFilledOrderSeqName = "fixDropFilledOrderSeq"
-const FixOrderTimestampName = "fixOrderTimestamp"
 
 func FixOrderSeqInPriceLevel(before func(), in func(), after func()) {
 	sdk.Upgrade(FixOrderSeqInPriceLevelName, before, in, after)
@@ -17,10 +16,4 @@ func FixOrderSeqInPriceLevel(before func(), in func(), after func()) {
 
 func FixDropFilledOrderSeq(before func(), after func()) {
 	sdk.Upgrade(FixDropFilledOrderSeqName, before, nil, after)
-}
-
-func FixOrderTimestamp(before func(), after func()) {
-	// deliberately not rebuild data here because rebuild means we need iterate all open orders
-	// and update their timestamps
-	sdk.Upgrade(FixOrderTimestampName, before, nil, after)
 }

--- a/networks/publisher/ordergen.sh
+++ b/networks/publisher/ordergen.sh
@@ -43,10 +43,10 @@ do
     pause=$(random 5 7)
     symbolNum=$(random 1 10)
 
-    symbol="NNB-DB5_BNB"
+    symbol="NNB-3DE_BNB"
     if [ $symbolNum -lt 4 ]
     then
-        symbol="NNB-DB5_BNB"
+        symbol="NNB-3DE_BNB"
     fi
 
     from="zc"

--- a/networks/publisher/setup.sh
+++ b/networks/publisher/setup.sh
@@ -49,7 +49,6 @@ sed -i -e "s/publishOrderBook = false/publishOrderBook = true/g" ${deamonhome}/c
 sed -i -e "s/publishBlockFee = false/publishBlockFee = true/g" ${deamonhome}/config/app.toml
 sed -i -e "s/publishTransfer = false/publishTransfer = true/g" ${deamonhome}/config/app.toml
 sed -i -e "s/publishLocal = false/publishLocal = true/g" ${deamonhome}/config/app.toml
-sed -i -e 's/"voting_period": "1209600000000000"/"voting_period": "5000000000"/g' ${deamonhome}/config/genesis.json
 
 # config witness node
 cp ${deamonhome}/config/genesis.json ${witnesshome}/config/
@@ -86,7 +85,8 @@ result=$(${cli} token issue --from=zc --token-name="New BNB Coin" --symbol=NNB -
 nnb_symbol=$(echo "${result}" | tail -n 1 | grep -o "NNB-[0-9A-Z]*")
 echo ${nnb_symbol}
 sleep 5
-${cli} gov submit-list-proposal --chain-id ${chain_id} --from zc --deposit 200000000000:BNB --base-asset-symbol ${nnb_symbol} --quote-asset-symbol BNB --init-price 1000000000 --title "list NNB/BNB" --description "list NNB/BNB" --expire-time 1644486400 --json
+((expire_time=$(date '+%s')+1000))
+${cli} gov submit-list-proposal --chain-id ${chain_id} --from zc --deposit 200000000000:BNB --base-asset-symbol ${nnb_symbol} --quote-asset-symbol BNB --init-price 1000000000 --title "list NNB/BNB" --description "list NNB/BNB" --expire-time ${expire_time} --voting-period 5 --json
 sleep 2
 ${cli} gov vote --from zc --chain-id ${chain_id} --proposal-id 1 --option Yes --json
 sleep 6
@@ -96,7 +96,8 @@ result=$(${cli} token issue --from=zc --token-name="ZC Coin" --symbol=ZCB --tota
 zcb_symbol=$(echo "${result}" | tail -n 1 | grep -o "ZCB-[0-9A-Z]*")
 echo ${zcb_symbol}
 sleep 5
-${cli} gov submit-list-proposal --chain-id ${chain_id} --from zc --deposit 200000000000:BNB --base-asset-symbol ${zcb_symbol} --quote-asset-symbol BNB --init-price 1000000000 --title "list NNB/BNB" --description "list NNB/BNB" --expire-time 1644486400 --json
+((expire_time=$(date '+%s')+1000))
+${cli} gov submit-list-proposal --chain-id ${chain_id} --from zc --deposit 200000000000:BNB --base-asset-symbol ${zcb_symbol} --quote-asset-symbol BNB --init-price 1000000000 --title "list NNB/BNB" --description "list NNB/BNB" --expire-time ${expire_time} --voting-period 5 --json
 sleep 2
 ${cli} gov vote --from zc --chain-id ${chain_id} --proposal-id 2 --option Yes --json
 sleep 6

--- a/plugins/dex/order/handler.go
+++ b/plugins/dex/order/handler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/binance-chain/node/common/fees"
 	"github.com/binance-chain/node/common/log"
 	common "github.com/binance-chain/node/common/types"
-	"github.com/binance-chain/node/common/upgrade"
 	me "github.com/binance-chain/node/plugins/dex/matcheng"
 	"github.com/binance-chain/node/plugins/dex/store"
 	"github.com/binance-chain/node/plugins/dex/types"
@@ -156,12 +155,7 @@ func handleNewOrder(
 		if txHash, ok := ctx.Value(baseapp.TxHashKey).(string); ok {
 			blockHeader := ctx.BlockHeader()
 			height := blockHeader.Height
-			var timestamp int64
-			upgrade.FixOrderTimestamp(func() {
-				timestamp = blockHeader.Time.Unix()
-			}, func() {
-				timestamp = blockHeader.Time.UnixNano()
-			})
+			timestamp := blockHeader.Time.UnixNano()
 			msg := OrderInfo{
 				msg,
 				height, timestamp,

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -668,12 +668,7 @@ func (kp *Keeper) MatchAndAllocateAll(
 	postAlloTransHandler TransferHandler,
 ) {
 	bnclog.Debug("Start Matching for all...", "symbolNum", len(kp.roundOrders))
-	var timestamp int64
-	upgrade.FixOrderTimestamp(func() {
-		timestamp = ctx.BlockHeader().Time.Unix()
-	}, func() {
-		timestamp = ctx.BlockHeader().Time.UnixNano()
-	})
+	timestamp := ctx.BlockHeader().Time.UnixNano()
 	tradeOuts := kp.matchAndDistributeTrades(true, ctx.BlockHeight(), timestamp)
 	if tradeOuts == nil {
 		kp.logger.Info("No order comes in for the block")

--- a/plugins/dex/order/keeper_recovery.go
+++ b/plugins/dex/order/keeper_recovery.go
@@ -189,12 +189,7 @@ func (kp *Keeper) replayOneBlocks(logger log.Logger, block *tmtypes.Block, txDB 
 		return
 	}
 	// the time we replay should be consistent with ctx.BlockHeader().Time
-	var t int64
-	upgrade.FixOrderTimestamp(func() {
-		t = timestamp.Unix()
-	}, func() {
-		t = timestamp.UnixNano()
-	})
+	t := timestamp.UnixNano()
 	for _, txBytes := range block.Txs {
 		txHash := cmn.HexBytes(tmhash.Sum(txBytes))
 		skipTxResultCheck := false


### PR DESCRIPTION
### Description

change order creatation time and lastupdate time to nanosecond

### Rationale

query service process

### Example

N/A

### Changes

### Preflight checks

- [x] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

