### PR TITLE
[R4R] add 0.8.1-hf.1 change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1-hf.1
+BUG FIXES
+* [\#823](https://github.com/binance-chain/node/pull/823) [Pub] return error when executing mirror or mirror sync request failed
+
 ## 0.8.1
 FEATURES
 * [\#809](https://github.com/binance-chain/node/pull/809) [Token] Implement BEP84

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.8.1"
+const NodeVersion = "v0.8.1-hf.1"
 
 func init() {
 	Version = fmt.Sprintf("Binance Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

Prepare for release  0.8.1-hf.1
## 0.8.1-hf.1
BUG FIXES
* [\#823](https://github.com/binance-chain/node/pull/823) [Pub] return error when executing mirror or mirror sync request failed

### Rationale
Only impact witness-explorer. It is a soft upgrade.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

