### PR TITLE
Makefile: add -w -s ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TENDER_RELEASE := $(shell grep 'github.com/tendermint/tendermint' Gopkg.toml -n2
 
 BUILD_TAGS = netgo
 BUILD_CLI_TAGS = netgo
-BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags "-X github.com/binance-chain/node/version.GitCommit=${COMMIT_HASH} -X github.com/binance-chain/node/version.CosmosRelease=${COSMOS_RELEASE} -X github.com/binance-chain/node/version.TendermintRelease=${TENDER_RELEASE}"
+BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags "-w -s -X github.com/binance-chain/node/version.GitCommit=${COMMIT_HASH} -X github.com/binance-chain/node/version.CosmosRelease=${COSMOS_RELEASE} -X github.com/binance-chain/node/version.TendermintRelease=${TENDER_RELEASE}"
 BUILD_CLI_FLAGS = -tags "${BUILD_CLI_TAGS}" -ldflags "-X github.com/binance-chain/node/version.GitCommit=${COMMIT_HASH} -X github.com/binance-chain/node/version.CosmosRelease=${COSMOS_RELEASE} -X github.com/binance-chain/node/version.TendermintRelease=${TENDER_RELEASE}"
 # Without -lstdc++ on CentOS we will encounter link error, solution comes from: https://stackoverflow.com/a/29285011/1147187
 BUILD_CGOFLAGS = CGO_ENABLED=1 CGO_LDFLAGS="-lleveldb -lsnappy -lstdc++"


### PR DESCRIPTION
https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick

### Rationale

Binaries are much smaller!

Original:
```
➜  node git:(master) ✗ ls -lah build_original
total 427360
drwxr-xr-x   8 luke  staff   256B Jun  3 15:40 .
drwxr-xr-x  27 luke  staff   864B Jun  3 15:44 ..
-rwxr-xr-x   1 luke  staff    41M Jun  3 15:39 bnbchaind
-rwxr-xr-x   1 luke  staff    35M Jun  3 15:39 bnbcli
-rwxr-xr-x   1 luke  staff    36M Jun  3 15:39 bnbsentry
-rwxr-xr-x   1 luke  staff    26M Jun  3 15:40 lightd
-rwxr-xr-x   1 luke  staff    35M Jun  3 15:39 pressuremaker
-rwxr-xr-x   1 luke  staff    35M Jun  3 15:39 tbnbcli
```

Without debug symbols (stripped):
```
➜  node git:(master) ✗ ls -lah build
total 331080
drwxr-xr-x   8 luke  staff   256B Jun  3 15:41 .
drwxr-xr-x  27 luke  staff   864B Jun  3 15:44 ..
-rwxr-xr-x   1 luke  staff    29M Jun  3 15:41 bnbchaind
-rwxr-xr-x   1 luke  staff    25M Jun  3 15:41 bnbcli
-rwxr-xr-x   1 luke  staff    25M Jun  3 15:41 bnbsentry
-rwxr-xr-x   1 luke  staff    22M Jun  3 15:41 lightd
-rwxr-xr-x   1 luke  staff    25M Jun  3 15:41 pressuremaker
-rwxr-xr-x   1 luke  staff    35M Jun  3 15:41 tbnbcli
```