### PR TITLE
[R4R]fix can't bring bnbchaind back when there is an order whose symbol is lower case

### DIFF
--- a/plugins/dex/order/keeper_recovery.go
+++ b/plugins/dex/order/keeper_recovery.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"time"
 
 	bc "github.com/tendermint/tendermint/blockchain"
@@ -165,11 +166,12 @@ func (kp *Keeper) LoadOrderBookSnapshot(ctx sdk.Context, latestBlockHeight int64
 	}
 	for _, m := range ao.Orders {
 		orderHolder := m
-		kp.allOrders[m.Symbol][m.Id] = &orderHolder
+		symbol := strings.ToUpper(m.Symbol)
+		kp.allOrders[symbol][m.Id] = &orderHolder
 		if m.CreatedHeight == height {
-			kp.roundOrders[m.Symbol] = append(kp.roundOrders[m.Symbol], m.Id)
+			kp.roundOrders[symbol] = append(kp.roundOrders[symbol], m.Id)
 			if m.TimeInForce == TimeInForce.IOC {
-				kp.roundIOCOrders[m.Symbol] = append(kp.roundIOCOrders[m.Symbol], m.Id)
+				kp.roundIOCOrders[symbol] = append(kp.roundIOCOrders[symbol], m.Id)
 			}
 		}
 		if kp.CollectOrderInfoForPublish {


### PR DESCRIPTION
### Description

see detail in issue https://github.com/binance-chain/node/issues/652

Just fix recovery panic,  no hard fork

### Rationale


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

