### PR TITLE
add LastMatchHeight in match engine

### DIFF
--- a/plugins/dex/matcheng/engine_new.go
+++ b/plugins/dex/matcheng/engine_new.go
@@ -14,7 +14,7 @@ import (
 
 func (me *MatchEng) Match(height int64) bool {
 	if !sdk.IsUpgrade(upgrade.BEP19) {
-		return me.MatchBeforeGalileo()
+		return me.MatchBeforeGalileo(height)
 	}
 	me.logger.Debug("match starts...", "height", height)
 	me.Trades = me.Trades[:0]
@@ -41,6 +41,7 @@ func (me *MatchEng) Match(height int64) bool {
 	surplus := me.overLappedLevel[index].BuySellSurplus
 	me.fillOrdersNew(takerSide, takerSideOrders, index, tradePrice, surplus)
 	me.LastTradePrice = tradePrice
+	me.LastMatchHeight = height
 	return true
 }
 

--- a/plugins/dex/matcheng/match_test.go
+++ b/plugins/dex/matcheng/match_test.go
@@ -773,7 +773,7 @@ func TestMatchEng_MatchDeprecated(t *testing.T) {
 	me.Book.InsertOrder("91", BUYSIDE, 107, 100, 50)
 	me.Book.InsertOrder("92", SELLSIDE, 108, 90, 50)
 
-	assert.True(me.MatchBeforeGalileo())
+	assert.True(me.MatchBeforeGalileo(1))
 	assert.Equal(3, len(me.overLappedLevel))
 	assert.Equal(int64(98), me.LastTradePrice)
 	assert.Equal("[{92 98 50 50 50 1 0} {3 98 80 80 80 2 0} {3 98 20 20 100 4 0} {5 98 50 50 50 6 0} {5 98 50 50 100 91 0} {9 98 50 50 50 8 0}]", fmt.Sprint(me.Trades))
@@ -789,7 +789,7 @@ func TestMatchEng_MatchDeprecated(t *testing.T) {
 	me.Book.InsertOrder("9", SELLSIDE, 106, 101, 50)
 	me.Book.InsertOrder("91", BUYSIDE, 107, 100, 50)
 	me.Book.InsertOrder("92", SELLSIDE, 108, 102, 50)
-	assert.True(me.MatchBeforeGalileo())
+	assert.True(me.MatchBeforeGalileo(1))
 	assert.Equal(0, len(me.overLappedLevel))
 	assert.Equal(0, len(me.Trades))
 
@@ -799,7 +799,7 @@ func TestMatchEng_MatchDeprecated(t *testing.T) {
 	me.Book.InsertOrder("1", BUYSIDE, 102, 100, 100)
 	me.Book.InsertOrder("8", BUYSIDE, 103, 99, 100)
 
-	assert.True(me.MatchBeforeGalileo())
+	assert.True(me.MatchBeforeGalileo(1))
 	assert.Equal(3, len(me.overLappedLevel))
 	assert.Equal("[{3 99 100 100 100 1 0} {5 99 100 100 100 8 0}]", fmt.Sprint(me.Trades))
 
@@ -815,7 +815,7 @@ func TestMatchEng_MatchDeprecated(t *testing.T) {
 	me.Book.InsertOrder("91", BUYSIDE, 107, 100, 50)
 	me.Book.InsertOrder("92", SELLSIDE, 108, 97, 50)
 
-	assert.True(me.MatchBeforeGalileo())
+	assert.True(me.MatchBeforeGalileo(1))
 	assert.Equal(3, len(me.overLappedLevel))
 	assert.Equal("[{92 98 50 50 50 1 0} {3 98 80 80 80 2 0} {3 98 20 20 100 4 0} {5 98 50 50 50 6 0} {5 98 50 50 100 91 0}]", fmt.Sprint(me.Trades))
 
@@ -843,7 +843,7 @@ func TestMatchEng_MatchDeprecated(t *testing.T) {
 	me.Book.InsertOrder("92", SELLSIDE, 105, 100, 100)
 	me.Book.InsertOrder("93", BUYSIDE, 105, 100, 300)
 
-	assert.True(me.MatchBeforeGalileo())
+	assert.True(me.MatchBeforeGalileo(1))
 	t.Log(me.overLappedLevel)
 	assert.Equal(6, len(me.overLappedLevel))
 	assert.Equal(int64(100), me.LastTradePrice)
@@ -879,7 +879,7 @@ func TestMatchEng_DropFilledOrder(t *testing.T) {
 	me.Book.InsertOrder("92", SELLSIDE, 105, 100, 100)
 	me.Book.InsertOrder("93", BUYSIDE, 105, 100, 300)
 
-	assert.True(me.MatchBeforeGalileo())
+	assert.True(me.MatchBeforeGalileo(1))
 	t.Log(me.overLappedLevel)
 	assert.Equal(6, len(me.overLappedLevel))
 	assert.Equal(int64(100), me.LastTradePrice)

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -465,6 +465,16 @@ func (kp *Keeper) GetPriceLevel(pair string, side int8, price int64) *me.PriceLe
 	}
 }
 
+func (kp *Keeper) GetLastTrades(height int64, pair string) ([]me.Trade, int64) {
+	if eng, ok := kp.engines[pair]; ok {
+		if eng.LastMatchHeight == height {
+			return eng.Trades, eng.LastTradePrice
+		}
+	}
+	return nil, 0
+}
+
+// !!! FOR TEST USE ONLY
 func (kp *Keeper) GetLastTradesForPair(pair string) ([]me.Trade, int64) {
 	if eng, ok := kp.engines[pair]; ok {
 		return eng.Trades, eng.LastTradePrice


### PR DESCRIPTION
### Description

as titled.  when matching finished, we record the height of this round of match.

### Rationale

we cannot tell the `Trades` in match engine belongs to which height. 
In this upgrade, publisher will use this  `Trades` as we need keeper the sequence.

### Example

### Changes

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

