### PR TITLE
[R4R] #476 enhancement essential log for query service efficient processing

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -689,6 +689,8 @@ func (app *BinanceChain) publish(tradesToPublish []*pub.Trade, proposalsToPublis
 		len(app.DexKeeper.OrderChanges),
 		"numOfProposals",
 		proposalsToPublish.NumOfMsgs,
+		"numOfStakeUpdates",
+		stakeUpdates.NumOfMsgs,
 		"numOfAccounts",
 		len(accountsToPublish))
 	pub.ToRemoveOrderIdCh = make(chan string, pub.ToRemoveOrderIdChannelSize)


### PR DESCRIPTION
# as DJ requested this should be released after mainnet launch
# @erhenglu need aware about this change

### Description

1. only log expire id (and fee), publish other types of order, proposals, stakeupdates in kafka message
2. add fee, account address with same line of order id: orderid<space>address<space>fee
3. add new line (blocktime in nanosecond) below height

### Rationale

tell us why we need these changes...

### Example

```
height:600
time:1555332663751976000
orders:
1E75316134703318D4F6607399B281AF4BD3EC2B-20 bnb1re6nzcf5wqe3348kvpeenv5p4a9a8mpt0tny0g BNB:50000;#Exp:5
1E75316134703318D4F6607399B281AF4BD3EC2B-29 bnb1re6nzcf5wqe3348kvpeenv5p4a9a8mpt0tny0g 
1E75316134703318D4F6607399B281AF4BD3EC2B-38 bnb1re6nzcf5wqe3348kvpeenv5p4a9a8mpt0tny0g 
1E75316134703318D4F6607399B281AF4BD3EC2B-47 bnb1re6nzcf5wqe3348kvpeenv5p4a9a8mpt0tny0g 
1E75316134703318D4F6607399B281AF4BD3EC2B-56 bnb1re6nzcf5wqe3348kvpeenv5p4a9a8mpt0tny0g 
4F0DA1F5AA8FBD80A4240EE43822FF73550C9DA9-30 bnb1fux6rad2377cpfpypmjrsghlwd2se8dfr0r6g7 BNB:50000;#Exp:5
4F0DA1F5AA8FBD80A4240EE43822FF73550C9DA9-39 bnb1fux6rad2377cpfpypmjrsghlwd2se8dfr0r6g7 
4F0DA1F5AA8FBD80A4240EE43822FF73550C9DA9-48 bnb1fux6rad2377cpfpypmjrsghlwd2se8dfr0r6g7 
4F0DA1F5AA8FBD80A4240EE43822FF73550C9DA9-57 bnb1fux6rad2377cpfpypmjrsghlwd2se8dfr0r6g7 
4F0DA1F5AA8FBD80A4240EE43822FF73550C9DA9-66 bnb1fux6rad2377cpfpypmjrsghlwd2se8dfr0r6g7 
```

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

