### PR TITLE
[R4R] hotfix statesync for paramhub change in breathe block is not loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.10
+BUG FIXES
+
+* [\#602](https://github.com/binance-chain/node/pull/602) [StateSync] Fix paramhub change in breathe block is not loaded
 
 ## 0.5.9
 

--- a/app/statesync_helper.go
+++ b/app/statesync_helper.go
@@ -153,6 +153,7 @@ func (app *BinanceChain) EndRecovery(height int64) error {
 
 	// TODO: sync the breathe block on state sync and just call app.DexKeeper.Init() to recover order book and recentPrices to memory
 	app.resetDexKeeper(height)
+	app.initParams()
 
 	// init app cache
 	accountStore := stores.GetKVStore(common.AccountStoreKey)

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "0.5.9"
+const NodeVersion = "0.5.10"
 
 func init() {
 	Version = fmt.Sprintf("Binance Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

hotfix statesync for paramhub change in breathe block is not loaded

@HaoyangLiu found after we update fee on 2019-06-13 breathe block (12701892), the state sync break on the block follows synced breathe block (12701893). 
I compared log of local publisher with disaster node, it was because new applied fee proposal didn't reloaded after state sync (so it keep the genesis ones) 

This bug only impact newly joined state sync fullnode from height 12701892, existing fullnodes (no matter sync from beginning or state sync doesn't effected)

```
./bnbchaind --home ~/.bnbchaind_statesync_prod start --pruning breathepanic: Failed to process committed block (12701894
:7FD1B55BC2C3DA8A91F85856C28DFE7EC5EC5CCE01F7A5217A795C49D0F2AABB): Wrong Block.Header.AppHash.  Expected C0E633FD6976C2743EF2F61D2A5FEF53D9A7A407F8568D01701D1FC8D584D5F7, got 81F8BBAF3C91C77415B0F3AC2AC310
11ED749696A5BF184B9351325F33A7E777

goroutine 349 [running]:
github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/blockchain.(*BlockchainReactor).poolRoutine(0xc002964000)
        /Users/huangsuyu/go/src/github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/blockchain/reactor.go:375 +0x1ced
created by github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/blockchain.(*BlockchainReactor).SwitchToBlockchain
        /Users/huangsuyu/go/src/github.com/binance-chain/node/vendor/github.com/tendermint/tendermint/blockchain/reactor.go:144 +0x326
```
### Rationale

tell us why we need these changes...

### Example

N/A

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

