### PR TITLE
setUpgradeConfig before all other initializations

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -122,6 +122,8 @@ func NewBinanceChain(logger log.Logger, db dbm.DB, traceStore io.Writer, baseApp
 		upgradeConfig:     ServerContext.UpgradeConfig,
 		publicationConfig: ServerContext.PublicationConfig,
 	}
+	// set upgrade config
+	app.setUpgradeConfig()
 	app.SetPruning(viper.GetString("pruning"))
 	app.SetCommitMultiStoreTracer(traceStore)
 
@@ -229,10 +231,7 @@ func NewBinanceChain(logger log.Logger, db dbm.DB, traceStore io.Writer, baseApp
 	if err != nil {
 		cmn.Exit(err.Error())
 	}
-
-	// set upgrade config
-	app.setUpgradeConfig()
-
+	
 	// remaining plugin init
 	app.initDex(tradingPairMapper)
 	app.initPlugins()


### PR DESCRIPTION
### Description

some components' initialization depends on the UpgradeHeight, so we need to set the upgrade config first. otherwise, the default upgrade height would be applied and the initialization logic may be wrong

### Rationale

### Example

### Changes

Notable changes: 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

