### PR TITLE
[R4R] support avro evolve

### DIFF
--- a/app/pub/msgs.go
+++ b/app/pub/msgs.go
@@ -17,7 +17,7 @@ const (
 	booksTpe
 	executionResultTpe
 	blockFeeTpe
-	transferType
+	transferTpe
 )
 
 // the strings should be keep consistence with top level record name in schemas.go
@@ -32,11 +32,23 @@ func (this msgType) String() string {
 		return "ExecutionResults"
 	case blockFeeTpe:
 		return "BlockFee"
-	case transferType:
+	case transferTpe:
 		return "Transfers"
 	default:
 		return "Unknown"
 	}
+}
+
+// Versions of schemas
+// This field is used to generate last component of key in kafka message and helps consumers
+// figure out which version of writer schema to use.
+// This allows consumers be deployed independently (in advance) with publisher
+var latestSchemaVersions = map[msgType]int{
+	accountsTpe:        0,
+	booksTpe:           0,
+	executionResultTpe: 1,
+	blockFeeTpe:        0,
+	transferTpe:        0,
 }
 
 type AvroOrJsonMsg interface {

--- a/app/pub/publisher.go
+++ b/app/pub/publisher.go
@@ -247,7 +247,7 @@ func publishBlockFee(publisher MarketDataPublisher, height, timestamp int64, blo
 
 func publishTransfers(publisher MarketDataPublisher, height, timestamp int64, transfers *Transfers) {
 	if transfers != nil {
-		publisher.publish(transfers, transferType, height, timestamp)
+		publisher.publish(transfers, transferTpe, height, timestamp)
 	}
 }
 

--- a/app/pub/publisher_mock.go
+++ b/app/pub/publisher_mock.go
@@ -30,7 +30,7 @@ func (publisher *MockMarketDataPublisher) publish(msg AvroOrJsonMsg, tpe msgType
 		publisher.ExecutionResultsPublished = append(publisher.ExecutionResultsPublished, msg.(*ExecutionResults))
 	case blockFeeTpe:
 		publisher.BlockFeePublished = append(publisher.BlockFeePublished, msg.(BlockFee))
-	case transferType:
+	case transferTpe:
 		publisher.TransferPublished = append(publisher.TransferPublished, msg.(Transfers))
 	default:
 		panic(fmt.Errorf("does not support type %s", tpe.String()))

--- a/app/pub/schema_test.go
+++ b/app/pub/schema_test.go
@@ -105,7 +105,7 @@ func TestBlockFeeMarshaling(t *testing.T) {
 func TestTransferMarshaling(t *testing.T) {
 	publisher := NewKafkaMarketDataPublisher(Logger, "")
 	msg := Transfers{42, 20, 1000, []Transfer{{TxHash: "123456ABCDE", From: "", To: []Receiver{Receiver{"bnc1", []Coin{{"BNB", 100}, {"BTC", 100}}}, Receiver{"bnc2", []Coin{{"BNB", 200}, {"BTC", 200}}}}}}}
-	_, err := publisher.marshal(&msg, transferType)
+	_, err := publisher.marshal(&msg, transferTpe)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/app/pub/schemas.go
+++ b/app/pub/schemas.go
@@ -1,5 +1,14 @@
 package pub
 
+// !!!!!NOTE!!!!!
+// consumers should aware of changes in this file
+// update app/pub/msgs.go `latestSchemaVersions`
+// put old version into pub/schemas with version suffixed to filename for tracking historical version
+
+// Backward compatibility:
+// 1. publisher add field, consumer should initialize two decoder with two publisher schema, choose which decoded should be used by `lastestSchemaVersion` component in kafka message Key
+// 2. consumer add field, consumer should initialize one decode with publisher schema and consumer schema. In which, consumer schema should define default value for added field
+
 const (
 	executionResultSchema = `
 		{

--- a/app/pub/schemas/executionResults0.avsc
+++ b/app/pub/schemas/executionResults0.avsc
@@ -1,0 +1,132 @@
+{
+    "type": "record",
+    "name": "ExecutionResults",
+    "namespace": "org.binance.dex.model.avro",
+    "fields": [
+        { "name": "height", "type": "long" },
+        { "name": "timestamp", "type": "long" },
+        { "name": "numOfMsgs", "type": "int" },
+        { "name": "trades", "type": ["null", {
+            "type": "record",
+            "name": "Trades",
+            "namespace": "org.binance.dex.model.avro",
+            "fields": [
+                { "name": "numOfMsgs", "type": "int" },
+                { "name": "trades", "type": {
+                    "type": "array",
+                    "items":
+                        {
+                            "type": "record",
+                            "name": "Trade",
+                            "namespace": "org.binance.dex.model.avro",
+                            "fields": [
+                                { "name": "symbol", "type": "string" },
+                                { "name": "id", "type": "string" },
+                                { "name": "price", "type": "long" },
+                                { "name": "qty", "type": "long"	},
+                                { "name": "sid", "type": "string" },
+                                { "name": "bid", "type": "string" },
+                                { "name": "sfee", "type": "string" },
+                                { "name": "bfee", "type": "string" },
+                                { "name": "saddr", "type": "string" },
+                                { "name": "baddr", "type": "string" }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }], "default": null },
+        { "name": "orders", "type": ["null", {
+            "type": "record",
+            "name": "Orders",
+            "namespace": "org.binance.dex.model.avro",
+            "fields": [
+                { "name": "numOfMsgs", "type": "int" },
+                { "name": "orders", "type": {
+                    "type": "array",
+                    "items":
+                    {
+                        "type": "record",
+                        "name": "Order",
+                        "namespace": "org.binance.dex.model.avro",
+                        "fields": [
+                            { "name": "symbol", "type": "string" },
+                            { "name": "status", "type": "string" },
+                            { "name": "orderId", "type": "string" },
+                            { "name": "tradeId", "type": "string" },
+                            { "name": "owner", "type": "string" },
+                            { "name": "side", "type": "int" },
+                            { "name": "orderType", "type": "int" },
+                            { "name": "price", "type": "long" },
+                            { "name": "qty", "type": "long" },
+                            { "name": "lastExecutedPrice", "type": "long" },
+                            { "name": "lastExecutedQty", "type": "long" },
+                            { "name": "cumQty", "type": "long" },
+                            { "name": "fee", "type": "string" },
+                            { "name": "orderCreationTime", "type": "long" },
+                            { "name": "transactionTime", "type": "long" },
+                            { "name": "timeInForce", "type": "int" },
+                            { "name": "currentExecutionType", "type": "string" },
+                            { "name": "txHash", "type": "string" }
+                        ]
+                    }
+                   }
+                }
+            ]
+        }], "default": null },
+        { "name": "proposals", "type": ["null", {
+            "type": "record",
+            "name": "Proposals",
+            "namespace": "org.binance.dex.model.avro",
+            "fields": [
+                { "name": "numOfMsgs", "type": "int" },
+                { "name": "proposals", "type": {
+                    "type": "array",
+                    "items":
+                    {
+                        "type": "record",
+                        "name": "Proposal",
+                        "namespace": "org.binance.dex.model.avro",
+                        "fields": [
+                            { "name": "id", "type": "long" },
+                            { "name": "status", "type": "string" }
+                        ]
+                    }
+                   }
+                }
+            ]
+        }], "default": null },
+        { "name": "stakeUpdates", "type": ["null", {
+            "type": "record",
+            "name": "StakeUpdates",
+            "namespace": "org.binance.dex.model.avro",
+            "fields": [
+                { "name": "numOfMsgs", "type": "int" },
+                { "name": "completedUnbondingDelegations", "type": {
+                    "type": "array",
+                    "items":
+                    {
+                        "type": "record",
+                        "name": "CompletedUnbondingDelegation",
+                        "namespace": "org.binance.dex.model.avro",
+                        "fields": [
+                            { "name": "validator", "type": "string" },
+                            { "name": "delegator", "type": "string" },
+                            { "name": "amount", "type": {
+                                    "type": "record",
+                                    "name": "Coin",
+                                    "namespace": "org.binance.dex.model.avro",
+                                    "fields": [
+                                        { "name": "denom", "type": "string" },
+                                        { "name": "amount", "type": "long" }
+                                    ]
+                                }
+                            }
+                        ]
+                     }
+                   }
+                }
+            ]
+        }], "default": null }
+    ]
+}


### PR DESCRIPTION
### Description

support avro evolve
websocket change: https://github.com/binance-chain/websocket-ap/pull/93
### Rationale

support avro evolve, this PR allows upstream services evolve and deploy independently with publisher schema change.

### Example

N/A

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

