### PR TITLE
prepare for release v0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.10.4
+FEATURES
+* [\#880](https://github.com/bnb-chain/node/pull/880) [BEP] BEP-159: Introduce A New Staking Mechanism on BNB Beacon Chain
+
+IMPROVEMENT
+* [\#899](https://github.com/bnb-chain/node/pull/899) [ci] update unmaintained tools to use maintained tools
+
+BUG FIX
+* [\#897](https://github.com/bnb-chain/node/pull/897) [fix] add bsc chainID to encodeSigHeader when submitting evidence for slashing
+
+
 ## 0.10.3
 IMPROVEMENTS
 * [\#886](https://github.com/bnb-chain/node/pull/875) [Staking] Fix issues for reward recon service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.5
+BUG FIX
+* [\#904](https://github.com/bnb-chain/node/pull/904) [fix] register cross stake channel after node restart
+
 ## v0.10.4
 FEATURES
 * [\#880](https://github.com/bnb-chain/node/pull/880) [BEP] BEP-159: Introduce A New Staking Mechanism on BNB Beacon Chain

--- a/app/app.go
+++ b/app/app.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/sidechain"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
 	"github.com/cosmos/cosmos-sdk/x/stake"
-	cStake "github.com/cosmos/cosmos-sdk/x/stake/cross_stake"
 	"github.com/cosmos/cosmos-sdk/x/stake/keeper"
 	sTypes "github.com/cosmos/cosmos-sdk/x/stake/types"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -62,6 +61,7 @@ import (
 	"github.com/bnb-chain/node/plugins/tokens/swap"
 	"github.com/bnb-chain/node/plugins/tokens/timelock"
 	"github.com/bnb-chain/node/wire"
+	cStake "github.com/cosmos/cosmos-sdk/x/stake/cross_stake"
 )
 
 const (
@@ -586,6 +586,14 @@ func (app *BinanceChain) initStaking() {
 	app.stakeKeeper.SubscribeParamChange(app.ParamHub)
 	app.stakeKeeper.SubscribeBCParamChange(app.ParamHub)
 	app.stakeKeeper = app.stakeKeeper.WithHooks(app.slashKeeper.Hooks())
+
+	if sdk.IsUpgrade(sdk.BEP153) {
+		crossStakeApp := cStake.NewCrossStakeApp(app.stakeKeeper)
+		err := app.scKeeper.RegisterChannel(sTypes.CrossStakeChannel, sTypes.CrossStakeChannelID, crossStakeApp)
+		if err != nil {
+			panic(err)
+		}
+	}
 }
 
 func (app *BinanceChain) initGov() {

--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -63,7 +63,11 @@ BEP153Height = 30516226
 #Block height of BEP173 upgrade
 BEP173Height = 9223372036854775807
 #Block height of FixDoubleSignChainIdHeight upgrade
-FixDoubleSignChainIdHeight = 9223372036854775807
+FixDoubleSignChainIdHeight = 34587202
+#Block height of BEP159Height upgrade
+BEP159Height = 34587202
+#Block height of BEP159Phase2Height upgrade
+BEP159Phase2Height = 34963303
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.4"
+const NodeVersion = "v0.10.5"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.3"
+const NodeVersion = "v0.10.4"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This is a bug fix release for a critical issue that the node may fail to reach a consensus state after a restart.

### Rationale

## v0.10.5

BUG FIX
* [\#8904](https://github.com/bnb-chain/node/pull/8904) [fix] register cross-stake channel after node restart

### Example
N/A

### Changes
Add cross stake channel register at node init

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)


### Related issues
https://github.com/bnb-chain/node/issues/898

