### PR TITLE
hotfix node-binary/issues/204

### DIFF
--- a/plugins/tokens/swap/handler.go
+++ b/plugins/tokens/swap/handler.go
@@ -27,7 +27,8 @@ func NewHandler(kp Keeper) sdk.Handler {
 }
 
 func handleHashTimerLockedTransfer(ctx sdk.Context, kp Keeper, msg HTLTMsg) sdk.Result {
-	blockTime := ctx.BlockHeader().Time.Unix()
+	header := ctx.BlockHeader()
+	blockTime := header.Time.Unix()
 	if msg.Timestamp < blockTime-ThirtyMinutes || msg.Timestamp > blockTime+FifteenMinutes {
 		return ErrInvalidTimestamp(fmt.Sprintf("Timestamp (%d) can neither be 15 minutes ahead of the current time (%d), nor 30 minutes later", msg.Timestamp, ctx.BlockHeader().Time.Unix())).Result()
 	}
@@ -50,6 +51,10 @@ func handleHashTimerLockedTransfer(ctx sdk.Context, kp Keeper, msg HTLTMsg) sdk.
 		ClosedTime:          0,
 		Status:              Open,
 		Index:               kp.getIndex(ctx),
+	}
+	// hotfix for chain "Binance-Chain-Tigris"
+	if header.Height == 90913098 && header.ChainID == "Binance-Chain-Tigris" {
+		swap.Index = 0
 	}
 	swapID := CalculateSwapID(swap.RandomNumberHash, swap.From, msg.SenderOtherChain)
 	err = kp.CreateSwap(ctx, swapID, swap)


### PR DESCRIPTION
### Description

This hotfix is to fix issue https://github.com/binance-chain/node/pull/new/hotfix204
In height 90913098 of main net, there came a swap transaction. This tx made some nodes that start within several days before the height failed to replay that block.

The root cause is that there is a bug in the IAVL library that would only be triggered when only 1 record in that store tree. 
Before the height 90913098, all other "atomic_swap" records were deleted and only  1 key left in that store. So the new swap tx coming in 90913098 triggers the bug.

All the nodes that already passed the height 90913098 before this hotfix does not need to do anything. 
We will fix the iavl issue in next release.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

