### PR TITLE
finalize the genesis staking params for mainnet

### DIFF
--- a/app/genesis.go
+++ b/app/genesis.go
@@ -24,14 +24,14 @@ import (
 const DefaultKeyPass = "12345678"
 
 var (
-	// each genesis validators will self delegate 1000e8 native tokens to become a validator
-	DefaultSelfDelegationToken = sdk.NewCoin(types.NativeTokenSymbol, 1000e8)
+	// each genesis validators will self delegate 10000e8 native tokens to become a validator
+	DefaultSelfDelegationToken = sdk.NewCoin(types.NativeTokenSymbol, 10000e8)
 	// we put 20% of the total supply to the stake pool
-	DefaultMaxBondedTokenAmount int64 = types.NativeTokenTotalSupply / 5
+	DefaultMaxBondedTokenAmount int64 = types.NativeTokenTotalSupply
 	// set default unbonding duration to 7 days
 	DefaultUnbondingTime = 60 * 60 * 24 * 7 * time.Second
-	// default max validators to 15
-	DefaultMaxValidators uint16 = 15
+	// default max validators to 21
+	DefaultMaxValidators uint16 = 21
 
 	// min gov deposit
 	DefaultGovMinDesposit = sdk.Coins{sdk.NewCoin(types.NativeTokenSymbol, 1000e8)}


### PR DESCRIPTION
### Description

Genesis validators' self delegation: 10000BNB
MaxValidator: 21
LooseToken: 200m

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

