### PR TITLE
release: prepare for release v0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.10.4
+FEATURES
+* [\#880](https://github.com/bnb-chain/node/pull/880) [BEP] BEP-159: Introduce A New Staking Mechanism on BNB Beacon Chain
+
+IMPROVEMENT
+* [\#899](https://github.com/bnb-chain/node/pull/899) [ci] update unmaintained tools to use maintained tools
+
+BUG FIX
+* [\#897](https://github.com/bnb-chain/node/pull/897) [fix] add bsc chainID to encodeSigHeader when submitting evidence for slashing
+
+
 ## 0.10.3
 IMPROVEMENTS
 * [\#886](https://github.com/bnb-chain/node/pull/875) [Staking] Fix issues for reward recon service

--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -63,7 +63,11 @@ BEP153Height = 30516226
 #Block height of BEP173 upgrade
 BEP173Height = 9223372036854775807
 #Block height of FixDoubleSignChainIdHeight upgrade
-FixDoubleSignChainIdHeight = 9223372036854775807
+FixDoubleSignChainIdHeight = 34587202
+#Block height of BEP159Height upgrade
+BEP159Height = 34587202
+#Block height of BEP159Phase2Height upgrade
+BEP159Phase2Height = 34963303
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.3"
+const NodeVersion = "v0.10.4"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description
This is a hardfork release to enable BEP159 on testnet

### Rationale

## v0.10.4
FEATURES
* [\#880](https://github.com/bnb-chain/node/pull/880) [BEP] BEP-159: Introduce A New Staking Mechanism on BNB Beacon Chain

IMPROVEMENT
* [\#899](https://github.com/bnb-chain/node/pull/899) [ci] update unmaintained tools to use maintained tools

BUG FIX
* [\#897](https://github.com/bnb-chain/node/pull/897) [fix] add bsc chainID to encodeSigHeader when submitting evidence for slashing



### Example
No.

### Changes
The breaking double sign issue is fixed in this release as well.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)


### Related issues
NO

