### PR TITLE
[R4R]abci: return error code when query orderbook that not exist

### DIFF
--- a/plugins/dex/abci.go
+++ b/plugins/dex/abci.go
@@ -90,6 +90,12 @@ func createAbciQueryHandler(keeper *DexKeeper) app.AbciQueryHandler {
 			pair := path[2]
 			height := app.GetContextForCheckState().BlockHeight()
 			levels := keeper.GetOrderBookLevels(pair, MaxDepthLevels)
+			if levels == nil{
+				return &abci.ResponseQuery{
+					Code:  uint32(sdk.CodeInternal),
+					Log:  "market pair do not exist",
+				}
+			}
 			book := store.OrderBook{
 				Height: height,
 				Levels: levels,

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -396,11 +396,10 @@ func (kp *Keeper) matchAndDistributeTrades(distributeTrade bool, height, timesta
 }
 
 func (kp *Keeper) GetOrderBookLevels(pair string, maxLevels int) []store.OrderBookLevel {
-	orderbook := make([]store.OrderBookLevel, maxLevels)
-
-	i, j := 0, 0
-
 	if eng, ok := kp.engines[pair]; ok {
+		orderbook := make([]store.OrderBookLevel, maxLevels)
+
+		i, j := 0, 0
 		// TODO: check considered bucket splitting?
 		eng.Book.ShowDepth(maxLevels, func(p *me.PriceLevel) {
 			orderbook[i].BuyPrice = utils.Fixed8(p.Price)
@@ -412,8 +411,10 @@ func (kp *Keeper) GetOrderBookLevels(pair string, maxLevels int) []store.OrderBo
 				orderbook[j].SellQty = utils.Fixed8(p.TotalLeavesQty())
 				j++
 			})
+		return orderbook
+	}else{
+		return nil
 	}
-	return orderbook
 }
 
 func (kp *Keeper) GetOpenOrders(pair string, addr sdk.AccAddress) []store.OpenOrder {


### PR DESCRIPTION
### Description
when abci_query orderbooks, we should return nil when there is no query market pair.

### Rationale
For now when query a non exist pair,will return: 
```
{
  "bids": [
    
  ],
  "asks": [
    
  ],
  "height": 15329373
}
```


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

