### PR TITLE
List on main market

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -402,7 +402,6 @@ func (app *BinanceChain) initDex() {
 		app.publicationConfig.ShouldPublishAny())
 	app.DexKeeper.SubscribeParamChange(app.ParamHub)
 	app.DexKeeper.SetBUSDSymbol(app.dexConfig.BUSDSymbol)
-	types.BUSDSymbol = app.dexConfig.BUSDSymbol
 
 	// do not proceed if we are in a unit test and `CheckState` is unset.
 	if app.CheckState == nil {

--- a/common/types/token.go
+++ b/common/types/token.go
@@ -28,8 +28,6 @@ const (
 	NativeTokenTotalSupply        = 2e16
 )
 
-var BUSDSymbol string
-
 type IToken interface {
 	GetName() string
 	GetSymbol() string

--- a/plugins/dex/types/msg_growth_market.go
+++ b/plugins/dex/types/msg_growth_market.go
@@ -46,8 +46,11 @@ func (msg ListGrowthMarketMsg) ValidateBasic() sdk.Error {
 		}
 	}
 
-	if msg.QuoteAssetSymbol != types.NativeTokenSymbol && msg.QuoteAssetSymbol != types.BUSDSymbol {
-		return sdk.ErrInvalidCoins("quote token must be " + types.NativeTokenSymbol + " or " + types.BUSDSymbol)
+	if !types.IsValidMiniTokenSymbol(msg.QuoteAssetSymbol) {
+		err := types.ValidateTokenSymbol(msg.QuoteAssetSymbol)
+		if err != nil {
+			return sdk.ErrInvalidCoins("quote token: " + err.Error())
+		}
 	}
 
 	if msg.InitPrice <= 0 {

--- a/plugins/dex/types/msg_growth_market_test.go
+++ b/plugins/dex/types/msg_growth_market_test.go
@@ -24,7 +24,7 @@ func TestGrowthWrongBaseAssetAndQuoteAssetSymbol(t *testing.T) {
 	msg = NewListGrowthMarketMsg(sdk.AccAddress{}, "BTC-000", "BUSD", 1000)
 	err = msg.ValidateBasic()
 	require.NotNil(t, err, "msg should be error")
-	require.Contains(t, err.Error(), "quote token must be BNB or")
+	require.Contains(t, err.Error(), "quote token: suffixed token symbol")
 }
 
 func TestGrowthWrongInitPrice(t *testing.T) {


### PR DESCRIPTION
### Description

 The trading pairs will be directly listed once the listing proposals get passed after voting
### Rationale

Simplifying the listing process to facilitate the listing on Dex
### Example


### Changes

Notable changes: 
* Add hooks OnProposalPassed
* Add more validation when submitting the listing proposal

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

None


