### PR TITLE
rename upgrade name AdjustTokenSymbolLength to BEP87

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -322,9 +322,9 @@ func SetUpgradeConfig(upgradeConfig *config.UpgradeConfig) {
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP8, upgradeConfig.BEP8Height)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP67, upgradeConfig.BEP67Height)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP70, upgradeConfig.BEP70Height)
-	upgrade.Mgr.AddUpgradeHeight(upgrade.AdjustTokenSymbolLength, upgradeConfig.AdjustTokenSymbolLengthHeight)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP82, upgradeConfig.BEP82Height)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP84, upgradeConfig.BEP84Height)
+	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP87, upgradeConfig.BEP87Height)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.FixFailAckPackage, upgradeConfig.FixFailAckPackageHeight)
 
 	// register store keys of upgrade

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -75,12 +75,12 @@ BEP8Height = {{ .UpgradeConfig.BEP8Height }}
 BEP67Height = {{ .UpgradeConfig.BEP67Height }}
 # Block height of BEP70 upgrade
 BEP70Height = {{ .UpgradeConfig.BEP70Height }}
-# Block height of token length adjustment upgrade
-AdjustTokenSymbolLengthHeight = {{ .UpgradeConfig.AdjustTokenSymbolLengthHeight }}
 # Block height of BEP82 upgrade
 BEP82Height = {{ .UpgradeConfig.BEP82Height }}
 # Block height of BEP84 upgrade
 BEP84Height = {{ .UpgradeConfig.BEP84Height }}
+# Block height of BEP87 upgrade
+BEP87Height = {{ .UpgradeConfig.BEP87Height }}
 # Block height of FixFailAckPackage upgrade
 FixFailAckPackageHeight = {{ .UpgradeConfig.FixFailAckPackageHeight }}
 # Block height of EnableAccountScriptsForCrossChainTransferHeight upgrade
@@ -520,9 +520,9 @@ type UpgradeConfig struct {
 	BEP67Height int64 `mapstructure:"BEP67Height"`
 	BEP70Height int64 `mapstructure:"BEP70Height"`
 
-	AdjustTokenSymbolLengthHeight                   int64 `mapstructure:"AdjustTokenSymbolLengthHeight"`
 	BEP82Height                                     int64 `mapstructure:"BEP82Height"`
 	BEP84Height                                     int64 `mapstructure:"BEP84Height"`
+	BEP87Height                                     int64 `mapstructure:"BEP87Height"`
 	FixFailAckPackageHeight                         int64 `mapstructure:"FixFailAckPackageHeight"`
 	EnableAccountScriptsForCrossChainTransferHeight int64 `mapstructure:"EnableAccountScriptsForCrossChainTransferHeight"`
 }
@@ -530,24 +530,24 @@ type UpgradeConfig struct {
 func defaultUpgradeConfig() *UpgradeConfig {
 	// make the upgraded functions enabled by default
 	return &UpgradeConfig{
-		BEP6Height:                    1,
-		BEP9Height:                    1,
-		BEP10Height:                   1,
-		BEP19Height:                   1,
-		BEP12Height:                   1,
-		BEP3Height:                    1,
-		FixSignBytesOverflowHeight:    1,
-		LotSizeUpgradeHeight:          1,
-		ListingRuleUpgradeHeight:      1,
-		FixZeroBalanceHeight:          1,
-		BEP8Height:                    1,
-		BEP67Height:                   1,
-		BEP70Height:                   1,
-		LaunchBscUpgradeHeight:        1,
-		AdjustTokenSymbolLengthHeight: math.MaxInt64,
-		BEP82Height:                   math.MaxInt64,
-		BEP84Height:                   math.MaxInt64,
-		FixFailAckPackageHeight:       math.MaxInt64,
+		BEP6Height:                 1,
+		BEP9Height:                 1,
+		BEP10Height:                1,
+		BEP19Height:                1,
+		BEP12Height:                1,
+		BEP3Height:                 1,
+		FixSignBytesOverflowHeight: 1,
+		LotSizeUpgradeHeight:       1,
+		ListingRuleUpgradeHeight:   1,
+		FixZeroBalanceHeight:       1,
+		BEP8Height:                 1,
+		BEP67Height:                1,
+		BEP70Height:                1,
+		LaunchBscUpgradeHeight:     1,
+		BEP82Height:                math.MaxInt64,
+		BEP84Height:                math.MaxInt64,
+		BEP87Height:                math.MaxInt64,
+		FixFailAckPackageHeight:    math.MaxInt64,
 		EnableAccountScriptsForCrossChainTransferHeight: math.MaxInt64,
 	}
 }

--- a/common/types/mini_token.go
+++ b/common/types/mini_token.go
@@ -180,7 +180,7 @@ func ValidateIssueMiniSymbol(symbol string) error {
 
 	// check len without suffix
 	symbolLen := len(symbol)
-	if sdk.UpgradeMgr.GetHeight() == 0 || sdk.IsUpgrade(upgrade.AdjustTokenSymbolLength) {
+	if sdk.UpgradeMgr.GetHeight() == 0 || sdk.IsUpgrade(upgrade.BEP87) {
 		if symbolLen > MiniTokenSymbolMaxLen || symbolLen < MiniTokenSymbolNewMinLen {
 			return errors.New("length of token symbol is limited to 2~8")
 		}
@@ -214,7 +214,7 @@ func ValidateMiniTokenSymbol(symbol string) error {
 	// check len without suffix
 	// This function is used by both client and server side, and the client needs to use MiniTokenSymbolNewMinLen for the validation.
 	// If the UpgradeMgr.GetHeight == 0, that indicates the function is invoked by client side, and we should use MiniTokenSymbolNewMinLen
-	if sdk.UpgradeMgr.GetHeight() == 0 || sdk.IsUpgrade(upgrade.AdjustTokenSymbolLength) {
+	if sdk.UpgradeMgr.GetHeight() == 0 || sdk.IsUpgrade(upgrade.BEP87) {
 		if len(symbolPart) < MiniTokenSymbolNewMinLen {
 			return fmt.Errorf("mini-token symbol part is too short, got %d chars", len(symbolPart))
 		}

--- a/common/types/token.go
+++ b/common/types/token.go
@@ -147,7 +147,7 @@ func ValidateIssueSymbol(symbol string) error {
 
 	// check len without .B suffix
 	symbolLen := len(symbol)
-	if sdk.UpgradeMgr.GetHeight() == 0 || sdk.IsUpgrade(upgrade.AdjustTokenSymbolLength) {
+	if sdk.UpgradeMgr.GetHeight() == 0 || sdk.IsUpgrade(upgrade.BEP87) {
 		if symbolLen > TokenSymbolMaxLen || symbolLen < TokenSymbolNewMinLen {
 			return errors.New("length of token symbol is limited to 2~8")
 		}
@@ -203,7 +203,7 @@ func ValidateTokenSymbol(symbol string) error {
 	// check len without .B suffix
 	// This function is used by both client and server side, and the client needs to use TokenSymbolNewMinLen for the validation.
 	// If the UpgradeMgr.GetHeight == 0, that indicates the function is invoked by client side, and we should use TokenSymbolNewMinLen
-	if sdk.UpgradeMgr.GetHeight() == 0 || sdk.IsUpgrade(upgrade.AdjustTokenSymbolLength) {
+	if sdk.UpgradeMgr.GetHeight() == 0 || sdk.IsUpgrade(upgrade.BEP87) {
 		if len(symbolPart) < TokenSymbolNewMinLen {
 			return fmt.Errorf("token symbol part is too short, got %d chars", len(symbolPart))
 		}

--- a/common/upgrade/upgrade.go
+++ b/common/upgrade/upgrade.go
@@ -33,10 +33,10 @@ const (
 	BEP67 = "BEP67"  // https://github.com/binance-chain/BEPs/pull/67 Expiry time upgrade
 	BEP70 = "BEP70"  // https://github.com/binance-chain/BEPs/pull/70 BUSD Pair Upgrade
 
-	AdjustTokenSymbolLength = "AdjustTokenSymbolLength"
-	BEP82                   = sdk.BEP82
-	BEP84                   = "BEP84" // https://github.com/binance-chain/BEPs/pull/84 Mirror Sync Upgrade
-	FixFailAckPackage       = sdk.FixFailAckPackage
+	BEP82             = sdk.BEP82 // https://github.com/binance-chain/BEPs/pull/82
+	BEP84             = "BEP84"   // https://github.com/binance-chain/BEPs/pull/84 Mirror Sync Upgrade
+	BEP87             = "BEP87"   // https://github.com/binance-chain/BEPs/pull/87
+	FixFailAckPackage = sdk.FixFailAckPackage
 )
 
 func UpgradeBEP10(before func(), after func()) {


### PR DESCRIPTION
### Description
rename upgrade name AdjustTokenSymbolLength to BEP87

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

