### PR TITLE
Install command for cli tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ export BNBCHAINPATH=~/go/src/github.com/bnb-chain/node
 $ mkdir -p $BNBCHAINPATH
 $ git clone git@github.com:bnb-chain/node.git $BNBCHAINPATH
 $ cd $BNBCHAINPATH
-$ make build
+$ make install
 ```
 
 **Windows**
@@ -57,7 +57,7 @@ You may need add BNBCHAINPATH to the environment variables.
 > md %BNBCHAINPATH%
 > git clone git@github.com:bnb-chain/node.git %BNBCHAINPATH%
 > cd %BNBCHAINPATH%
-> make build
+> make install
 ```
 
 To test that installation worked, try to run the cli tool:


### PR DESCRIPTION
`make install` instead of `make build`

### Description

Just running `make build` will not make the `bnbcli` command to run. `make install` will install it and then `bnbcli` will run fine.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

