### PR TITLE
Upgrade go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/binance-chain/node
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Shopify/sarama v1.21.0
@@ -23,8 +23,134 @@ require (
 	github.com/tendermint/iavl v0.12.4
 	github.com/tendermint/tendermint v0.32.3
 	go.uber.org/ratelimit v0.1.0
+)
+
+require (
+	github.com/DataDog/zstd v1.3.5 // indirect
+	github.com/bartekn/go-bip39 v0.0.0-20171116152956-a05967ea095d // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/binance-chain/tss v0.1.2 // indirect
+	github.com/binance-chain/tss-lib v1.0.0 // indirect
+	github.com/btcsuite/btcd v0.20.0-beta // indirect
+	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d // indirect
+	github.com/cosmos/ledger-go v0.9.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
+	github.com/eapache/queue v1.1.0 // indirect
+	github.com/etcd-io/bbolt v1.3.3 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/gorilla/websocket v1.4.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/huin/goupnp v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/ipfs/go-cid v0.0.3 // indirect
+	github.com/ipfs/go-datastore v0.0.5 // indirect
+	github.com/ipfs/go-ipfs-util v0.0.1 // indirect
+	github.com/ipfs/go-log v0.0.1 // indirect
+	github.com/ipfs/go-todocounter v0.0.1 // indirect
+	github.com/jackpal/gateway v1.0.5 // indirect
+	github.com/jackpal/go-nat-pmp v1.0.1 // indirect
+	github.com/jbenet/go-temp-err-catcher v0.0.0-20150120210811-aac704a3f4f2 // indirect
+	github.com/jbenet/goprocess v0.1.3 // indirect
+	github.com/jmhodges/levigo v1.0.0 // indirect
+	github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b // indirect
+	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
+	github.com/libp2p/go-addr-util v0.0.1 // indirect
+	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
+	github.com/libp2p/go-conn-security-multistream v0.1.0 // indirect
+	github.com/libp2p/go-eventbus v0.1.0 // indirect
+	github.com/libp2p/go-flow-metrics v0.0.1 // indirect
+	github.com/libp2p/go-libp2p v0.3.0 // indirect
+	github.com/libp2p/go-libp2p-autonat v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-circuit v0.1.1 // indirect
+	github.com/libp2p/go-libp2p-core v0.2.2 // indirect
+	github.com/libp2p/go-libp2p-discovery v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-kad-dht v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-kbucket v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-loggables v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-mplex v0.2.1 // indirect
+	github.com/libp2p/go-libp2p-nat v0.0.4 // indirect
+	github.com/libp2p/go-libp2p-peerstore v0.1.3 // indirect
+	github.com/libp2p/go-libp2p-record v0.1.1 // indirect
+	github.com/libp2p/go-libp2p-routing v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-secio v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-swarm v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-transport-upgrader v0.1.1 // indirect
+	github.com/libp2p/go-libp2p-yamux v0.2.1 // indirect
+	github.com/libp2p/go-maddr-filter v0.0.5 // indirect
+	github.com/libp2p/go-mplex v0.1.0 // indirect
+	github.com/libp2p/go-msgio v0.0.4 // indirect
+	github.com/libp2p/go-nat v0.0.3 // indirect
+	github.com/libp2p/go-openssl v0.0.2 // indirect
+	github.com/libp2p/go-reuseport v0.0.1 // indirect
+	github.com/libp2p/go-reuseport-transport v0.0.2 // indirect
+	github.com/libp2p/go-stream-muxer-multistream v0.2.0 // indirect
+	github.com/libp2p/go-tcp-transport v0.1.0 // indirect
+	github.com/libp2p/go-ws-transport v0.1.0 // indirect
+	github.com/libp2p/go-yamux v1.2.3 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
+	github.com/minio/sha256-simd v0.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/mr-tron/base58 v1.1.2 // indirect
+	github.com/multiformats/go-base32 v0.0.3 // indirect
+	github.com/multiformats/go-multiaddr v0.0.4 // indirect
+	github.com/multiformats/go-multiaddr-dns v0.0.3 // indirect
+	github.com/multiformats/go-multiaddr-fmt v0.0.1 // indirect
+	github.com/multiformats/go-multiaddr-net v0.0.1 // indirect
+	github.com/multiformats/go-multibase v0.0.1 // indirect
+	github.com/multiformats/go-multihash v0.0.7 // indirect
+	github.com/multiformats/go-multistream v0.1.0 // indirect
+	github.com/opentracing/opentracing-go v1.1.0 // indirect
+	github.com/otiai10/primes v0.0.0-20180210170552-f6d2a1ba97c4 // indirect
+	github.com/pelletier/go-toml v1.4.0 // indirect
+	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
+	github.com/prometheus/common v0.6.0 // indirect
+	github.com/prometheus/procfs v0.0.3 // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 // indirect
+	github.com/rs/cors v1.6.0 // indirect
+	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/spf13/afero v1.2.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 // indirect
+	github.com/tendermint/btcd v0.1.1 // indirect
+	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc // indirect
+	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
+	github.com/whyrusleeping/go-logging v0.0.1 // indirect
+	github.com/whyrusleeping/go-notifier v0.0.0-20170827234753-097c5d47330f // indirect
+	github.com/whyrusleeping/mafmt v1.2.8 // indirect
+	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
+	github.com/zondax/hid v0.9.0 // indirect
+	github.com/zondax/ledger-cosmos-go v0.9.9 // indirect
+	go.opencensus.io v0.22.0 // indirect
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
+	golang.org/x/net v0.0.0-20191021144547-ec77196f6094 // indirect
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
+	google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb // indirect
+	google.golang.org/grpc v1.23.0 // indirect
 	gopkg.in/linkedin/goavro.v1 v1.0.5 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/yaml.v2 v2.2.4 // indirect
 )
 
 replace (


### PR DESCRIPTION
### Description

The go.mod file in thornode enforces a minimum version requirement of go 1.16. Unfortunately, these versions of Go contain vulnerabilities that may affect the confidentiality, integrity, or availability of an application built with it. An example of a bug that could have a severe impact on networked applications is CVE-2021-31525, which enables remote attackers to cause a denial of service via a large header to ReadRequest or ReadResponse in net/http.

### Rationale

Upgrade go version

### Changes

Notable changes:

- Update go.mod setting go version to 1.17