### PR TITLE
add upgrade config for bep19

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -248,6 +248,7 @@ func (app *BinanceChain) setUpgradeConfig() {
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP6, app.upgradeConfig.BEP6Height)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP9, app.upgradeConfig.BEP9Height)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP10, app.upgradeConfig.BEP10Height)
+	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP19, app.upgradeConfig.BEP10Height)
 
 	// register store keys of upgrade
 	upgrade.Mgr.RegisterStoreKeys(upgrade.BEP9, common.TimeLockStoreKey.Name())

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -53,6 +53,8 @@ BEP6Height = {{ .UpgradeConfig.BEP6Height }}
 BEP9Height = {{ .UpgradeConfig.BEP9Height }}
 # Block height of BEP10 upgrade
 BEP10Height = {{ .UpgradeConfig.BEP10Height }} 
+# Block height of UpgradeMatchEngineHeight upgrade
+BEP19Height = {{ .UpgradeConfig.BEP19Height }}
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
@@ -294,13 +296,15 @@ type UpgradeConfig struct {
 	BEP6Height  int64 `mapstructure:"BEP6Height"`
 	BEP9Height  int64 `mapstructure:"BEP9Height"`
 	BEP10Height int64 `mapstructure:"BEP10Height"`
+	BEP19Height int64 `mapstructure:"BEP19Height"`
 }
 
 func defaultUpgradeConfig() *UpgradeConfig {
 	return &UpgradeConfig{
-		BEP6Height:  1,
-		BEP9Height:  1, //TODO change default when update
+		BEP6Height:  math.MaxInt64,
+		BEP9Height:  math.MaxInt64, //TODO change default when update
 		BEP10Height: math.MaxInt64,
+		BEP19Height: math.MaxInt64,
 	}
 }
 

--- a/common/upgrade/upgrade.go
+++ b/common/upgrade/upgrade.go
@@ -7,9 +7,12 @@ var Mgr = sdk.UpgradeMgr
 // prefix for the upgrade name
 // bugfix: fix
 // improvement: (maybe bep ?)
+
+// Galileo Upgrade
 const BEP6 = "BEP6"   // https://github.com/binance-chain/BEPs/pull/6
 const BEP9 = "BEP9"   // https://github.com/binance-chain/BEPs/pull/9
 const BEP10 = "BEP10" // https://github.com/binance-chain/BEPs/pull/10
+const BEP19 = "BEP19" // https://github.com/binance-chain/BEPs/pull/19  match engine revision
 
 func UpgradeBEP10(before func(), after func()) {
 	sdk.Upgrade(BEP10, before, nil, after)

--- a/plugins/dex/matcheng/engine_new.go
+++ b/plugins/dex/matcheng/engine_new.go
@@ -6,17 +6,17 @@ import (
 
 	"github.com/pkg/errors"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/binance-chain/node/common/upgrade"
 	"github.com/binance-chain/node/common/utils"
 )
 
-// TODO: add upgrade config in a separate PR.
-const upgradeHeight = 1
-
 func (me *MatchEng) Match(height int64) bool {
-	if height < upgradeHeight {
+	if !sdk.IsUpgrade(upgrade.BEP19) {
 		return me.MatchBeforeGalileo()
 	}
-
+	me.logger.Debug("match starts...", "height", height)
 	me.Trades = me.Trades[:0]
 	r := me.Book.GetOverlappedRange(&me.overLappedLevel, &me.buyBuf, &me.sellBuf)
 	if r <= 0 {

--- a/plugins/dex/matcheng/match_new_test.go
+++ b/plugins/dex/matcheng/match_new_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/binance-chain/node/common/upgrade"
 )
 
 func Test_dropRedundantQty(t *testing.T) {
@@ -867,7 +869,7 @@ func TestMatchEng_fillOrdersNew(t *testing.T) {
 		SellOrders:        makerSideOrders[:1],
 		SellTakerStartIdx: 1,
 		SellMakerTotal:    0,
-	},{
+	}, {
 		Price:             90,
 		SellOrders:        makerSideOrders[1:],
 		SellTakerStartIdx: 1,
@@ -900,6 +902,8 @@ func TestMatchEng_fillOrdersNew(t *testing.T) {
 }
 
 func TestMatchEng_Match(t *testing.T) {
+	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP19, 1)
+
 	assert := assert.New(t)
 	me := NewMatchEng(DefaultPairSymbol, 100, 5, 0.05)
 	me.Book = NewOrderBookOnULList(4, 2)
@@ -918,6 +922,7 @@ func TestMatchEng_Match(t *testing.T) {
 	me.Book.InsertOrder("14", BUYSIDE, 100, 100, 10)
 	me.Book.InsertOrder("16", BUYSIDE, 100, 100, 20)
 
+	upgrade.Mgr.SetHeight(100)
 	assert.True(me.Match(100))
 	assert.Equal(4, len(me.overLappedLevel))
 	assert.Equal(int64(100), me.LastTradePrice)

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -18,6 +18,7 @@ import (
 	"github.com/binance-chain/node/common/fees"
 	bnclog "github.com/binance-chain/node/common/log"
 	"github.com/binance-chain/node/common/types"
+	"github.com/binance-chain/node/common/upgrade"
 	"github.com/binance-chain/node/common/utils"
 	me "github.com/binance-chain/node/plugins/dex/matcheng"
 	"github.com/binance-chain/node/plugins/dex/store"
@@ -530,8 +531,7 @@ func (kp *Keeper) StoreTradePrices(ctx sdk.Context) {
 
 func (kp *Keeper) allocate(ctx sdk.Context, tranCh <-chan Transfer, postAllocateHandler func(tran Transfer)) (
 	types.Fee, map[string]*types.Fee) {
-	// TODO: add upgrade config in a separate PR
-	if ctx.BlockHeader().Height < 1 {
+	if !sdk.IsUpgrade(upgrade.BEP19) {
 		return kp.allocateBeforeGalileo(ctx, tranCh, postAllocateHandler)
 	}
 

--- a/plugins/dex/order/transfer_test.go
+++ b/plugins/dex/order/transfer_test.go
@@ -1,14 +1,10 @@
 package order
 
 import (
-	"fmt"
-	"github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/require"
-	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
-
-
 
 func TestTradeTransfers_Sort(t *testing.T) {
 	e := TradeTransfers {


### PR DESCRIPTION
### Description

add upgrade height for bep19 which including match engine and fee calculation revision

### Rationale

for Galileo upgrade

### Example

### Changes

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

