### PR TITLE
[R4R] prepare for release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0
+IMPROVEMENTS
+* [\#875](https://github.com/bnb-chain/node/pull/875) [DEX] Implement BEP151
+
 ## 0.9.2
 IMPROVEMENTS
 * [\#865](https://github.com/bnb-chain/node/pull/865) [CI] Build state recover tool in release job

--- a/app/app.go
+++ b/app/app.go
@@ -328,6 +328,7 @@ func SetUpgradeConfig(upgradeConfig *config.UpgradeConfig) {
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP87, upgradeConfig.BEP87Height)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.FixFailAckPackage, upgradeConfig.FixFailAckPackageHeight)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP128, upgradeConfig.BEP128Height)
+	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP151, upgradeConfig.BEP151Height)
 
 	// register store keys of upgrade
 	upgrade.Mgr.RegisterStoreKeys(upgrade.BEP9, common.TimeLockStoreKey.Name())

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -87,6 +87,8 @@ FixFailAckPackageHeight = {{ .UpgradeConfig.FixFailAckPackageHeight }}
 EnableAccountScriptsForCrossChainTransferHeight = {{ .UpgradeConfig.EnableAccountScriptsForCrossChainTransferHeight }}
 # Block height of BEP128 upgrade
 BEP128Height = {{ .UpgradeConfig.BEP128Height }}
+# Block height of BEP151 upgrade
+BEP151Height = {{ .UpgradeConfig.BEP151Height }}
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]
@@ -526,6 +528,7 @@ type UpgradeConfig struct {
 	FixFailAckPackageHeight                         int64 `mapstructure:"FixFailAckPackageHeight"`
 	EnableAccountScriptsForCrossChainTransferHeight int64 `mapstructure:"EnableAccountScriptsForCrossChainTransferHeight"`
 	BEP128Height                                    int64 `mapstructure:"BEP128Height"`
+	BEP151Height                                    int64 `mapstructure:"BEP151Height"`
 }
 
 func defaultUpgradeConfig() *UpgradeConfig {
@@ -546,6 +549,7 @@ func defaultUpgradeConfig() *UpgradeConfig {
 		BEP70Height:                1,
 		LaunchBscUpgradeHeight:     1,
 		BEP128Height:               math.MaxInt64,
+		BEP151Height:               math.MaxInt64,
 		BEP82Height:                math.MaxInt64,
 		BEP84Height:                math.MaxInt64,
 		BEP87Height:                math.MaxInt64,

--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -56,6 +56,8 @@ FixFailAckPackageHeight = 7841000
 EnableAccountScriptsForCrossChainTransferHeight = 7841000
 #Block height of BEP128 upgrade
 BEP128Height = 23551600
+#Block height of BEP151 upgrade
+BEP151Height = 28250000
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]

--- a/common/upgrade/upgrade.go
+++ b/common/upgrade/upgrade.go
@@ -38,6 +38,7 @@ const (
 	FixFailAckPackage = sdk.FixFailAckPackage
 
 	BEP128 = sdk.BEP128 // https://github.com/bnb-chain/BEPs/pull/128 Staking reward distribution upgrade
+	BEP151 = "BEP151"   // https://github.com/bnb-chain/BEPs/pull/151 Decommission Decentralized Exchange
 )
 
 func UpgradeBEP10(before func(), after func()) {

--- a/plugins/dex/list/handler.go
+++ b/plugins/dex/list/handler.go
@@ -22,8 +22,14 @@ func NewHandler(keeper *order.DexKeeper, tokenMapper tokens.Mapper, govKeeper go
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		switch msg := msg.(type) {
 		case types.ListMsg:
+			if sdk.IsUpgrade(upgrade.BEP151) {
+				return sdk.ErrMsgNotSupported("ListMsg disabled in BEP-151").Result()
+			}
 			return handleList(ctx, keeper, tokenMapper, govKeeper, msg)
 		case types.ListMiniMsg:
+			if sdk.IsUpgrade(upgrade.BEP151) {
+				return sdk.ErrMsgNotSupported("ListMiniMsg disabled in BEP-151").Result()
+			}
 			return handleListMini(ctx, keeper, tokenMapper, msg)
 		default:
 			errMsg := fmt.Sprintf("Unrecognized dex msg type: %v", reflect.TypeOf(msg).Name())

--- a/plugins/dex/order/handler.go
+++ b/plugins/dex/order/handler.go
@@ -27,6 +27,9 @@ func NewHandler(dexKeeper *DexKeeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		switch msg := msg.(type) {
 		case NewOrderMsg:
+			if sdk.IsUpgrade(upgrade.BEP151) {
+				return sdk.ErrMsgNotSupported("NewOrderMsg disabled in BEP-151").Result()
+			}
 			return handleNewOrder(ctx, dexKeeper, msg)
 		case CancelOrderMsg:
 			return handleCancelOrder(ctx, dexKeeper, msg)

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.9.2"
+const NodeVersion = "v0.10.0"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This pr includes the changes for v0.10.0 release. Please refer Changes section for details.

### Rationale
Decommission Decentralized Exchange on BNB Beacon Chain.

### Example
n/a

### Changes
* [\#875](https://github.com/bnb-chain/node/pull/875) [DEX] Implement BEP151