### PR TITLE
Add cli param to set DefaultKeyPass

### DIFF
--- a/app/genesis.go
+++ b/app/genesis.go
@@ -21,7 +21,8 @@ import (
 	"github.com/binance-chain/node/wire"
 )
 
-const DefaultKeyPass = "12345678"
+//DefaultKeyPass only for private test net
+var DefaultKeyPass = "12345678"
 
 var (
 	// each genesis validators will self delegate 10000e8 native tokens to become a validator

--- a/cmd/bnbchaind/init/init.go
+++ b/cmd/bnbchaind/init/init.go
@@ -118,6 +118,7 @@ enabled, and the genesis file will not be generated.
 		},
 	}
 
+	cmd.Flags().StringVar(&app.DefaultKeyPass, "kpass", "12345678", "defaultKeyPass for client keystore")
 	cmd.Flags().StringP(flagClientHome, "c", app.DefaultCLIHome, "client's home directory")
 	cmd.Flags().BoolP(flagOverwrite, "o", false, "overwrite the genesis.json file")
 	cmd.Flags().String(client.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")

--- a/cmd/bnbchaind/init/testnet.go
+++ b/cmd/bnbchaind/init/testnet.go
@@ -91,6 +91,7 @@ Example:
 	app.ServerContext.BindPFlag("addr.bech32PrefixAccAddr", cmd.Flags().Lookup(flagAccPrefix))
 	cmd.Flags().StringSlice(flagMonikers, nil, "specify monikers for nodes if needed")
 	cmd.Flags().String(flagNodeInfoOutputFile, "", "the file containing all node info with json format, if not specified, will just print it")
+	cmd.Flags().StringVar(&app.DefaultKeyPass, "kpass", "12345678", "defaultKeyPass for client keystore")
 
 	return cmd
 }


### PR DESCRIPTION
### Description

On the genesis default key pass is hardcoded. The complexity is only defined with sequential numbers.

### Rationale

Add a command line flag to set password for keystore, just used for private testnet.

### Changes

Notable changes:

- Add flag for bnbchaind under subcommand *init, testnet* with `--kpass`