### PR TITLE
fix flagLevels binding in showOrderbook cmd

### DIFF
--- a/plugins/dex/client/cli/tx.go
+++ b/plugins/dex/client/cli/tx.go
@@ -101,7 +101,6 @@ func newOrderCmd(cdc *wire.Codec) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringP(flagSymbol, "l", "", "the listed trading pair, such as ADA_BNB")
-	cmd.Flags().IntP(flagLevels, "L", 100, "maximum level (1,5,10,20,50,100,500,1000) to return")
 	cmd.Flags().StringP(flagSide, "s", "", "side (buy as 1 or sell as 2) of the order")
 	cmd.Flags().StringP(flagPrice, "p", "", "price for the order")
 	cmd.Flags().StringP(flagQty, "q", "", "quantity for the order")
@@ -141,6 +140,7 @@ func showOrderBookCmd(cdc *wire.Codec) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().IntP(flagLevels, "L", 100, "maximum level (1,5,10,20,50,100,500,1000) to return")
 	cmd.Flags().StringP(flagSymbol, "l", "", "the listed trading pair, such as ADA_BNB")
 	return cmd
 }


### PR DESCRIPTION
### Description

the parameter `levels` is put in a wrong place.

### Rationale

### Example


### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

