### PR TITLE
hotfix: upgrade tendermint to 0.32.3-binance.4 to fix memory leak issue in hotsync mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/binance-chain/bnc-cosmos-sdk v0.25.0-binance.23
 	github.com/tendermint/go-amino => github.com/binance-chain/bnc-go-amino v0.14.1-binance.2
 	github.com/tendermint/iavl => github.com/binance-chain/bnc-tendermint-iavl v0.12.0-binance.4
-	github.com/tendermint/tendermint => github.com/binance-chain/bnc-tendermint v0.32.3-binance.3
+	github.com/tendermint/tendermint => github.com/binance-chain/bnc-tendermint v0.32.3-binance.4
 	github.com/zondax/ledger-cosmos-go => github.com/binance-chain/ledger-cosmos-go v0.9.9-binance.3
 	golang.org/x/crypto => github.com/tendermint/crypto v0.0.0-20190823183015-45b1026d81ae
 )

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/binance-chain/bnc-cosmos-sdk v0.25.0-binance.23 h1:lD8uAYAJX6ZjLf3vdv
 github.com/binance-chain/bnc-cosmos-sdk v0.25.0-binance.23/go.mod h1:25UaVXWOjzVAmL4I6szOdC4SQz4wsBG6wpv68V2vK7w=
 github.com/binance-chain/bnc-go-amino v0.14.1-binance.2 h1:XcbcfisVItk92UKoGbtNT8nbcfadj3H3ayuM2srAfVs=
 github.com/binance-chain/bnc-go-amino v0.14.1-binance.2/go.mod h1:yaElUUxWtv/TC/ldGtlKAvS1vKwokxgJ1d97I+6is80=
-github.com/binance-chain/bnc-tendermint v0.32.3-binance.3 h1:b8SqtWmtHPhPQ2ADzUgO9sr+ChKL9ho4dTorBjGAAyY=
-github.com/binance-chain/bnc-tendermint v0.32.3-binance.3/go.mod h1:kN5dNxE8voFtDqx2HjbM8sBIH5cUuMtLg0XEHjqzUiY=
+github.com/binance-chain/bnc-tendermint v0.32.3-binance.4 h1:CShRjCKBmpZwVBDgwnQpbUiZlBFYpM7UQYST542DcdM=
+github.com/binance-chain/bnc-tendermint v0.32.3-binance.4/go.mod h1:kN5dNxE8voFtDqx2HjbM8sBIH5cUuMtLg0XEHjqzUiY=
 github.com/binance-chain/bnc-tendermint-iavl v0.12.0-binance.4 h1:BhaV2iiGWfRC6iB8HHOYJeUDwtQMB2pUA4ah+KCbBhI=
 github.com/binance-chain/bnc-tendermint-iavl v0.12.0-binance.4/go.mod h1:Zmh8GRdNJB8DULIOBar3JCZp6tSpcvM1NGKfE9U2EzA=
 github.com/binance-chain/ledger-cosmos-go v0.9.9-binance.3 h1:FFpFbkzlP2HUyxQCm0eoU6mkfgMNynfqZRbeWqlaLdQ=


### PR DESCRIPTION
### Description

upgrade tendermint to 0.32.3-binance.4 to fix memory leak issue in hotsync mode, 
no hard fork.

### Rationale

some external full nodes meet memory issues

### Example

### Changes

Notable changes: 
* upgrade tendermint to 0.32.3-binance.4
* ...

### Preflight checks

- [x] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

