### PR TITLE
R4R: Add account flag in api-server account query response

### DIFF
--- a/plugins/api/handlers/account.go
+++ b/plugins/api/handlers/account.go
@@ -22,6 +22,7 @@ import (
 func AccountReqHandler(cdc *wire.Codec, ctx context.CLIContext) http.HandlerFunc {
 	type response struct {
 		auth.BaseAccount
+		Flags    uint64                  `json:"flags"`
 		Balances []tkclient.TokenBalance `json:"balances"`
 		Coins    *struct{}               `json:"coins,omitempty"` // omit `coins`
 	}
@@ -71,6 +72,7 @@ func AccountReqHandler(cdc *wire.Codec, ctx context.CLIContext) http.HandlerFunc
 		appAccount := account.(*types.AppAccount)
 		resp := response{
 			BaseAccount: appAccount.BaseAccount,
+			Flags:       appAccount.Flags,
 			Balances:    toTokenBalances(appAccount),
 		}
 


### PR DESCRIPTION
### Description

Add account flag in api-server account query response

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

