### PR TITLE
fix incorrect log messages

### DIFF
--- a/plugins/dex/order/fee.go
+++ b/plugins/dex/order/fee.go
@@ -154,7 +154,7 @@ func (m *FeeManager) calcNativeFee(tran *Transfer, engines map[string]*matcheng.
 				}
 
 				notional, pairExist = m.calcNotional(BUSDSymbol, qty, types.NativeTokenSymbol, engines)
-				if pairExist {
+				if !pairExist {
 					// must not happen
 					m.logger.Error(BUSDSymbol + " must be listed against " + types.NativeTokenSymbol)
 				}


### PR DESCRIPTION
### Description

Fix incorrect log messages.

### Rationale

The flag for writing logs is wrong, we need to fix the flag.

### Example
NA

### Changes

Notable changes: 
* flip a flag when outputting logs.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

NO

### Related issues

NA

