### PR TITLE
[R4R] hot fix panic is not recovered in prechecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1-hf.1
+BUG FIXES
+* [\#635](https://github.com/binance-chain/node/pull/635) fix panic in pre-check is not recovered
+
 ## 0.6.1
 FEATURES
 * [\#605](https://github.com/binance-chain/node/pull/605) [Account] accounts can set flags to turn on memo validation

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "0.6.1"
+const NodeVersion = "0.6.1-hf.1"
 
 func init() {
 	Version = fmt.Sprintf("Binance Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

Fix Panic within ante handler and prechecker is not recovered.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xd533f7]

goroutine 416261 [running]:
github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/x/auth.StdTx.GetSigners(0xc017b4a710, 0x1, 0x1, 0xc00ec73e80, 0x1, 0x1, 0xc00cd62f68, 0x8, 0x1, 0x0, ...)
        /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/x/auth/stdtx.go:49 +0x127
github.com/binance-chain/node/common/tx.validateBasic(0xc017b4a710, 0x1, 0x1, 0xc00ec73e80, 0x1, 0x1, 0xc00cd62f68, 0x8, 0x1, 0x0, ...)
        /root/bnbchain/src/github.com/binance-chain/node/common/tx/ante.go:208 +0x129
github.com/binance-chain/node/common/tx.NewTxPreChecker.func1(0x14e9100, 0xc00f67f500, 0xc00aaea1c0, 0xb, 0xc00806bad0, 0xc8, 0xc9, 0x14cb660, 0xc00fe42600, 0x0, ...)
        /root/bnbchain/src/github.com/binance-chain/node/common/tx/ante.go:69 +0xde
github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).preCheck(0xc00010c000, 0xc00806bad0, 0xc8, 0xc9, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/baseapp/baseapp.go:600 +0x219
github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).PreCheckTx(0xc00010c000, 0xc00806bad0, 0xc8, 0xc9, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/baseapp/baseapp.go:612 +0x9d
github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/server/concurrent.(*asyncLocalClient).CheckTxAsync.func1()
        /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/server/concurrent/async_local_client.go:235 +0x19b
github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/server/concurrent/pool.(*Pool).worker(0xc00ec6b0b0, 0xc010a6cb90)
        /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/server/concurrent/pool/pool.go:72 +0x7d
created by github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/server/concurrent/pool.(*Pool).schedule
        /root/bnbchain/src/github.com/binance-chain/node/vendor/github.com/cosmos/cosmos-sdk/server/concurrent/pool/pool.go:61 +0x13b
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xd533f7]

```
### Rationale

N/A

### Example

N/A

### Changes

recover panic with in 
### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

