### PR TITLE
ci: update unmaintained tools to use maintained tools

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build image
         run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,4 +29,9 @@ jobs:
       - run: go env -w GOPRIVATE="github.com/bnb-chain/*"
       - run: go mod tidy && go mod download
       - name: golangci-lint
-        run: make lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.45.2
+          skip-pkg-cache: true
+          args: --timeout=99m

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,11 +13,11 @@ jobs:
         with:
           go-version: 1.17
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/go/bin/golangci-lint
           key: golangci-lint-1.45.2
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,11 +11,11 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.17
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/go/bin
           key: tools-v0
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod
@@ -36,11 +36,11 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.17
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/go/bin
           key: tools-v0
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -12,18 +12,18 @@ jobs:
     strategy:
       matrix:
         go-version: [1.17.x]
-        os: [ubuntu-18.04, macos-11, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           # In order:
           # * Module download cache
@@ -58,22 +58,22 @@ jobs:
       # ==============================
 
       - name: Upload Linux Build
-        uses: actions/upload-artifact@v2
-        if: matrix.os == 'ubuntu-18.04'
+        uses: actions/upload-artifact@v3
+        if: matrix.os == 'ubuntu-latest'
         with:
           name: linux
           path: ./build
 
       - name: Upload MacOS Build
-        uses: actions/upload-artifact@v2
-        if: matrix.os == 'macos-11'
+        uses: actions/upload-artifact@v3
+        if: matrix.os == 'macos-latest'
         with:
           name: macos
           path: ./build
 
       - name: Upload Windows Build
-        uses: actions/upload-artifact@v2
-        if: matrix.os == 'windows-2019'
+        uses: actions/upload-artifact@v3
+        if: matrix.os == 'windows-latest'
         with:
           name: windows
           path: ./build
@@ -81,29 +81,32 @@ jobs:
   release:
     name: Release
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
+      - name: Set Env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # ==============================
       #       Download artifacts
       # ==============================
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux
           path: ./linux
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: macos
           path: ./macos
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows
           path: ./windows
@@ -115,67 +118,19 @@ jobs:
       - run: zip -r testnet_config.zip asset/testnet
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_VERSION }}
+          release_name: ${{ env.RELEASE_VERSION }}
           body: |
             git commit: ${{ github.sha }}
           draft: true
           prerelease: true
-
-      # Check downloaded files
-      - run: ls
-
-      - name: Upload Release Asset - Linux
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./linux_binary.zip
-          asset_name: linux_binary.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload Release Asset - MacOS
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./macos_binary.zip
-          asset_name: macos_binary.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload Release Asset - Windows
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./windows_binary.zip
-          asset_name: windows_binary.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload Mainnet Config
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./mainnet_config.zip
-          asset_name: mainnet_config.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload Testnet Config
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./testnet_config.zip
-          asset_name: testnet_config.zip
-          asset_content_type: application/octet-stream
+          files: |
+            ./linux_binary.zip
+            ./macos_binary.zip
+            ./windows_binary.zip
+            ./mainnet_config.zip
+            ./testnet_config.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,18 @@ jobs:
     strategy:
       matrix:
         go-version: [1.17.x]
-        os: [ubuntu-18.04, macos-11, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           # In order:
           # * Module download cache
@@ -58,22 +58,22 @@ jobs:
       # ==============================
 
       - name: Upload Linux Build
-        uses: actions/upload-artifact@v2
-        if: matrix.os == 'ubuntu-18.04'
+        uses: actions/upload-artifact@v3
+        if: matrix.os == 'ubuntu-latest'
         with:
           name: linux
           path: ./build
 
       - name: Upload MacOS Build
-        uses: actions/upload-artifact@v2
-        if: matrix.os == 'macos-11'
+        uses: actions/upload-artifact@v3
+        if: matrix.os == 'macos-latest'
         with:
           name: macos
           path: ./build
 
       - name: Upload Windows Build
-        uses: actions/upload-artifact@v2
-        if: matrix.os == 'windows-2019'
+        uses: actions/upload-artifact@v3
+        if: matrix.os == 'windows-latest'
         with:
           name: windows
           path: ./build
@@ -81,29 +81,32 @@ jobs:
   release:
     name: Release
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
+      - name: Set Env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # ==============================
       #       Download artifacts
       # ==============================
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux
           path: ./linux
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: macos
           path: ./macos
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows
           path: ./windows
@@ -125,67 +128,19 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_VERSION }}
+          release_name: ${{ env.RELEASE_VERSION }}
           body: |
             ${{ env.CHANGELOG }}
           draft: false
           prerelease: false
-
-      # Check downloaded files
-      - run: ls
-
-      - name: Upload Release Asset - Linux
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./linux_binary.zip
-          asset_name: linux_binary.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload Release Asset - MacOS
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./macos_binary.zip
-          asset_name: macos_binary.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload Release Asset - Windows
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./windows_binary.zip
-          asset_name: windows_binary.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload Mainnet Config
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./mainnet_config.zip
-          asset_name: mainnet_config.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload Testnet Config
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./testnet_config.zip
-          asset_name: testnet_config.zip
-          asset_content_type: application/octet-stream
+          files: |
+            ./linux_binary.zip
+            ./macos_binary.zip
+            ./windows_binary.zip
+            ./mainnet_config.zip
+            ./testnet_config.zip


### PR DESCRIPTION
### Description

Some GitHub action tools will no longer be supported soon. Update these tools to ensure that CI can normally work in the future.

### Rationale

#### Tools update
1. `ubuntu-18.04` => `ubuntu-latest`
2. `macos-11` => `macos-latest`
3. `windows-2019` => `windows-latest`
4. `actions/checkout@v2` => `actions/checkout@v3`
5. `actions/setup-go@v2` => `actions/setup-go@v3`
6. `actions/cache@v2` => `actions/cache@v3`
7. `actions/upload-artifact@v2` => `actions/upload-artifact@v3`
8. `actions/download-artifact@v2` => `actions/download-artifact@v3`
9. `actions/create-release@latest`, `actions/upload-release-asset@v1` => `softprops/action-gh-release@v1`
<img width="1367" alt="image" src="https://user-images.githubusercontent.com/25412254/209107745-564fddc9-5df4-4453-8a3d-5f50c00fc542.png">

### Example

N/A

### Changes
Notable changes: 
* ci
