### PR TITLE
docs: update the readme to latest working one

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Beacon Chain has the basic features of most blockchains:
 - Issuing new digital assets (we have a standard called BEP-2)
 - Mint/burn, freeze/unfreeze, lock/unlock of digital assets
 
-Besides it get many other rich features:
+Besides, it has many other rich features:
 - Staking/governance for both Beacon Chain and BNB Smart Chain.
 - Cross chain communication.
 - Atomic swap support.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ testnode        local   bnb1elavnu4uyzt43hw380vhw0m2zl7djz0xeac60t      bnbp1add
 Check a balance with this command, e.g.:
 
 ```bash
-$  ./build/bnbcli account bnb1elavnu4uyzt43hw380vhw0m2zl7djz0xeac60t  --chain-id ${chainId} |jq
+$  ./build/bnbcli account bnb1elavnu4uyzt43hw380vhw0m2zl7djz0xeac60t --chain-id ${chainId} | jq
 ```
 
 ### Sending assets

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Please refer to the document for joining [mainnet](https://docs.bnbchain.world/d
 Assets may be issued through `bnbcli` while the blockchain is running; see here for an example:
 
 ```bash
-$ chainId=`cat ~/.bnbchaind/config/genesis.json  |jq .chain_id --raw-output`
+$ chainId=`cat ~/.bnbchaind/config/genesis.json | jq .chain_id --raw-output`
 # Input password "12345678"
 $ ./build/bnbcli token issue --trust-node --symbol FBTC --token-name FunBitCoin  --total-supply  10000000000  --from testnode  --chain-id ${chainId}
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Besides it get many other rich features:
 #### Requirement
 Go version above 1.17 is required.
 
-Please [install it](https://golang.org/dl) or use brew on macOS: `brew install go` and `brew install dep`.
+Please [install it](https://go.dev/doc/install) or use brew on macOS: `brew install go`.
 
 #### Build from Source
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Besides it get many other rich features:
 * Full nodes are not validator nodes, but anyone can get a copy of the whole blockchain and validate it.
 * No PoW means block times are very fast.
 * UXTO/account does not matter as we just use the [cosmos](https://github.com/cosmos/cosmos-sdk/tree/master/x/bank) bank.
-* Features like the DEX will run directly on the node as apps written in golang(deprecated now).
-
+* Features like the DEX (deprecated now) will run directly on the node as apps written in golang.
 [Read](https://tendermint.readthedocs.io/en/master/introduction.html) [more](https://blog.cosmos.network/tendermint-explained-bringing-bft-based-pos-to-the-public-blockchain-domain-f22e274a0fdb) about Tendermint and ABCI.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ $  ./build/bnbcli tx 40C2B27B056A63DFE5BCE32709F160F53633C0EBEBBD05E1AC26419D353
 Then you can check the balance of pepe's key to see that he now has 100 satoshi units of `FBTC-4C9`:
 
 ```bash
-$ ./build/bnbcli account bnb1u5mvgkqt9rmj4fut60rnpqfv0a865pwnn90v9q  --chain-id ${chainId} |jq
+$ ./build/bnbcli account bnb1u5mvgkqt9rmj4fut60rnpqfv0a865pwnn90v9q  --chain-id ${chainId} | jq
 {
   "type": "bnbchain/Account",
   "value": {

--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Beacon Chain has the basic features of most blockchains:
 - Issuing new digital assets (we have a standard called BEP-2)
 - Mint/burn, freeze/unfreeze, lock/unlock of digital assets
 
-It has DEX and trading-specific functionality:
-- Propose exchange listing for trading pairs
-- Creating maker/taker orders for traders
-- Listing assets from other chains using atomic swaps (BEP-3)
+Besides it get many other rich features:
+- Staking/governance for both Beacon Chain and BNB Smart Chain.
+- Cross chain communication.
+- Atomic swap support.
+- Support hot sync and state sync.
 
 ## Overview
 
@@ -25,7 +26,7 @@ It has DEX and trading-specific functionality:
 * Full nodes are not validator nodes, but anyone can get a copy of the whole blockchain and validate it.
 * No PoW means block times are very fast.
 * UXTO/account does not matter as we just use the [cosmos](https://github.com/cosmos/cosmos-sdk/tree/master/x/bank) bank.
-* Features like the DEX will run directly on the node as apps written in golang.
+* Features like the DEX will run directly on the node as apps written in golang(deprecated now).
 
 [Read](https://tendermint.readthedocs.io/en/master/introduction.html) [more](https://blog.cosmos.network/tendermint-explained-bringing-bft-based-pos-to-the-public-blockchain-domain-f22e274a0fdb) about Tendermint and ABCI.
 
@@ -33,37 +34,23 @@ It has DEX and trading-specific functionality:
 
 ### Environment setup
 
-If you do not have golang yet, please [install it](https://golang.org/dl) or use brew on macOS: `brew install go` and `brew install dep`.
+#### Requirement
+Go version above 1.17 is required.
 
+Please [install it](https://golang.org/dl) or use brew on macOS: `brew install go` and `brew install dep`.
 
-**Mac & Linux**
+#### Build from Source
 
 ```bash
-$ export GOPATH=~/go
-$ export PATH=~/go/bin:$PATH
-$ export BNBCHAINPATH=~/go/src/github.com/bnb-chain/node
-$ mkdir -p $BNBCHAINPATH
-$ git clone git@github.com:bnb-chain/node.git $BNBCHAINPATH
-$ cd $BNBCHAINPATH
-$ make build
+$ git clone git@github.com:bnb-chain/node.git 
+$ cd node && make build
 ```
 
-**Windows**
-
-If you are working on windows, `GOPATH` and `PATH` should already be set when you install golang.
-You may need add BNBCHAINPATH to the environment variables.
-
-```bat
-> md %BNBCHAINPATH%
-> git clone git@github.com:bnb-chain/node.git %BNBCHAINPATH%
-> cd %BNBCHAINPATH%
-> make build
-```
 
 To test that installation worked, try to run the cli tool:
 
 ```bash
-$ bnbcli
+$./build/bnbchaind version
 ```
 
 ### Start the blockchain
@@ -71,24 +58,35 @@ $ bnbcli
 This command will generate a keypair for your node and create the genesis block config:
 
 ```bash
-$ bnbchaind init
+$ ./build/bnbchaind init --moniker testnode
 $ cat ~/.bnbchaind/config/genesis.json
 ```
 
 You may want to check the [Issuing assets](#issuing-assets) section below before you start, but this is how to start the node and begin generating blocks:
 
 ```bash
-$ bnbchaind start --moniker ${YOURNAME}
+$ ./build/bnbchaind start --moniker testnode
 ```
 
-If everything worked you will see blocks being generated around every 1s in your console.
+If everything worked you will see blocks being generated around every 1s in your console, like 
+```shell
+I[2023-01-05|20:39:46.960] Starting ABCI with Tendermint                module=main 
+I[2023-01-05|20:39:47.016] Loading order book snapshot from last breathe block module=main blockHeight=0
+I[2023-01-05|20:39:47.016] No breathe block is ever saved. just created match engines for all the pairs. module=main 
+I[2023-01-05|20:39:47.017] get last breathe block height                module=main height=0
+I[2023-01-05|20:39:48.194] Executed block                               module=state height=1 validTxs=0 invalidTxs=0
+I[2023-01-05|20:39:48.200] Committed state                              module=state height=1 txs=0 appHash=45AE480E42446C584BEFF2162941F4A76C542E96E44F878B21546DCC7E79DCE5
+I[2023-01-05|20:39:49.194] Executed block                               module=state height=2 validTxs=0 invalidTxs=0
+I[2023-01-05|20:39:49.198] Committed state                              module=state height=2 txs=0 appHash=6903AA785839B393C7E252C74185F42297E38ADD9804D8EE0AF08A3EF9D99080
+I[2023-01-05|20:39:50.215] Executed block                               module=state height=3 validTxs=0 invalidTxs=0
+```
 
 ### Reset
 
 When you make a change you probably want to reset your chain, remember to kill the node first.
 
 ```bash
-$ bnbchaind unsafe_reset_all
+$ ./build/bnbchaind unsafe-reset-all
 ```
 
 ### Join mainnet/testnet
@@ -102,7 +100,9 @@ Please refer to the document for joining [mainnet](https://docs.bnbchain.world/d
 Assets may be issued through `bnbcli` while the blockchain is running; see here for an example:
 
 ```bash
-$ bnbcli tokens issue bnb -n bnb -s 100000
+$ chainId=`cat ~/.bnbchaind/config/genesis.json  |jq .chain_id --raw-output`
+# Input password "12345678"
+$ ./build/bnbcli token issue --trust-node --symbol FBTC --token-name FunBitCoin  --total-supply  10000000000  --from testnode  --chain-id ${chainId}
 ```
 
 This will post a transaction with an `IssueMsg` to the blockchain, which contains the data needed for token issuance.
@@ -112,39 +112,16 @@ This will post a transaction with an `IssueMsg` to the blockchain, which contain
 Start your node, then list your keys as below:
 
 ```bash
-$ bnbcli keys list
-All keys:
-pepe    B71E119324558ABA3AE3F5BC854F1225132465A0
-you     DEBF30B59A5CD0111FDF4F86664BC063BF450A1A
+$ ./build/bnbcli keys list 
+
+NAME:   TYPE:   ADDRESS:                                                PUBKEY:
+testnode        local   bnb1elavnu4uyzt43hw380vhw0m2zl7djz0xeac60t      bnbp1addwnpepqva5fmn4r4hc66fpqafwwdf20nq8xjpr3kezkclpmluufxdk5x4gw9xsln5
 ```
 
 Check a balance with this command, e.g.:
 
 ```bash
-$ bnbcli account DEBF30B59A5CD0111FDF4F86664BC063BF450A1A
-```
-
-Alternatively through http when `bnbcli api-server` is running. Amounts are returned as decimal numbers in strings.
-
-```bash
-$ curl -s http://localhost:8080/balances/cosmosaccaddr173hyu6dtfkrj9vujjhvz2ayehrng64rxq3h4yp | json_pp
-{
-   "address" : "cosmosaccaddr173hyu6dtfkrj9vujjhvz2ayehrng64rxq3h4yp",
-   "balances" : [
-      {
-         "symbol" : "BNB",
-         "free" : "2.00000000",
-         "locked" : "0.00000000",
-         "frozen" : "0.00000000"
-      },
-      {
-         "symbol" : "XYZ",
-         "free" : "0.98999900",
-         "locked" : "0.00000100",
-         "frozen" : "0.00000000"
-      }
-   ]
-}
+$  ./build/bnbcli account bnb1elavnu4uyzt43hw380vhw0m2zl7djz0xeac60t  --chain-id ${chainId} |jq
 ```
 
 ### Sending assets
@@ -154,30 +131,31 @@ You have to send a transaction to send assets to another address, which is possi
 Make sure `chain-id` is set correctly; you can find it in your `genesis.json`.
 
 ```bash
-$ bnbcli send --chain-id=$CHAIN_ID --name=you --amount=1000mycoin --to=B71E119324558ABA3AE3F5BC854F1225132465A0 --sequence=0
-Password to sign with 'you': xxx
-Committed at block 88. Hash: 492B08FFE364D389BB508FD3507BBACD3DB58A98
+$ ./build/bnbcli send --to bnb1u5mvgkqt9rmj4fut60rnpqfv0a865pwnn90v9q --amount 100:FBTC-4C9  --from testnode  --chain-id ${chainId}
+
+Password to sign with 'you': 12345678
+Committed at block 833 (tx hash: 40C2B27B056A63DFE5BCE32709F160F53633C0EBEBBD05E1AC26419D35303765, response: {Code:0 Data:[] Log:Msg 0:  Info: GasWanted:0 GasUsed:0 Events:[{Type: Attributes:[{Key:[115 101 110 100 101 114] Value:[98 110 98 49 101 108 97 118 110 117 52 117 121 122 116 52 51 104 119 51 56 48 118 104 119 48 109 50 122 108 55 100 106 122 48 120 101 97 99 54 48 116] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} {Key:[114 101 99 105 112 105 101 110 116] Value:[98 110 98 49 117 53 109 118 103 107 113 116 57 114 109 106 52 102 117 116 54 48 114 110 112 113 102 118 48 97 56 54 53 112 119 110 110 57 48 118 57 113] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} {Key:[97 99 116 105 111 110] Value:[115 101 110 100] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}] Codespace: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0})
 ```
 
 You can look at the contents of the tx, use the tx hash above:
 
 ```bash
-$ bnbcli tx 492B08FFE364D389BB508FD3507BBACD3DB58A98
+$  ./build/bnbcli tx 40C2B27B056A63DFE5BCE32709F160F53633C0EBEBBD05E1AC26419D35303765 --chain-id ${chainId} 
 ```
 
-Then you can check the balance of pepe's key to see that he now has 1000 satoshi units of `mycoin`:
+Then you can check the balance of pepe's key to see that he now has 100 satoshi units of `FBTC-4C9`:
 
 ```bash
-$ bnbcli account B71E119324558ABA3AE3F5BC854F1225132465A0
+$ ./build/bnbcli account bnb1u5mvgkqt9rmj4fut60rnpqfv0a865pwnn90v9q  --chain-id ${chainId} |jq
 {
-  "type": "16542275FBFAB8",
+  "type": "bnbchain/Account",
   "value": {
-    "BaseAccount": {
-      "address": "B71E119324558ABA3AE3F5BC854F1225132465A0",
+    "base": {
+      "address": "bnb1u5mvgkqt9rmj4fut60rnpqfv0a865pwnn90v9q",
       "coins": [
         {
-          "denom": "mycoin",
-          "amount": 1000
+          "denom": "FBTC-4C9",
+          "amount": "100"
         }
       ],
       ...
@@ -188,27 +166,6 @@ $ bnbcli account B71E119324558ABA3AE3F5BC854F1225132465A0
 ```
 
 Amounts are represented as ints, and all coins have a fixed scale of 8. This means that if a balance of `100000000` were to be shown here, that would represent a balance of `1` coin.
-
-## DEX
-
-### Placing an order
-
-```bash
-$ bnbcli dex order -i uniqueid1 -l XYZ_BNB -s 1 -p 100000000 -q 100000000 --from me --chain-id=$CHAIN_ID -t 1
-```
-
-### Viewing the order book
-
-```bash
-$ bnbcli dex show -l XYZ_BNB
-```
-
-Alternatively through http when `bnbcli api-server` is running. Prices and quantities are returned as decimal numbers in strings.
-
-```bash
-$ curl -s http://localhost:8080/api/v1/depth?symbol=XYZ_BNB&limit=5 | json_pp
-{"asks":[["0.00000000","0.00000000"],["0.00000000","0.00000000"],["0.00000000","0.00000000"],["0.00000000","0.00000000"],["0.00000000","0.00000000"]],"bids":[["0.10000000","1.00000000"],["0.00000000","0.00000000"],["0.00000000","0.00000000"],["0.00000000","0.00000000"],["0.00000000","0.00000000"]]}
-```
 
 ## Contribution
 It is welcomed to contribute to this repo from everyone. If you'd like to contribute, please fork, fix, commit and submit a pull request to review and merge into the main code base. Please make sure your contributions adhere to our coding guidelines:


### PR DESCRIPTION
### Description
The current readme is totally out of date, this PR fix it.

### Rationale
The following update is made in this PR:

1. Dex-related chapter is removed.
2. Fix the not working CLI tutorial.
3. Adding more futures.

### Example
No

### Changes
Document fix.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)



