### PR TITLE
Tidy todo comments

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -521,7 +521,6 @@ func (app *BinanceChain) initStaking() {
 			MinDelegationChange: 1e8,
 		})
 		app.stakeKeeper.SetPool(newCtx, stake.Pool{
-			// TODO: optimize these parameters
 			LooseTokens: sdk.NewDec(5e15),
 		})
 	})
@@ -755,10 +754,6 @@ func (app *BinanceChain) PreDeliverTx(req abci.RequestDeliverTx) (res abci.Respo
 	if res.IsErr() {
 		txHash := cmn.HexBytes(tmhash.Sum(req.Tx)).String()
 		app.Logger.Error("failed to process invalid tx during pre-deliver", "tx", txHash, "res", res.String())
-		// TODO(#446): comment out temporally for thread safety
-		//if app.publicationConfig.PublishOrderUpdates {
-		//	app.processErrAbciResponseForPub(txBytes)
-		//}
 	}
 	return res
 }
@@ -855,7 +850,6 @@ func (app *BinanceChain) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) a
 	pub.Pool.Clean()
 	//match may end with transaction failure, which is better to save into
 	//the EndBlock response. However, current cosmos doesn't support this.
-	//future TODO: add failure info.
 	return abci.ResponseEndBlock{
 		ValidatorUpdates: validatorUpdates,
 		Events:           ctx.EventManager().ABCIEvents(),

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -512,10 +512,8 @@ type UpgradeConfig struct {
 	LotSizeUpgradeHeight       int64 `mapstructure:"LotSizeUpgradeHeight"`
 	ListingRuleUpgradeHeight   int64 `mapstructure:"ListingRuleUpgradeHeight"`
 	FixZeroBalanceHeight       int64 `mapstructure:"FixZeroBalanceHeight"`
-	// TODO: add upgrade name
-	LaunchBscUpgradeHeight int64 `mapstructure:"LaunchBscUpgradeHeight"`
+	LaunchBscUpgradeHeight     int64 `mapstructure:"LaunchBscUpgradeHeight"`
 
-	// TODO: add upgrade name
 	BEP8Height  int64 `mapstructure:"BEP8Height"`
 	BEP67Height int64 `mapstructure:"BEP67Height"`
 	BEP70Height int64 `mapstructure:"BEP70Height"`

--- a/app/fee_distribution.go
+++ b/app/fee_distribution.go
@@ -77,8 +77,6 @@ func distributeFee(ctx sdk.Context, am auth.AccountKeeper, valAddrCache *ValAddr
 		avgTokens := sdk.Coins{}
 		roundingTokens := sdk.Coins{}
 		for _, token := range fee.Tokens {
-			// TODO: int64 is enough, will drop big.Int
-			// TODO: temporarily, the validators average the fees. Will change to use power as a weight to calc fees.
 			amount := token.Amount
 			avgAmount := amount / valSize
 			roundingAmount := amount - avgAmount*valSize

--- a/app/pub/msgs.go
+++ b/app/pub/msgs.go
@@ -156,7 +156,6 @@ func (msg *ExecutionResults) ToNativeMap() map[string]interface{} {
 func (msg *ExecutionResults) EssentialMsg() string {
 	// mainly used to recover for large breathe block expiring message, there should be no trade on breathe block
 	orders := msg.Orders.EssentialMsg()
-	//TODO output other fields: trades, stakeUpdate etc.
 	return fmt.Sprintf("height:%d\ntime:%d\norders:\n%s\n", msg.Height, msg.Timestamp, orders)
 }
 

--- a/common/log/async_file_writer.go
+++ b/common/log/async_file_writer.go
@@ -178,7 +178,7 @@ func (w *AsyncFileWriter) Stop() {
 }
 
 func (w *AsyncFileWriter) Write(msg []byte) (n int, err error) {
-	// TODO(wuzhenxing): for the underlying array may change, is there a better way to avoid copying slice?
+	// TODO: for the underlying array may change, is there a better way to avoid copying slice?
 	buf := make([]byte, len(msg))
 	copy(buf, msg)
 

--- a/common/tx/ante.go
+++ b/common/tx/ante.go
@@ -151,7 +151,6 @@ func NewAnteHandler(am auth.AccountKeeper) sdk.AnteHandler {
 		}
 
 		// collect signer accounts
-		// TODO: abort if there is more than one signer?
 		var signerAccs = make([]sdk.Account, len(signerAddrs))
 		txHash, _ := ctx.Value(baseapp.TxHashKey).(string)
 		chainID := ctx.ChainID()
@@ -321,7 +320,6 @@ func processSig(txHash string,
 
 func calcAndCollectFees(ctx sdk.Context, am auth.AccountKeeper, acc sdk.Account, msg sdk.Msg, txHash string) sdk.Result {
 	// first sig pays the fees
-	// TODO: Add min fees
 	// Can this function be moved outside of the loop?
 
 	fee, err := calculateFees(msg)

--- a/common/types/mini_token.go
+++ b/common/types/mini_token.go
@@ -67,7 +67,7 @@ type MiniToken struct {
 	Owner            sdk.AccAddress  `json:"owner"`
 	Mintable         bool            `json:"mintable"`
 	TokenType        SupplyRangeType `json:"token_type"`
-	TokenURI         string          `json:"token_uri"` //TODO set max length
+	TokenURI         string          `json:"token_uri"`
 	ContractAddress  string          `json:"contract_address,omitempty"`
 	ContractDecimals int8            `json:"contract_decimals,omitempty"`
 }

--- a/common/upgrade/upgrade.go
+++ b/common/upgrade/upgrade.go
@@ -23,7 +23,6 @@ const (
 	ListingRuleUpgrade   = "ListingRuleUpgrade" // Remove restriction that only the owner of base asset can list trading pair
 	FixZeroBalance       = "FixZeroBalance"
 
-	// TODO: add upgrade name
 	LaunchBscUpgrade = sdk.LaunchBscUpgrade
 
 	EnableAccountScriptsForCrossChainTransfer = "EnableAccountScriptsForCrossChainTransfer"

--- a/plugins/api/routes.go
+++ b/plugins/api/routes.go
@@ -85,9 +85,6 @@ func (s *server) bindRoutes() *server {
 		Queries("offset", "{offset:[0-9]+}", "limit", "{limit:[0-9]+}").
 		Methods("GET")
 
-	// legacy plugin routes
-	// TODO: make these more like the above for simplicity.
-
 	// keys rest routes disabled for security. while the nodes with keys (validators) run in a secure ringfenced environment,
 	// disabling this is a precaution to protect third-party validators that might not have protected their networks adequately.
 	//keys.RegisterRoutes(r, true)

--- a/plugins/dex/abci.go
+++ b/plugins/dex/abci.go
@@ -15,7 +15,6 @@ import (
 	"github.com/binance-chain/node/plugins/dex/utils"
 )
 
-// TODO: improve, should be configurable
 const MaxDepthLevels = 1000    // matches UI requirement
 const DefaultDepthLevels = 100 // matches UI requirement
 
@@ -91,7 +90,6 @@ func createAbciQueryHandler(keeper *DexKeeper, abciQueryPrefix string) app.AbciQ
 						queryPrefix, path),
 				}
 			}
-			//TODO: sync lock, validate pair
 			if len(path) < 3 {
 				return &abci.ResponseQuery{
 					Code: uint32(sdk.CodeUnknownRequest),

--- a/plugins/dex/matcheng/unrolledlinkedlist.go
+++ b/plugins/dex/matcheng/unrolledlinkedlist.go
@@ -75,7 +75,6 @@ func (b *bucket) insert(p *PriceLevel, compare Comparator) int {
 	k := len(b.elements)
 	i := sort.Search(k, func(i int) bool { return compare(b.elements[i].Price, p.Price) < 0 })
 	if i > 0 && compare(b.elements[i-1].Price, p.Price) == 0 {
-		//TODO: overwrite?
 		return 0 // duplicated
 	}
 	if i == k { // not found

--- a/plugins/dex/order/keeper.go
+++ b/plugins/dex/order/keeper.go
@@ -509,7 +509,6 @@ func (kp *DexKeeper) ClearAfterMatch() {
 }
 
 func (kp *DexKeeper) StoreTradePrices(ctx sdk.Context) {
-	// TODO: check block height != 0
 	if ctx.BlockHeight()%pricesStoreEvery == 0 {
 		lastTradePrices := make(map[string]int64, len(kp.engines))
 		for symbol, engine := range kp.engines {
@@ -920,7 +919,7 @@ func (kp *DexKeeper) CanDelistTradingPair(ctx sdk.Context, baseAsset, quoteAsset
 	}
 
 	tradingPairs := kp.PairMapper.ListAllTradingPairs(ctx)
-	for _, pair := range tradingPairs { //TODO
+	for _, pair := range tradingPairs {
 		if (pair.BaseAssetSymbol == symbolToCheck && pair.QuoteAssetSymbol != types.NativeTokenSymbol) ||
 			(pair.QuoteAssetSymbol == symbolToCheck && pair.BaseAssetSymbol != types.NativeTokenSymbol) {
 			return fmt.Errorf("trading pair %s_%s should not exist before delisting %s_%s",

--- a/plugins/tokens/client/rest/helpers.go
+++ b/plugins/tokens/client/rest/helpers.go
@@ -36,8 +36,6 @@ func GetBalances(
 	for _, coin := range coins {
 		denom := coin.Denom
 		exists := tokens.ExistsCC(ctx, denom)
-		// TODO: we probably actually want to show zero balances.
-		// if exists && !sdk.Int.IsZero(coins.AmountOf(denom)) {
 		if exists {
 			denoms[denom] = true
 		}


### PR DESCRIPTION
### Description

There're quite a lot `todo` comments, should get rid of them.

### Rationale

Screen out `todo`s security/feature related for furthur development, and remove those which are useless. 

### Changes

Notable changes:

- Remove some `todo` comments.