### PR TITLE
[R4R] node repo fix for state sync snapshot command

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -117,7 +117,7 @@ func NewBinanceChain(logger log.Logger, db dbm.DB, traceStore io.Writer, baseApp
 		publicationConfig: ServerContext.PublicationConfig,
 	}
 	// set upgrade config
-	app.setUpgradeConfig()
+	SetUpgradeConfig(app.upgradeConfig)
 	app.initRunningMode()
 	app.SetCommitMultiStoreTracer(traceStore)
 
@@ -243,8 +243,22 @@ func NewBinanceChain(logger log.Logger, db dbm.DB, traceStore io.Writer, baseApp
 }
 
 // setUpgradeConfig will overwrite default upgrade config
-func (app *BinanceChain) setUpgradeConfig() {
-	app.upgradeConfig.SetUpgradeConfig()
+func SetUpgradeConfig(upgradeConfig *config.UpgradeConfig) {
+	// register upgrade height
+	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP6, upgradeConfig.BEP6Height)
+	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP9, upgradeConfig.BEP9Height)
+	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP10, upgradeConfig.BEP10Height)
+	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP19, upgradeConfig.BEP19Height)
+
+	// register store keys of upgrade
+	upgrade.Mgr.RegisterStoreKeys(upgrade.BEP9, common.TimeLockStoreKey.Name())
+
+	// register msg types of upgrade
+	upgrade.Mgr.RegisterMsgTypes(upgrade.BEP9,
+		timelock.TimeLockMsg{}.Type(),
+		timelock.TimeRelockMsg{}.Type(),
+		timelock.TimeUnlockMsg{}.Type(),
+	)
 }
 
 func (app *BinanceChain) initRunningMode() {

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -12,10 +12,6 @@ import (
 	"github.com/tendermint/tendermint/libs/common"
 
 	"github.com/cosmos/cosmos-sdk/server"
-
-	commonPkg "github.com/binance-chain/node/common"
-	"github.com/binance-chain/node/common/upgrade"
-	"github.com/binance-chain/node/plugins/tokens/timelock"
 )
 
 var configTemplate *template.Template
@@ -310,25 +306,6 @@ func defaultUpgradeConfig() *UpgradeConfig {
 		BEP10Height: math.MaxInt64,
 		BEP19Height: math.MaxInt64,
 	}
-}
-
-// setUpgradeConfig will overwrite default upgrade config
-func (upgradeConfig UpgradeConfig) SetUpgradeConfig() {
-	// register upgrade height
-	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP6, upgradeConfig.BEP6Height)
-	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP9, upgradeConfig.BEP9Height)
-	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP10, upgradeConfig.BEP10Height)
-	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP19, upgradeConfig.BEP19Height)
-
-	// register store keys of upgrade
-	upgrade.Mgr.RegisterStoreKeys(upgrade.BEP9, commonPkg.TimeLockStoreKey.Name())
-
-	// register msg types of upgrade
-	upgrade.Mgr.RegisterMsgTypes(upgrade.BEP9,
-		timelock.TimeLockMsg{}.Type(),
-		timelock.TimeRelockMsg{}.Type(),
-		timelock.TimeUnlockMsg{}.Type(),
-	)
 }
 
 func (context *BinanceChainContext) ParseAppConfigInPlace() error {

--- a/cmd/bnbchaind/init/snapshot.go
+++ b/cmd/bnbchaind/init/snapshot.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/binance-chain/node/app"
 	configPkg "github.com/binance-chain/node/app/config"
 	"github.com/binance-chain/node/common"
 )
@@ -36,7 +37,7 @@ func SnapshotCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 			config.SetRoot(viper.GetString(cli.HomeFlag))
 			appCtx := configPkg.NewDefaultContext()
 			appCtx.ParseAppConfigInPlace()
-			appCtx.BinanceChainConfig.UpgradeConfig.SetUpgradeConfig()
+			app.SetUpgradeConfig(appCtx.BinanceChainConfig.UpgradeConfig)
 
 			logger.Info("setup block db")
 			blockDB, err := node.DefaultDBProvider(&node.DBContext{"blockstore", config})


### PR DESCRIPTION
### Description

node repo fix for https://github.com/binance-chain/bnc-cosmos-sdk/pull/150

### Rationale

move set upgrade to upgrade config's method so that utility tools can override upgrade config

### Example

N/A

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

