### PR TITLE
[R4R] add levels parameter to depth ABCI query

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,3 +6,4 @@ BUG FIXES
 
 IMPROVEMENTS
 * [\#638](https://github.com/binance-chain/node/pull/638) [Pub] BEP39 - add memo to transfer kafka message
+* [\#639](https://github.com/binance-chain/node/pull/639) [ABCI] add levels parameter to depth ABCI query

--- a/plugins/dex/client/cli/commands.go
+++ b/plugins/dex/client/cli/commands.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	flagSymbol = "symbol"
+	flagLevels = "levels"
 )
 
 func AddCommands(cmd *cobra.Command, cdc *wire.Codec) {

--- a/plugins/dex/client/cli/tx.go
+++ b/plugins/dex/client/cli/tx.go
@@ -16,6 +16,7 @@ import (
 	"github.com/binance-chain/node/common/client"
 	"github.com/binance-chain/node/common/types"
 	"github.com/binance-chain/node/common/utils"
+	"github.com/binance-chain/node/plugins/dex"
 	"github.com/binance-chain/node/plugins/dex/order"
 	"github.com/binance-chain/node/plugins/dex/store"
 	"github.com/binance-chain/node/wire"
@@ -95,6 +96,7 @@ func newOrderCmd(cdc *wire.Codec) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringP(flagSymbol, "l", "", "the listed trading pair, such as ADA_BNB")
+	cmd.Flags().IntP(flagLevels, "L", 100, "maximum level (1,5,10,20,50,100,500,1000) to return")
 	cmd.Flags().StringP(flagSide, "s", "", "side (buy as 1 or sell as 2) of the order")
 	cmd.Flags().StringP(flagPrice, "p", "", "price for the order")
 	cmd.Flags().StringP(flagQty, "q", "", "quantity for the order")
@@ -114,8 +116,12 @@ func showOrderBookCmd(cdc *wire.Codec) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			levelsLimit := viper.GetInt(flagLevels)
+			if levelsLimit <= 0 || levelsLimit > dex.MaxDepthLevels {
+				return fmt.Errorf("%s should be greater than 0 and not exceed %d", flagLevels, dex.MaxDepthLevels)
+			}
 
-			ob, err := store.GetOrderBook(cdc, ctx, symbol)
+			ob, err := store.GetOrderBook(cdc, ctx, symbol, levelsLimit)
 			if err != nil {
 				return err
 			}

--- a/plugins/dex/store/codec.go
+++ b/plugins/dex/store/codec.go
@@ -9,8 +9,8 @@ import (
 )
 
 // queryOrderBook queries the store for the serialized order book for a given pair.
-func queryOrderBook(cdc *wire.Codec, ctx context.CLIContext, pair string) (*[]byte, error) {
-	bz, err := ctx.Query(fmt.Sprintf("dex/orderbook/%s", pair), nil)
+func queryOrderBook(cdc *wire.Codec, ctx context.CLIContext, pair string, levels int) (*[]byte, error) {
+	bz, err := ctx.Query(fmt.Sprintf("dex/orderbook/%s/%d", pair, levels), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -28,8 +28,8 @@ func decodeOrderBook(cdc *wire.Codec, bz *[]byte) (*OrderBook, error) {
 }
 
 // GetOrderBook decodes the order book from the serialized store
-func GetOrderBook(cdc *wire.Codec, ctx context.CLIContext, pair string) (*OrderBook, error) {
-	bz, err := queryOrderBook(cdc, ctx, pair)
+func GetOrderBook(cdc *wire.Codec, ctx context.CLIContext, pair string, levels int) (*OrderBook, error) {
+	bz, err := queryOrderBook(cdc, ctx, pair, levels)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

add levels parameter to depth ABCI query
@guagualvcha should change http-ap, but this change is compatible with current http-ap if he doesn't :)
WebSocket change: https://github.com/binance-chain/websocket-ap/pull/100

### Rationale

websocket needs to snapshot more levels

### Example

N/A

### Changes

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

N/A

Pressure test: @ackratos @zjubfd see the results of depth api using larger limit, https://docs.google.com/spreadsheets/d/147NYJa38FRvXgMnKrUHIfarmg8FYylOmhpCPG9E3MCk/edit?usp=sharing
