### PR TITLE
Remove useless code

### DIFF
--- a/plugins/api/cli.go
+++ b/plugins/api/cli.go
@@ -20,7 +20,6 @@ import (
 // that exposes functionality similar to the cli, but over http
 func ServeCommand(cdc *wire.Codec) *cobra.Command {
 	flagListenAddr := "laddr"
-	flagCORS := "cors"
 	flagMaxOpenConnections := "max-open"
 
 	cmd := &cobra.Command{
@@ -63,7 +62,6 @@ func ServeCommand(cdc *wire.Codec) *cobra.Command {
 	}
 
 	cmd.Flags().String(flagListenAddr, "tcp://localhost:8080", "The address for the server to listen on")
-	cmd.Flags().String(flagCORS, "", "Set the domains that can make CORS requests (* for all)")
 	cmd.Flags().String(sdk.FlagChainID, "", "The chain ID to connect to")
 	cmd.Flags().String(sdk.FlagNode, "tcp://localhost:26657", "Address of the node to connect to")
 	cmd.Flags().Int(flagMaxOpenConnections, 1000, "The number of maximum open connections")


### PR DESCRIPTION
### Description

There's no need to support *CORS* flag

### Rationale

Just remove CORS flag and related variable

### Changes

Notable changes:

- Remove flag `--cors`