### PR TITLE
[R4R] BEP39 - add memo to transfer kafka message

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 
 BUG FIXES
 * [\#641](https://github.com/binance-chain/node/pull/641) [Dex] Add max lock time in time lock plugin
+
+IMPROVEMENTS
+* [\#638](https://github.com/binance-chain/node/pull/638) [Pub] BEP39 - add memo to transfer kafka message

--- a/app/pub/msgs.go
+++ b/app/pub/msgs.go
@@ -48,7 +48,7 @@ var latestSchemaVersions = map[msgType]int{
 	booksTpe:           0,
 	executionResultTpe: 1,
 	blockFeeTpe:        0,
-	transferTpe:        0,
+	transferTpe:        1,
 }
 
 type AvroOrJsonMsg interface {
@@ -652,17 +652,19 @@ func (msg Receiver) ToNativeMap() map[string]interface{} {
 
 type Transfer struct {
 	TxHash string
+	Memo   string // Added for BEP39
 	From   string
 	To     []Receiver
 }
 
 func (msg Transfer) String() string {
-	return fmt.Sprintf("Transfer : from: %s, to: %v", msg.From, msg.To)
+	return fmt.Sprintf("Transfer: txHash: %s, memo: %s, from: %s, to: %v", msg.TxHash, msg.Memo, msg.From, msg.To)
 }
 
 func (msg Transfer) ToNativeMap() map[string]interface{} {
 	var native = make(map[string]interface{})
 	native["txhash"] = msg.TxHash
+	native["memo"] = msg.Memo
 	native["from"] = msg.From
 	to := make([]map[string]interface{}, len(msg.To), len(msg.To))
 	for idx, t := range msg.To {

--- a/app/pub/schema_test.go
+++ b/app/pub/schema_test.go
@@ -104,7 +104,7 @@ func TestBlockFeeMarshaling(t *testing.T) {
 
 func TestTransferMarshaling(t *testing.T) {
 	publisher := NewKafkaMarketDataPublisher(Logger, "")
-	msg := Transfers{42, 20, 1000, []Transfer{{TxHash: "123456ABCDE", From: "", To: []Receiver{Receiver{"bnc1", []Coin{{"BNB", 100}, {"BTC", 100}}}, Receiver{"bnc2", []Coin{{"BNB", 200}, {"BTC", 200}}}}}}}
+	msg := Transfers{42, 20, 1000, []Transfer{{TxHash: "123456ABCDE", Memo: "1234", From: "", To: []Receiver{Receiver{"bnc1", []Coin{{"BNB", 100}, {"BTC", 100}}}, Receiver{"bnc2", []Coin{{"BNB", 200}, {"BTC", 200}}}}}}}
 	_, err := publisher.marshal(&msg, transferTpe)
 	if err != nil {
 		t.Fatal(err)

--- a/app/pub/schemas.go
+++ b/app/pub/schemas.go
@@ -6,7 +6,7 @@ package pub
 // put old version into pub/schemas with version suffixed to filename for tracking historical version
 
 // Backward compatibility:
-// 1. publisher add field, consumer should initialize two decoder with two publisher schema, choose which decoded should be used by `lastestSchemaVersion` component in kafka message Key
+// 1. publisher add field, consumer should initialize two decoder with two publisher schema, choose which decoder should be used by `lastestSchemaVersion` component in kafka message Key
 // 2. consumer add field, consumer should initialize one decode with publisher schema and consumer schema. In which, consumer schema should define default value for added field
 
 const (
@@ -264,6 +264,7 @@ const (
 						"namespace": "com.company",
 						"fields": [
 							{ "name": "txhash", "type": "string" },
+							{ "name": "memo", "type": "string" },
 							{ "name": "from", "type": "string" },
 							{ "name": "to", 
                   				"type": {

--- a/app/pub/schemas/transfers0.avsc
+++ b/app/pub/schemas/transfers0.avsc
@@ -1,0 +1,51 @@
+{
+    "type": "record",
+    "name": "Transfers",
+    "namespace": "com.company",
+    "fields": [
+        { "name": "height", "type": "long"},
+        { "name": "num", "type": "int" },
+        { "name": "timestamp", "type": "long" },
+        { "name": "transfers",
+          "type": {
+            "type": "array",
+            "items": {
+                "type": "record",
+                "name": "Transfer",
+                "namespace": "com.company",
+                "fields": [
+                    { "name": "txhash", "type": "string" },
+                    { "name": "from", "type": "string" },
+                    { "name": "to",
+                        "type": {
+                            "type": "array",
+                            "items": {
+                                "type": "record",
+                                "name": "Receiver",
+                                "namespace": "com.company",
+                                "fields": [
+                                    { "name": "addr", "type": "string" },
+                                    { "name": "coins",
+                                        "type": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "record",
+                                                "name": "Coin",
+                                                "namespace": "com.company",
+                                                "fields": [
+                                                    { "name": "denom", "type": "string" },
+                                                    { "name": "amount", "type": "long" }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+          }
+        }
+    ]
+}

--- a/networks/publisher/newPublisher.sh
+++ b/networks/publisher/newPublisher.sh
@@ -43,6 +43,7 @@ sed -i -e "s/publishBlockFee = false/publishBlockFee = true/g" ${witnesshome}/co
 sed -i -e "s/accountBalanceTopic = \"accounts\"/accountBalanceTopic = \"test\"/g" ${witnesshome}/config/app.toml
 sed -i -e "s/orderBookTopic = \"orders\"/orderBookTopic = \"test\"/g" ${witnesshome}/config/app.toml
 sed -i -e "s/orderUpdatesTopic = \"orders\"/orderUpdatesTopic = \"test\"/g" ${witnesshome}/config/app.toml
+sed -i -e "s/transferTopic = \"transfers\"/transferTopic = \"test\"/g" ${witnesshome}/config/app.toml
 sed -i -e "s/blockFeeTopic = \"accounts\"/blockFeeTopic = \"test\"/g" ${witnesshome}/config/app.toml
 sed -i -e "s/publishKafka = false/publishKafka = true/g" ${witnesshome}/config/app.toml
 sed -i -e "s/publishLocal = false/publishLocal = true/g" ${witnesshome}/config/app.toml


### PR DESCRIPTION
### Description

add memo to transfer kafka message

Document: 
https://github.com/binance-chain/docs-site/pull/151
Websocket:
https://github.com/binance-chain/websocket-ap/pull/101

### Rationale

BEP39

### Example

```
 /Users/zhaocong/go/src/github.com/binance-chain/node/build/bnbcli send --amount 1000000:BNB --to bnb12lu3cs95afx3x222uyr58kfx3mq3wdw2h0t8gx --from zc --chain-id test-chain-n4b735 --memo "1234"
```

```json
{  
   "stream":"transfers",
   "data":{  
      "e":"outboundTransferInfo",
      "E":1122,
      "H":"3251F90C832B17E5C58F8A06B9BA6757AA168E5BF2CEE5A10EB5AE6313EF9655",
      "M":"1234",
      "f":"bnb15ev5gmsvmwsd93zm837d277u8lr7avdcfe5ntc",
      "t":[  
         {  
            "o":"bnb12lu3cs95afx3x222uyr58kfx3mq3wdw2h0t8gx",
            "c":[  
               {  
                  "a":"BNB",
                  "A":"0.01000000"
               }
            ]
         }
      ]
   }
}
```

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

