### PR TITLE
[R4R] fee configuration for mainnet

### DIFF
--- a/plugins/param/genesis.go
+++ b/plugins/param/genesis.go
@@ -18,8 +18,8 @@ const (
 	// Operate fee
 	ProposeFee = 10e8
 	DepositFee = 125e3
-	ListingFee = 800e8
-	IssueFee   = 400e8
+	ListingFee = 2000e8
+	IssueFee   = 1000e8
 	MintFee    = 200e8
 	BurnFee    = 1e8
 	FreezeFee  = 1e6


### PR DESCRIPTION
### Description

Reduce the transfer/cancel/expire fee by half for mainnet, the base is the config in our testnet.


### Rationale

### Example

### Changes

Notable changes: 
* 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

