### PR TITLE
Add pendingmatch flag to orderbook query response

### DIFF
--- a/app/apptest/match_allocation_test.go
+++ b/app/apptest/match_allocation_test.go
@@ -230,7 +230,7 @@ func GetOrderId(add sdk.AccAddress, seq int64, ctx sdk.Context) string {
 func GetOrderBook(pair string) ([]level, []level) {
 	buys := make([]level, 0)
 	sells := make([]level, 0)
-	orderbooks := testApp.DexKeeper.GetOrderBookLevels(pair, 25)
+	orderbooks, _ := testApp.DexKeeper.GetOrderBookLevels(pair, 25)
 	for _, l := range orderbooks {
 		if l.BuyPrice != 0 {
 			buys = append(buys, level{price: l.BuyPrice, qty: l.BuyQty})

--- a/app/apptest/ordertx_test.go
+++ b/app/apptest/ordertx_test.go
@@ -22,10 +22,10 @@ type level struct {
 	qty   utils.Fixed8
 }
 
-func getOrderBook(pair string) ([]level, []level) {
+func getOrderBook(pair string) ([]level, []level, bool) {
 	buys := make([]level, 0)
 	sells := make([]level, 0)
-	orderbooks := testApp.DexKeeper.GetOrderBookLevels(pair, 5)
+	orderbooks, pendingMatch := testApp.DexKeeper.GetOrderBookLevels(pair, 5)
 	for _, l := range orderbooks {
 		if l.BuyPrice != 0 {
 			buys = append(buys, level{price: l.BuyPrice, qty: l.BuyQty})
@@ -34,7 +34,7 @@ func getOrderBook(pair string) ([]level, []level) {
 			sells = append(sells, level{price: l.SellPrice, qty: l.SellQty})
 		}
 	}
-	return buys, sells
+	return buys, sells, pendingMatch
 }
 
 func genOrderID(add sdk.AccAddress, seq int64, ctx sdk.Context, am auth.AccountKeeper) string {
@@ -125,6 +125,10 @@ func Test_handleNewOrder_DeliverTx(t *testing.T) {
 	testApp.DexKeeper.PairMapper.AddTradingPair(ctx, tradingPair)
 	testApp.DexKeeper.AddEngine(tradingPair)
 
+	tradingPair2 := types.NewTradingPair("ETH-001", "BNB", 1e8)
+	testApp.DexKeeper.PairMapper.AddTradingPair(ctx, tradingPair2)
+	testApp.DexKeeper.AddEngine(tradingPair2)
+
 	add := Account(0).GetAddress()
 	oid := fmt.Sprintf("%X-0", add)
 	msg := o.NewNewOrderMsg(add, oid, 1, "BTC-000_BNB", 355e8, 1e8)
@@ -133,11 +137,17 @@ func Test_handleNewOrder_DeliverTx(t *testing.T) {
 	t.Logf("res is %v and error is %v", res, e)
 	assert.Equal(uint32(0), res.Code)
 	assert.Nil(e)
-	buys, sells := getOrderBook("BTC-000_BNB")
+	buys, sells, pendingMatch := getOrderBook("BTC-000_BNB")
 	assert.Equal(1, len(buys))
 	assert.Equal(0, len(sells))
+	assert.Equal(true, pendingMatch)
 	assert.Equal(utils.Fixed8(355e8), buys[0].price)
 	assert.Equal(utils.Fixed8(1e8), buys[0].qty)
+
+	buys, sells, pendingMatch = getOrderBook("ETH-001_BNB")
+	assert.Equal(0, len(buys))
+	assert.Equal(0, len(sells))
+	assert.Equal(false, pendingMatch)
 }
 
 func Test_Match(t *testing.T) {
@@ -196,13 +206,15 @@ func Test_Match(t *testing.T) {
 	t.Logf("res is %v and error is %v", res, e)
 	msg = o.NewNewOrderMsg(add, genOrderID(add, 3, ctx, am), 1, "BTC-000_BNB", 98e8, 300e8)
 	res, e = testClient.DeliverTxSync(msg, testApp.Codec)
-	buys, sells := getOrderBook("BTC-000_BNB")
+	buys, sells, pendingMatch := getOrderBook("BTC-000_BNB")
 	assert.Equal(4, len(buys))
 	assert.Equal(3, len(sells))
+	assert.Equal(true, pendingMatch)
 	testApp.DexKeeper.MatchAndAllocateAll(ctx, nil)
-	buys, sells = getOrderBook("BTC-000_BNB")
+	buys, sells, pendingMatch = getOrderBook("BTC-000_BNB")
 	assert.Equal(0, len(buys))
 	assert.Equal(3, len(sells))
+	assert.Equal(false, pendingMatch)
 
 	trades, lastPx := testApp.DexKeeper.GetLastTradesForPair("BTC-000_BNB")
 	assert.Equal(int64(96e8), lastPx)
@@ -247,20 +259,20 @@ func Test_Match(t *testing.T) {
 	res, e = testClient.DeliverTxSync(msg, testApp.Codec)
 	t.Logf("res is %v and error is %v", res, e)
 
-	buys, sells = getOrderBook("BTC-000_BNB")
+	buys, sells, _ = getOrderBook("BTC-000_BNB")
 	assert.Equal(0, len(buys))
 	assert.Equal(3, len(sells))
-	buys, sells = getOrderBook("ETH-000_BNB")
+	buys, sells, _ = getOrderBook("ETH-000_BNB")
 	assert.Equal(4, len(buys))
 	assert.Equal(3, len(sells))
 
 	testApp.DexKeeper.MatchAndAllocateAll(ctx, nil)
-	buys, sells = getOrderBook("ETH-000_BNB")
+	buys, sells, _ = getOrderBook("ETH-000_BNB")
 	t.Logf("buys: %v", buys)
 	t.Logf("sells: %v", sells)
 	assert.Equal(1, len(buys))
 	assert.Equal(2, len(sells))
-	buys, sells = getOrderBook("BTC-000_BNB")
+	buys, sells, _ = getOrderBook("BTC-000_BNB")
 	assert.Equal(0, len(buys))
 	assert.Equal(3, len(sells))
 	trades, lastPx = testApp.DexKeeper.GetLastTradesForPair("ETH-000_BNB")

--- a/plugins/dex/abci.go
+++ b/plugins/dex/abci.go
@@ -106,10 +106,11 @@ func createAbciQueryHandler(keeper *DexKeeper) app.AbciQueryHandler {
 					levelLimit = l
 				}
 			}
-			levels := keeper.GetOrderBookLevels(pair, levelLimit)
+			levels, pendingMatch := keeper.GetOrderBookLevels(pair, levelLimit)
 			book := store.OrderBook{
-				Height: height,
-				Levels: levels,
+				Height:       height,
+				Levels:       levels,
+				PendingMatch: pendingMatch,
 			}
 			bz, err := app.GetCodec().MarshalBinaryLengthPrefixed(book)
 			if err != nil {

--- a/plugins/dex/client/rest/utils/streamer.go
+++ b/plugins/dex/client/rest/utils/streamer.go
@@ -78,6 +78,10 @@ func StreamDepthResponse(w io.Writer, ob *store.OrderBook, limit int) error {
 		i++
 	}
 
-	// end streamed json with height
-	return write(w, fmt.Sprintf("],\"height\":%d}", ob.Height))
+	// pass 3 - height
+	if err := write(w, fmt.Sprintf("],\"height\":%d", ob.Height)); err != nil {
+		return err
+	}
+	// end streamed json with pendingMatch flag
+	return write(w, fmt.Sprintf(",\"pendingMatch\":%t}", ob.PendingMatch))
 }

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -450,8 +450,8 @@ func (kp *Keeper) matchAndDistributeTrades(distributeTrade bool, height, timesta
 	return tradeOuts
 }
 
-func (kp *Keeper) GetOrderBookLevels(pair string, maxLevels int) []store.OrderBookLevel {
-	orderbook := make([]store.OrderBookLevel, maxLevels)
+func (kp *Keeper) GetOrderBookLevels(pair string, maxLevels int) (orderbook []store.OrderBookLevel, pendingMatch bool) {
+	orderbook = make([]store.OrderBookLevel, maxLevels)
 
 	i, j := 0, 0
 
@@ -467,8 +467,9 @@ func (kp *Keeper) GetOrderBookLevels(pair string, maxLevels int) []store.OrderBo
 				orderbook[j].SellQty = utils.Fixed8(p.TotalLeavesQty())
 				j++
 			})
+		pendingMatch = len(kp.roundOrders[pair]) > 0
 	}
-	return orderbook
+	return orderbook, pendingMatch
 }
 
 func (kp *Keeper) GetOpenOrders(pair string, addr sdk.AccAddress) []store.OpenOrder {

--- a/plugins/dex/store/types.go
+++ b/plugins/dex/store/types.go
@@ -6,8 +6,9 @@ import (
 
 // OrderBook represents an order book at the current point block height, which is included in its struct.
 type OrderBook struct {
-	Height int64
-	Levels []OrderBookLevel
+	Height       int64
+	Levels       []OrderBookLevel
+	PendingMatch bool
 }
 
 // OrderBookLevel represents a single order book level.


### PR DESCRIPTION
### Description

Prevent cross order
Meanwhile, need merge https://github.com/binance-chain/http-ap/pull/85 and https://github.com/binance-chain/go-sdk/pull/110 with this change

### Rationale

Here is an example of crossed price levels in websocket depth:
	After BeginBlock of height 101, the round order (sell, price=3,quantity=5) was inserted into order book. Websocket queried node depth API and the response included this order. and then an order (buy price=3,quantity=9) was also inserted into order book. After matching, in the endblock the remaining price level (buy, price=3,quantity=4)  was published to websocket as delta. However, the price level (sell, price=3,quantity=5) still stayed in websocket depth cache, hence the crossed order (buy, 3,5) and (sell, 3,4) received by websocket subscriber. The price level (buy, 3,5) actually doesn’t exist in the real order book.


Solution:

 Add a boolean flag “pending_match” in node depth API response to indicate the case of unmatched round orders in order book.
If len(roundOrders[symbol])>0, “pending_match” = true. The drawback is for mini-tokens, the roundOrders will be kept for several blocks until match, and hence the client has a lower chance to get order book with pending_match=false.

The client (websocket-ap) will discard this query result when pendingMatch is true.


### Example

 RUN   TestGetDepth
{"Height":2644,"Levels":[{"buyQty":"0.00000000","buyPrice":"0.00000000","sellQty":"0.00000000","sellPrice":"0.00000000"},{"buyQty":"0.00000000","buyPrice":"0.00000000","sellQty":"0.00000000","sellPrice":"0.00000000"}],"PendingMatch":true}

### Changes

Notable changes: 
* Add a bool flag pending_match in orderbook API

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues


