### PR TITLE
R4R: Fix swap query limit issue

### DIFF
--- a/plugins/tokens/swap/queryable.go
+++ b/plugins/tokens/swap/queryable.go
@@ -94,7 +94,7 @@ func querySwapByCreator(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) (
 		if count <= params.Offset {
 			continue
 		}
-		if int64(len(swapIDList)) > params.Limit {
+		if int64(len(swapIDList)) >= params.Limit {
 			break
 		}
 		swapIDList = append(swapIDList, iterator.Value())
@@ -143,7 +143,7 @@ func querySwapByRecipient(ctx sdk.Context, req abci.RequestQuery, keeper Keeper)
 		if count <= params.Offset {
 			continue
 		}
-		if int64(len(swapIDList)) > params.Limit {
+		if int64(len(swapIDList)) >= params.Limit {
 			break
 		}
 		swapIDList = append(swapIDList, iterator.Value())


### PR DESCRIPTION
### Description

Previously, query by creator or recipient will return one more item in each query. There is a bug in limit calculation. 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

