### PR TITLE
decode by itoken pointer

### DIFF
--- a/plugins/tokens/client/rest/gettoken.go
+++ b/plugins/tokens/client/rest/gettoken.go
@@ -27,7 +27,7 @@ func getTokenInfo(ctx context.CLIContext, cdc *wire.Codec, symbol string, isMini
 	}
 
 	var token types.IToken
-	err = cdc.UnmarshalBinaryLengthPrefixed(bz, token)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &token)
 	if err != nil {
 		fmt.Println(err)
 		return nil, err


### PR DESCRIPTION
### Description

bnbcli api-server --chain-id Binance-Chain-Tigris --node https://dataseed5.defibit.io:443
curl 'localhost:8080/api/v1/mini/tokens/AURO-39C'
Failed to get token
E[2020-08-24|19:51:27.228] Panic in RPC HTTP handler                    module=apiserv err="Unmarshal expects a pointer" stack="goroutine 16 [running]:\nruntime/debug.Stack(0xc000cf50a0, 0x4db6f00, 0x52a8940)\n\t/usr/local/Cellar/go@1.12/1.12.17/libexec/src/runtime/debug/stack.go:24 +0x9d\ngithub.com/tendermint/tendermint/rpc/lib/server.RecoverAndLogHandler.func1.1(0xc0000b9200, 0x52e9800, 0xc0001ada50, 0xbfc9084f781bb178, 0x69b01e52, 0x5dbfee0, 0xc000384c00)\n\t/Users/luerheng/go/pkg/mod/github.com/binance-chain/bnc-tendermint@v0.32.3-binance.3/rpc/lib/server/http_server.go:161 +0x552\npanic(0x4db6f00, 0x52a8940)\n\t/usr/local/Cellar/go@1.12/1.12.17/libexec/src/runtime/panic.go:522 +0x1b5\ngithub.com/tendermint/go-amino.(*Codec).UnmarshalBinaryBare(0xc0003a6230, 0xc001343d61, 0x41, 0x41, 0x4f662e0, 0xc0013ae0e0, 0x60, 0x70)\n\t/Users/luerheng/go/pkg/mod/github.com/binance-chain/bnc-go-amino@v0.14.1-binance.2/amino.go:325 +0xa09\ngithub.com/tendermint/go-amino.(*Codec).UnmarshalBinaryLengthPrefixed

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

