### PR TITLE
[R4R]return error when executing mirror or mirror sync request failed

### DIFF
--- a/plugins/bridge/cross_app.go
+++ b/plugins/bridge/cross_app.go
@@ -524,6 +524,7 @@ func (app *MirrorApp) ExecuteSynPackage(ctx sdk.Context, payload []byte, relayer
 		return sdk.ExecuteResult{
 			Payload: ackPackage,
 			Tags:    tags,
+			Err:     types.ErrInvalidMirror("invalid mirror package"),
 		}
 	}
 
@@ -540,6 +541,7 @@ func (app *MirrorApp) ExecuteSynPackage(ctx sdk.Context, payload []byte, relayer
 		return sdk.ExecuteResult{
 			Payload: ackPackage,
 			Tags:    tags,
+			Err:     types.ErrMirrorSymbolExists(fmt.Sprintf("symbol %s already exists", symbol)),
 		}
 	}
 
@@ -700,6 +702,7 @@ func (app *MirrorSyncApp) ExecuteSynPackage(ctx sdk.Context, payload []byte, rel
 		return sdk.ExecuteResult{
 			Payload: ackPackage,
 			Tags:    tags,
+			Err:     types.ErrInvalidMirrorSync("invalid mirror sync package"),
 		}
 	}
 
@@ -720,6 +723,7 @@ func (app *MirrorSyncApp) ExecuteSynPackage(ctx sdk.Context, payload []byte, rel
 		return sdk.ExecuteResult{
 			Tags:    tags,
 			Payload: ackPackage,
+			Err:     types.ErrNotBoundByMirror(fmt.Sprintf("token %s is not bound by mirror", token.GetSymbol())),
 		}
 	}
 
@@ -737,8 +741,10 @@ func (app *MirrorSyncApp) ExecuteSynPackage(ctx sdk.Context, payload []byte, rel
 		return sdk.ExecuteResult{
 			Tags:    tags,
 			Payload: ackPackage,
+			Err:     types.ErrMirrorSyncInvalidSupply(fmt.Sprintf("mirror sync supply %d is invalid", newSupply)),
 		}
 	}
+
 	oldSupply := token.GetTotalSupply().ToInt64()
 	if newSupply > oldSupply {
 		if _, _, sdkError := app.bridgeKeeper.BankKeeper.AddCoins(ctx, token.GetOwner(),

--- a/plugins/bridge/types/errors.go
+++ b/plugins/bridge/types/errors.go
@@ -24,6 +24,11 @@ const (
 	CodeTokenBindRelationChanged sdk.CodeType = 15
 	CodeTransferInExpire         sdk.CodeType = 16
 	CodeScriptsExecutionError    sdk.CodeType = 17
+	CodeInvalidMirror            sdk.CodeType = 18
+	CodeMirrorSymbolExists       sdk.CodeType = 19
+	CodeInvalidMirrorSync        sdk.CodeType = 20
+	CodeNotBoundByMirror         sdk.CodeType = 21
+	CodeMirrorSyncInvalidSupply  sdk.CodeType = 22
 )
 
 //----------------------------------------
@@ -95,4 +100,24 @@ func ErrTransferInExpire(msg string) sdk.Error {
 
 func ErrScriptsExecutionError(msg string) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeScriptsExecutionError, msg)
+}
+
+func ErrInvalidMirror(msg string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidMirror, msg)
+}
+
+func ErrMirrorSymbolExists(msg string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeMirrorSymbolExists, msg)
+}
+
+func ErrInvalidMirrorSync(msg string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidMirrorSync, msg)
+}
+
+func ErrNotBoundByMirror(msg string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeNotBoundByMirror, msg)
+}
+
+func ErrMirrorSyncInvalidSupply(msg string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeMirrorSyncInvalidSupply, msg)
 }


### PR DESCRIPTION
### Description

For now, we did not return error when executing mirror or mirror sync request failed, so recon service can not get the relay fee. So we add the related error for these cross chain apps. 

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

