### PR TITLE
Change word binance to bnb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-BinanceChain
+BNB Beacon Chain
 ------------
 
-BinanceChain is a blockchain with a flexible set of native assets and pluggable modules. It uses [tendermint](https://tendermint.com) for consensus and app logic is written in golang. It targets fast block times, a native dApp layer and multi-token support with no smart contract VM.
+BNB Beacon Chain is a blockchain with a flexible set of native assets and pluggable modules. It uses [tendermint](https://tendermint.com) for consensus and app logic is written in golang. It targets fast block times, a native dApp layer and multi-token support with no smart contract VM.
 
 This is a fork of [basecoin](https://github.com/cosmos/cosmos-sdk/tree/master/examples/basecoin) and is already functional as a multi-asset cryptocurrency blockchain and DEX; see below for instructions on how to use it.
 
@@ -38,7 +38,7 @@ $ make get_vendor_deps
 $ make install
 ```
 
-> If you want run bnbchaind with cleveldb as backend, please ensure leveldb is installed: https://github.com/google/leveldb#building, 
+> If you want run bnbchaind with cleveldb as backend, please ensure leveldb is installed: https://github.com/google/leveldb#building,
 > and change `make install` to `make install_c`
 > For mac, `brew install leveldb` would help. For linux, you can build from source
 
@@ -56,7 +56,7 @@ You may need add BNBCHAINPATH to the environment variables.
 > make install
 ```
 
-> If you encounter some network issues when downloading the dependencies, make sure you have configured shadowsocks correctly and switch to global mode. Run `set(win)/export(linux/mac) https_proxy=127.0.0.1:1080` if you still have https issues. 
+> If you encounter some network issues when downloading the dependencies, make sure you have configured shadowsocks correctly and switch to global mode. Run `set(win)/export(linux/mac) https_proxy=127.0.0.1:1080` if you still have https issues.
 
 To test that installation worked, try to run the cli tool:
 

--- a/cmd/lightd/main.go
+++ b/cmd/lightd/main.go
@@ -49,7 +49,7 @@ var (
 func init() {
 	LiteCmd.Flags().StringVar(&listenAddr, "laddr", "tcp://localhost:27147", "Serve the proxy on the given address")
 	LiteCmd.Flags().StringVar(&nodeAddr, "node", "tcp://localhost:27147", "Connect to a binance node at this address")
-	LiteCmd.Flags().StringVar(&chainID, "chain-id", "bnbchain", "Specify the binance chain ID")
+	LiteCmd.Flags().StringVar(&chainID, "chain-id", "bnbchain", "Specify the bnb beacon chain ID")
 	LiteCmd.Flags().StringVar(&home, "home-dir", ".binance-lite", "Specify the home directory")
 	LiteCmd.Flags().IntVar(&maxOpenConnections, "max-open-connections", 900, "Maximum number of simultaneous connections (including WebSocket).")
 	LiteCmd.Flags().IntVar(&cacheSize, "cache-size", 10, "Specify the memory trust store cache size")

--- a/version/version.go
+++ b/version/version.go
@@ -15,9 +15,9 @@ var (
 const NodeVersion = "v0.8.3"
 
 func init() {
-	Version = fmt.Sprintf("Binance Chain Release: %s;", NodeVersion)
+	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)
 	if GitCommit != "" {
-		Version += fmt.Sprintf("Binance Chain Commit: %s;", GitCommit)
+		Version += fmt.Sprintf("BNB Beacon Chain Commit: %s;", GitCommit)
 	}
 	if CosmosRelease != "" {
 		Version += fmt.Sprintf(" Cosmos Release: %s;", CosmosRelease)


### PR DESCRIPTION
### Description

Binance chain has been renamed to BNB Beacon chain, modify related spelling. 

### Rationale

Change related words from Binance chain to BNB Beacon chain.

### Changes

Notable changes:

- Modify some word spelling.