### PR TITLE
Crypto-level random

### DIFF
--- a/admin/client.go
+++ b/admin/client.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	flagPVPath = "pvpath"
+	errRandF   = "failed to generate random int with error: %s"
 	randMax    = 2147483647
 )
 
@@ -51,8 +52,11 @@ func setModeCmd(cdc *wire.Codec) *cobra.Command {
 			mode := args[0]
 			if mode == "0" || mode == "1" || mode == "2" {
 				cliCtx := context.NewCLIContext().WithCodec(cdc)
-				nTmp, _ := rand.Int(rand.Reader, big.NewInt(randMax))
-				nonce := nTmp.Bytes()
+				nonceB, err := rand.Int(rand.Reader, big.NewInt(randMax))
+				if err != nil {
+					return fmt.Errorf(errRandF, err.Error())
+				}
+				nonce := nonceB.Bytes()
 				sig, err := privKey.Sign([]byte(nonce))
 				if err != nil {
 					return err
@@ -86,8 +90,11 @@ func getModeCmd(cdc *wire.Codec) *cobra.Command {
 			}
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			nTmp, _ := rand.Int(rand.Reader, big.NewInt(randMax))
-			nonce := nTmp.Bytes()
+			nonceB, err := rand.Int(rand.Reader, big.NewInt(randMax))
+			if err != nil {
+				return fmt.Errorf(errRandF, err.Error())
+			}
+			nonce := nonceB.Bytes()
 			sig, err := privKey.Sign([]byte(nonce))
 			if err != nil {
 				return err


### PR DESCRIPTION
### Description

*math/rand* is the fastest for applications that don’t need crypto-level or security-related random data generation. *crypto.rand* is suited for secure and crypto-ready usage, but it’s slower. In the admin cli, the random number has been used on the nonce generation.

### Rationale

Replace math.rand with crypto.rand which generate random integer within 0~2147483647

### Changes

Notable changes:

- Change math.rand to crypto.rand