### PR TITLE
Prepare for release v0.10.1: Add BEP-151 Mainnet Height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.1
+IMPROVEMENTS
+* [\#875](https://github.com/bnb-chain/node/pull/875) [DEX] Implement BEP151
+
 ## 0.10.0
 IMPROVEMENTS
 * [\#875](https://github.com/bnb-chain/node/pull/875) [DEX] Implement BEP151

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.10.1
 IMPROVEMENTS
-* [\#875](https://github.com/bnb-chain/node/pull/875) [DEX] Implement BEP151
+* [\#882](https://github.com/bnb-chain/node/pull/875) [DEX] Add BEP151 Mainnet Height
 
 ## 0.10.0
 IMPROVEMENTS

--- a/asset/mainnet/app.toml
+++ b/asset/mainnet/app.toml
@@ -56,6 +56,8 @@ FixFailAckPackageHeight = 146060000
 EnableAccountScriptsForCrossChainTransferHeight = 146060000
 #Block height of BEP128 upgrade
 BEP128Height =234560000
+#Block height of BEP151 upgrade
+BEP151Height = 264000000
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.0"
+const NodeVersion = "v0.10.1"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This release is to add activation height of [BEP-151](https://github.com/bnb-chain/BEPs/blob/master/BEP151.md) on Mainnet.

### Rationale

BEP-151 proposes to securely and smoothly decommission the build-in decentralized exchange on BNB Beacon Chain.
The activation height is 264000000, which will be approximately happened at 2 Sep 2022 06:00 UTC.

### Example

No

### Changes



### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

No

