### PR TITLE
Support for Kafka TLS

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -189,12 +189,12 @@ kafkaPassword = "{{ .PublicationConfig.KafkaPassword }}"
 # stop process when publish to Kafka failed
 stopOnKafkaFail = {{ .PublicationConfig.StopOnKafkaFail }}
 
-# tls configuration
-tls = {{ .PublicationConfig.TLS }}
-insecureSkipVerify = {{ .PublicationConfig.InsecureSkipVerify }}
-clientCertPath = "{{ .PublicationConfig.ClientCertPath }}"
-clientKeyPath = "{{ .PublicationConfig.ClientKeyPath }}"
-caCertPath = "{{ .PublicationConfig.CaCertPath }}"
+# kafka tls configuration
+kafkaTLS = {{ .PublicationConfig.KafkaTLS }}
+kafkaInsecureSkipVerify = {{ .PublicationConfig.KafkaInsecureSkipVerify }}
+kafkaClientCertPath = "{{ .PublicationConfig.KafkaClientCertPath }}"
+kafkaClientKeyPath = "{{ .PublicationConfig.KafkaClientKeyPath }}"
+kafkaCaCertPath = "{{ .PublicationConfig.KafkaCaCertPath }}"
 
 # please modify the default value into the version of Kafka you are using
 # kafka broker version, default (and most recommended) is 2.1.0. Minimal supported version could be 0.8.2.0
@@ -362,12 +362,12 @@ type PublicationConfig struct {
 	KafkaUserName   string `mapstructure:"kafkaUserName"`
 	KafkaPassword   string `mapstructure:"kafkaPassword"`
 
-	// tls configuration
-	TLS                bool   `mapstructure:"tls"`
-	InsecureSkipVerify bool   `mapstructure:"insecureSkipVerify"`
-	ClientCertPath     string `mapstructure:"clientCertPath"`
-	ClientKeyPath      string `mapstructure:"clientKeyPath"`
-	CaCertPath         string `mapstructure:"caCertPath"`
+	// kafka tls configuration
+	KafkaTLS                bool   `mapstructure:"kafkaTLS"`
+	KafkaInsecureSkipVerify bool   `mapstructure:"kafkaInsecureSkipVerify"`
+	KafkaClientCertPath     string `mapstructure:"kafkaClientCertPath"`
+	KafkaClientKeyPath      string `mapstructure:"kafkaClientKeyPath"`
+	KafkaCaCertPath         string `mapstructure:"kafkaCaCertPath"`
 
 	KafkaVersion string `mapstructure:"kafkaVersion"`
 }
@@ -439,11 +439,11 @@ func defaultPublicationConfig() *PublicationConfig {
 		KafkaPassword:   "",
 		StopOnKafkaFail: false,
 
-		TLS:                false,
-		InsecureSkipVerify: false,
-		ClientCertPath:     "",
-		ClientKeyPath:      "",
-		CaCertPath:         "",
+		KafkaTLS:                false,
+		KafkaInsecureSkipVerify: false,
+		KafkaClientCertPath:     "",
+		KafkaClientKeyPath:      "",
+		KafkaCaCertPath:         "",
 
 		KafkaVersion: "2.1.0",
 	}

--- a/app/pub/publisher_kafka.go
+++ b/app/pub/publisher_kafka.go
@@ -108,10 +108,10 @@ func (publisher *KafkaMarketDataPublisher) newProducers() (config *sarama.Config
 		config.Net.SASL.Password = Cfg.KafkaPassword
 	}
 
-	if Cfg.TLS {
+	if Cfg.KafkaTLS {
 		config.Net.TLS.Enable = true
-		tlsConfig, err := NewTLSConfig(Cfg.ClientCertPath,
-			Cfg.ClientKeyPath, Cfg.CaCertPath, Cfg.InsecureSkipVerify)
+		tlsConfig, err := NewTLSConfig(Cfg.KafkaClientCertPath,
+			Cfg.KafkaClientKeyPath, Cfg.KafkaCaCertPath, Cfg.KafkaInsecureSkipVerify)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Description

add an option for enabling TLS for Kafka publisher

### Rationale

Some third-party needs the message communicating with kafka to be encrypted via tls for the security concern
### Example

add an example CLI or API response...

### Changes

Notable changes: 
add the tls configuration in app.toml

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

