### PR TITLE
Add go compiler build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TENDER_RELEASE := $(shell grep 'github.com/binance-chain/bnc-tendermint' go.mod|
 BUILD_TAGS = netgo
 
 BUILD_CLI_TAGS = netgo
-BUILD_FLAGS = -mod=readonly -tags "${BUILD_TAGS}" -ldflags "-X github.com/binance-chain/node/version.GitCommit=${COMMIT_HASH} -X github.com/binance-chain/node/version.CosmosRelease=${COSMOS_RELEASE} -X github.com/binance-chain/node/version.TendermintRelease=${TENDER_RELEASE}"
+BUILD_FLAGS = -mod=readonly -tags "${BUILD_TAGS}" -ldflags "-w -s -X github.com/binance-chain/node/version.GitCommit=${COMMIT_HASH} -X github.com/binance-chain/node/version.CosmosRelease=${COSMOS_RELEASE} -X github.com/binance-chain/node/version.TendermintRelease=${TENDER_RELEASE}" -trimpath
 BUILD_CLI_FLAGS = -tags "${BUILD_CLI_TAGS}" -ldflags "-X github.com/binance-chain/node/version.GitCommit=${COMMIT_HASH} -X github.com/binance-chain/node/version.CosmosRelease=${COSMOS_RELEASE} -X github.com/binance-chain/node/version.TendermintRelease=${TENDER_RELEASE}"
 # Without -lstdc++ on CentOS we will encounter link error, solution comes from: https://stackoverflow.com/a/29285011/1147187
 BUILD_CGOFLAGS = CGO_ENABLED=1 CGO_LDFLAGS="-lleveldb -lsnappy -lstdc++"


### PR DESCRIPTION
### Description

Some of the `Go` compiler build flags are not configured. The use of compiler flags and compiler sequences can optimize and improve the performance of specific types of the applications.

### Rationale

- Add ldflags `-w -s` to turns off DWARF debugging information and symbol table.
- Add `-trimpath` to remove file system paths

### Changes

Notable changes:

- Add ldflags `-w -s` and `-trimpath` in compile script.