### PR TITLE
release: prepare for release v0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.5
+BUG FIX
+* [\#904](https://github.com/bnb-chain/node/pull/904) [fix] register cross stake channel after node restart
+
 ## v0.10.4
 FEATURES
 * [\#880](https://github.com/bnb-chain/node/pull/880) [BEP] BEP-159: Introduce A New Staking Mechanism on BNB Beacon Chain

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.4"
+const NodeVersion = "v0.10.5"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This is a release for issue fix

### Rationale

## v0.10.5

BUG FIX
* [\#8904](https://github.com/bnb-chain/node/pull/8904) [fix] register cross stake channel after node restart

### Example
N/A

### Changes
Add cross stake channel register at node init

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)


### Related issues
https://github.com/bnb-chain/node/issues/898

