### PR TITLE
R4R: Read sequence from flag in offline mode

### DIFF
--- a/plugins/dex/client/cli/tx.go
+++ b/plugins/dex/client/cli/tx.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	clientflag "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	txutils "github.com/cosmos/cosmos-sdk/client/utils"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -67,14 +68,18 @@ func newOrderCmd(cdc *wire.Codec) *cobra.Command {
 			side := int8(viper.GetInt(flagSide))
 
 			// avoids an ugly panin sequence 0 with --dry
-			acc, err := cliCtx.GetAccount(from)
-			if acc == nil || err != nil {
-				fmt.Println("No transactions involving this address yet. Using sequence 0.")
-				txBldr = txBldr.WithSequence(0)
+			if viper.GetBool(clientflag.FlagOffline) {
+				txBldr = txBldr.WithSequence(viper.GetInt64(clientflag.FlagSequence))
 			} else {
-				err = client.EnsureSequence(cliCtx, &txBldr)
-				if err != nil {
-					return err
+				acc, err := cliCtx.GetAccount(from)
+				if acc == nil || err != nil {
+					fmt.Println("No transactions involving this address yet. Using sequence 0.")
+					txBldr = txBldr.WithSequence(0)
+				} else {
+					err = client.EnsureSequence(cliCtx, &txBldr)
+					if err != nil {
+						return err
+					}
 				}
 			}
 


### PR DESCRIPTION
### Description

Now in offline mode, the send order command will use wrong sequence for calculate order-id. This PR will enable command to read sequence from flag in offline mode.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

