### PR TITLE
release: prepare for release v0.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.10.6
+IMPROVEMENT
+* [\#908](https://github.com/bnb-chain/node/pull/908) [docs] update the readme to latest working one
+* [\#907](https://github.com/bnb-chain/node/pull/907) [fix] remove bnb-chain go-sdk dep
+
 ## v0.10.5
 BUG FIX
 * [\#904](https://github.com/bnb-chain/node/pull/904) [fix] register cross stake channel after node restart

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.5"
+const NodeVersion = "v0.10.6"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This is a release for code improvement

### Rationale

#### v0.10.6
IMPROVEMENT
* [\#908](https://github.com/bnb-chain/node/pull/908) [docs] update the readme to latest working one
* [\#907](https://github.com/bnb-chain/node/pull/907) [fix] remove bnb-chain go-sdk dep


### Example
N/A

### Changes
N/A

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

