### PR TITLE
[R4R]support recover height before 1024*1024

### DIFF
--- a/networks/tools/state_recover/state_recover.go
+++ b/networks/tools/state_recover/state_recover.go
@@ -116,6 +116,10 @@ func resetBlockChainState(height int64, rootDir string) {
 			return
 		}
 		blockState.LastHeightConsensusParamsChanged = 1
+		validatorInfo := loadValidatorsInfo(stateDb, height)
+		if validatorInfo != nil {
+			blockState.LastHeightValidatorsChanged = validatorInfo.LastHeightChanged
+		}
 		blockState.ConsensusParams, err = state.LoadConsensusParams(stateDb, height)
 		if err != nil {
 			cmn.Exit(fmt.Sprintf("failed to load consensusparam info"))


### PR DESCRIPTION
### Description

for now, the recover tool do not support rollback to height that is 1024*1024 ago, but user may still need to rollback to any height. 

This pr try to rebuild the state from block.


### Rationale

resolve https://github.com/binance-chain/node/issues/674
### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

