### PR TITLE
config: add LimitConsAddrUpdateIntervalHeight and BEP159Height in asset

### DIFF
--- a/asset/mainnet/app.toml
+++ b/asset/mainnet/app.toml
@@ -63,6 +63,10 @@ BEP153Height = 284376000
 #Block height of BEP173 upgrade
 BEP173Height = 284376000
 FixDoubleSignChainIdHeight = 9223372036854775807
+# Block height of BEP159Height upgrade
+BEP159Height = 298721375
+# Block height of LimitConsAddrUpdateInterval upgrade
+LimitConsAddrUpdateIntervalHeight = 298721375
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address

--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -68,6 +68,8 @@ FixDoubleSignChainIdHeight = 34587202
 BEP159Height = 34587202
 #Block height of BEP159Phase2Height upgrade
 BEP159Phase2Height = 34963303
+# Block height of LimitConsAddrUpdateInterval upgrade
+LimitConsAddrUpdateIntervalHeight = 36174050
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]


### PR DESCRIPTION
### Description

Add LimitConsAddrUpdateIntervalHeight and BEP159Height in Mainnet and LimitConsAddrUpdateIntervalHeight in Testnet to activate the hardfork.

The approximate time of Testnet height   36174050  is `2023-02-15T06:00:00`.
The approximate time of Mainnet height 298721375 is `2023-02-24T06:00:00`.