### PR TITLE
[R4R]feat: decommission decentralized exchange on BNB Beacon Chain

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -328,6 +328,7 @@ func SetUpgradeConfig(upgradeConfig *config.UpgradeConfig) {
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP87, upgradeConfig.BEP87Height)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.FixFailAckPackage, upgradeConfig.FixFailAckPackageHeight)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP128, upgradeConfig.BEP128Height)
+	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP151, upgradeConfig.BEP151Height)
 
 	// register store keys of upgrade
 	upgrade.Mgr.RegisterStoreKeys(upgrade.BEP9, common.TimeLockStoreKey.Name())

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -87,6 +87,8 @@ FixFailAckPackageHeight = {{ .UpgradeConfig.FixFailAckPackageHeight }}
 EnableAccountScriptsForCrossChainTransferHeight = {{ .UpgradeConfig.EnableAccountScriptsForCrossChainTransferHeight }}
 # Block height of BEP128 upgrade
 BEP128Height = {{ .UpgradeConfig.BEP128Height }}
+# Block height of BEP151 upgrade
+BEP151Height = {{ .UpgradeConfig.BEP151Height }}
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]
@@ -526,6 +528,7 @@ type UpgradeConfig struct {
 	FixFailAckPackageHeight                         int64 `mapstructure:"FixFailAckPackageHeight"`
 	EnableAccountScriptsForCrossChainTransferHeight int64 `mapstructure:"EnableAccountScriptsForCrossChainTransferHeight"`
 	BEP128Height                                    int64 `mapstructure:"BEP128Height"`
+	BEP151Height                                    int64 `mapstructure:"BEP151Height"`
 }
 
 func defaultUpgradeConfig() *UpgradeConfig {
@@ -546,6 +549,7 @@ func defaultUpgradeConfig() *UpgradeConfig {
 		BEP70Height:                1,
 		LaunchBscUpgradeHeight:     1,
 		BEP128Height:               math.MaxInt64,
+		BEP151Height:               math.MaxInt64,
 		BEP82Height:                math.MaxInt64,
 		BEP84Height:                math.MaxInt64,
 		BEP87Height:                math.MaxInt64,

--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -57,7 +57,7 @@ EnableAccountScriptsForCrossChainTransferHeight = 7841000
 #Block height of BEP128 upgrade
 BEP128Height = 23551600
 #Block height of BEP151 upgrade
-BEP151Height = 28250121
+BEP151Height = 28250000
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]

--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -56,6 +56,8 @@ FixFailAckPackageHeight = 7841000
 EnableAccountScriptsForCrossChainTransferHeight = 7841000
 #Block height of BEP128 upgrade
 BEP128Height = 23551600
+#Block height of BEP151 upgrade
+BEP151Height = 28250121
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]

--- a/common/upgrade/upgrade.go
+++ b/common/upgrade/upgrade.go
@@ -38,6 +38,7 @@ const (
 	FixFailAckPackage = sdk.FixFailAckPackage
 
 	BEP128 = sdk.BEP128 // https://github.com/bnb-chain/BEPs/pull/128 Staking reward distribution upgrade
+	BEP151 = "BEP151"   // https://github.com/bnb-chain/BEPs/pull/151 Dex Prune Upgrade
 )
 
 func UpgradeBEP10(before func(), after func()) {

--- a/common/upgrade/upgrade.go
+++ b/common/upgrade/upgrade.go
@@ -38,7 +38,7 @@ const (
 	FixFailAckPackage = sdk.FixFailAckPackage
 
 	BEP128 = sdk.BEP128 // https://github.com/bnb-chain/BEPs/pull/128 Staking reward distribution upgrade
-	BEP151 = "BEP151"   // https://github.com/bnb-chain/BEPs/pull/151 Dex Prune Upgrade
+	BEP151 = "BEP151"   // https://github.com/bnb-chain/BEPs/pull/151 Decommission Decentralized Exchange
 )
 
 func UpgradeBEP10(before func(), after func()) {

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -40,7 +40,6 @@ function prepare_node() {
 	$(cd "./${home}/config" && sed -i -e "s/BEP8Height = 9223372036854775807/BEP8Height = 1/g" app.toml)
 	$(cd "./${home}/config" && sed -i -e "s/BEP67Height = 9223372036854775807/BEP67Height = 1/g" app.toml)
 	$(cd "./${home}/config" && sed -i -e "s/BEP70Height = 9223372036854775807/BEP70Height = 1/g" app.toml)
-#	$(cd "./${home}/config" && sed -i -e "s/BEP151Height = 9223372036854775807/BEP151Height = 1/g" app.toml)
 
 	# stop and start node
 	ps -ef  | grep bnbchaind | grep testnoded | awk '{print $2}' | xargs kill -9

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -40,7 +40,7 @@ function prepare_node() {
 	$(cd "./${home}/config" && sed -i -e "s/BEP8Height = 9223372036854775807/BEP8Height = 1/g" app.toml)
 	$(cd "./${home}/config" && sed -i -e "s/BEP67Height = 9223372036854775807/BEP67Height = 1/g" app.toml)
 	$(cd "./${home}/config" && sed -i -e "s/BEP70Height = 9223372036854775807/BEP70Height = 1/g" app.toml)
-	$(cd "./${home}/config" && sed -i -e "s/BEP151Height = 9223372036854775807/BEP151Height = 1/g" app.toml)
+#	$(cd "./${home}/config" && sed -i -e "s/BEP151Height = 9223372036854775807/BEP151Height = 1/g" app.toml)
 
 	# stop and start node
 	ps -ef  | grep bnbchaind | grep testnoded | awk '{print $2}' | xargs kill -9

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -40,7 +40,7 @@ function prepare_node() {
 	$(cd "./${home}/config" && sed -i -e "s/BEP8Height = 9223372036854775807/BEP8Height = 1/g" app.toml)
 	$(cd "./${home}/config" && sed -i -e "s/BEP67Height = 9223372036854775807/BEP67Height = 1/g" app.toml)
 	$(cd "./${home}/config" && sed -i -e "s/BEP70Height = 9223372036854775807/BEP70Height = 1/g" app.toml)
-#	$(cd "./${home}/config" && sed -i -e "s/BEP151Height = 9223372036854775807/BEP151Height = 1/g" app.toml)
+	$(cd "./${home}/config" && sed -i -e "s/BEP151Height = 9223372036854775807/BEP151Height = 1/g" app.toml)
 
 	# stop and start node
 	ps -ef  | grep bnbchaind | grep testnoded | awk '{print $2}' | xargs kill -9

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -40,6 +40,7 @@ function prepare_node() {
 	$(cd "./${home}/config" && sed -i -e "s/BEP8Height = 9223372036854775807/BEP8Height = 1/g" app.toml)
 	$(cd "./${home}/config" && sed -i -e "s/BEP67Height = 9223372036854775807/BEP67Height = 1/g" app.toml)
 	$(cd "./${home}/config" && sed -i -e "s/BEP70Height = 9223372036854775807/BEP70Height = 1/g" app.toml)
+#	$(cd "./${home}/config" && sed -i -e "s/BEP151Height = 9223372036854775807/BEP151Height = 1/g" app.toml)
 
 	# stop and start node
 	ps -ef  | grep bnbchaind | grep testnoded | awk '{print $2}' | xargs kill -9

--- a/plugins/dex/list/handler.go
+++ b/plugins/dex/list/handler.go
@@ -22,6 +22,9 @@ func NewHandler(keeper *order.DexKeeper, tokenMapper tokens.Mapper, govKeeper go
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		switch msg := msg.(type) {
 		case types.ListMsg:
+			if sdk.IsUpgrade(upgrade.BEP151) {
+				return sdk.ErrMsgNotSupported("ListMsg disabled in BEP-151").Result()
+			}
 			return handleList(ctx, keeper, tokenMapper, govKeeper, msg)
 		case types.ListMiniMsg:
 			if sdk.IsUpgrade(upgrade.BEP151) {

--- a/plugins/dex/list/handler.go
+++ b/plugins/dex/list/handler.go
@@ -24,6 +24,9 @@ func NewHandler(keeper *order.DexKeeper, tokenMapper tokens.Mapper, govKeeper go
 		case types.ListMsg:
 			return handleList(ctx, keeper, tokenMapper, govKeeper, msg)
 		case types.ListMiniMsg:
+			if sdk.IsUpgrade(upgrade.BEP151) {
+				return sdk.ErrMsgNotSupported("ListMiniMsg disabled in BEP-151").Result()
+			}
 			return handleListMini(ctx, keeper, tokenMapper, msg)
 		default:
 			errMsg := fmt.Sprintf("Unrecognized dex msg type: %v", reflect.TypeOf(msg).Name())

--- a/plugins/dex/order/handler.go
+++ b/plugins/dex/order/handler.go
@@ -27,6 +27,9 @@ func NewHandler(dexKeeper *DexKeeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		switch msg := msg.(type) {
 		case NewOrderMsg:
+			if sdk.IsUpgrade(upgrade.BEP151) {
+				return sdk.ErrMsgNotSupported("NewOrderMsg disabled in BEP-151").Result()
+			}
 			return handleNewOrder(ctx, dexKeeper, msg)
 		case CancelOrderMsg:
 			return handleCancelOrder(ctx, dexKeeper, msg)


### PR DESCRIPTION
### Description

BNB Beacon Chain’s primary focus, its native decentralized application ("dApp") BNB DEX, has demonstrated its low-latency matching with large capacity headroom. With the development of BNB Smart Chain and AMM-based decentralized exchanges running well on it, BNB DEX has less usage and liquidity. After implementing this BEP, the DEX module will be disabled, which will give Beacon Chain more computing power for the future computing and governance focuses.
### Rationale

BNB Beacon Chain(BC) is a blockchain developed by the BNB Chain community that implements a vision of a decentralized exchange (DEX) for digital assets. The heart of Beacon Chain is a highly performant matching engine built on distributed consensus that aims to replicate the < 1 second trading efficiency of current centralized exchanges.

Since BNB Smart Chain's(BSC) launch to mainnet in 2020, the AMM based decentralized exchanges gain great success on BSC which even steal the thunder of order-book based DEX on BC. BC and BSC is a dual chain structure, with the evolution of this structure, BC plays more like a Beacon Chain that helps to enhance the security of BSC as a staking and governance layer. It is not suitable for a Beacon Chain to sustain a high-performance DEX any longer, especially when there is another DEX with massive adoption in the same ecosystem.

Decommissioning the DEX module will reduce the need for system resources significantly for both validators and full nodes. The demand for liquidation can be fulfilled by BNB Smart Chain or the upcoming zkBAS.

### Example


### Changes

* Add a BEP-151 upgrade flag.
* Return error for `NewOrderMsg` when BEP-151 upgrade activates.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by



### Related issues

https://github.com/bnb-chain/BEPs/pull/151

