### PR TITLE
release: prepare for release v0.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v0.10.7
 IMPROVEMENT
-* [\#919](https://github.com/bnb-chain/node/pull/919) [Deps] dep: bump cosmos-sdk to v0.25.8
+* [\#921](https://github.com/bnb-chain/node/pull/921) [config] add LimitConsAddrUpdateIntervalHeight and BEP159Height in assets
+* [\#919](https://github.com/bnb-chain/node/pull/919) [deps] bump cosmos-sdk to v0.25.8
 
 
 ## v0.10.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## v0.10.7
+IMPROVEMENT
+* [\#919](https://github.com/bnb-chain/node/pull/919) [Deps] dep: bump cosmos-sdk to v0.25.8
+
+
 ## v0.10.6
 IMPROVEMENT
-* [\#908](https://github.com/bnb-chain/node/pull/908) [docs] update the readme to latest working one
+* [\#908](https://github.com/bnb-chain/node/pull/908) [docs] update the readme to the latest working one
 * [\#907](https://github.com/bnb-chain/node/pull/907) [fix] remove bnb-chain go-sdk dep
 
 ## v0.10.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
 ## v0.10.7
-IMPROVEMENT
+FEATURES
 * [\#921](https://github.com/bnb-chain/node/pull/921) [config] add LimitConsAddrUpdateIntervalHeight and BEP159Height in assets
-* [\#919](https://github.com/bnb-chain/node/pull/919) [deps] bump cosmos-sdk to v0.25.8
+* [\#917](https://github.com/bnb-chain/node/pull/917) [Staking] limit sidechain consensus addr update interval
 
+IMPROVEMENT
+* [\#919](https://github.com/bnb-chain/node/pull/919) [deps] bump cosmos-sdk to v0.25.8
+* [\#915](https://github.com/bnb-chain/node/pull/915) [deps] update deps that were reported in OSV issues
+
+BUG FIX
+* [\#914](https://github.com/bnb-chain/node/pull/914) [fix] fix bnbcli params side-params error
 
 ## v0.10.6
 IMPROVEMENT

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.6"
+const NodeVersion = "v0.10.7"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This is a hard-fork release, with improvements and bug fixes.
For the hard-fork height on testnet and mainnet, please refer to https://github.com/bnb-chain/node/pull/921

### Rationale

#### v0.10.7
FEATURES
* [\#921](https://github.com/bnb-chain/node/pull/921) [config] add LimitConsAddrUpdateIntervalHeight and BEP159Height in assets
* [\#917](https://github.com/bnb-chain/node/pull/917) [Staking] limit sidechain consensus addr update interval

IMPROVEMENT
* [\#919](https://github.com/bnb-chain/node/pull/919) [deps] bump cosmos-sdk to v0.25.8
* [\#915](https://github.com/bnb-chain/node/pull/915) [deps] update deps that were reported in OSV issues

BUG FIX
* [\#914](https://github.com/bnb-chain/node/pull/914) [fix] fix bnbcli params side-params error



### Example
N/A

### Changes
N/A

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

