### PR TITLE
[R4R] remove indirect dependency btcd in gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,10 +45,6 @@
   version = "=v0.25.0-binance.17"
 
 [[constraint]]
-  name = "github.com/btcsuite/btcd"
-  revision = "ed77733ec07dfc8a513741138419b8d9d3de9d2d"
-
-[[constraint]]
   name = "github.com/pkg/errors"
   version = "0.8.0"
 


### PR DESCRIPTION
### Description

remove indirect dependency btcd in gopkg.toml, but leave it in gopkg.lock

### Rationale

dep ensure will have the following warning:

> Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:
>  ✗  github.com/btcsuite/btcd
> However, these projects are not direct dependencies of the current project:
> they are not imported in any .go files, nor are they in the 'required' list in
> Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
> these rules will have no effect.

Either import/require packages from these projects so that they become direct
dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
on these projects, if they happen to be transitive dependencies.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

