### PR TITLE
revert: remove the hardfork height of BEP159Height on mainnet

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -564,7 +564,7 @@ func defaultUpgradeConfig() *UpgradeConfig {
 		BEP67Height:                       1,
 		BEP70Height:                       1,
 		LaunchBscUpgradeHeight:            1,
-		LimitConsAddrUpdateIntervalHeight: 1,
+		LimitConsAddrUpdateIntervalHeight: math.MaxInt64,
 		BEP128Height:                      math.MaxInt64,
 		BEP151Height:                      math.MaxInt64,
 		BEP153Height:                      math.MaxInt64,

--- a/asset/mainnet/app.toml
+++ b/asset/mainnet/app.toml
@@ -63,10 +63,6 @@ BEP153Height = 284376000
 #Block height of BEP173 upgrade
 BEP173Height = 284376000
 FixDoubleSignChainIdHeight = 9223372036854775807
-# Block height of BEP159Height upgrade
-BEP159Height = 298721375
-# Block height of LimitConsAddrUpdateInterval upgrade
-LimitConsAddrUpdateIntervalHeight = 298721375
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address

--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -68,8 +68,6 @@ FixDoubleSignChainIdHeight = 34587202
 BEP159Height = 34587202
 #Block height of BEP159Phase2Height upgrade
 BEP159Phase2Height = 34963303
-# Block height of LimitConsAddrUpdateInterval upgrade
-LimitConsAddrUpdateIntervalHeight = 36174050
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]

--- a/cmd/gen_devnet/main.go
+++ b/cmd/gen_devnet/main.go
@@ -74,6 +74,7 @@ func main() {
 		binanceChainConfig.UpgradeConfig.BEP153Height = 2
 		binanceChainConfig.UpgradeConfig.BEP159Height = 3
 		binanceChainConfig.UpgradeConfig.BEP159Phase2Height = 6
+		binanceChainConfig.UpgradeConfig.LimitConsAddrUpdateIntervalHeight = 6
 		binanceChainConfig.BreatheBlockInterval = 5
 		appConfigFilePath := filepath.Join(ctxConfig.RootDir, "config", "app.toml")
 		config.WriteConfigFile(appConfigFilePath, binanceChainConfig)

--- a/scripts/bep159_integration_test.sh
+++ b/scripts/bep159_integration_test.sh
@@ -45,6 +45,7 @@ function prepare_node() {
 	$(cd "./${home}/config" && sed -i -e "s/BEP153Height = 9223372036854775807/BEP153Height = 2/g" app.toml)
 	$(cd "./${home}/config" && sed -i -e "s/BEP159Height = 9223372036854775807/BEP159Height = 3/g" app.toml)
 	$(cd "./${home}/config" && sed -i -e "s/BEP159Phase2Height = 9223372036854775807/BEP159Phase2Height = 11/g" app.toml)
+	$(cd "./${home}/config" && sed -i -e "s/LimitConsAddrUpdateIntervalHeight = 9223372036854775807/LimitConsAddrUpdateIntervalHeight = 11/g" app.toml)
 	$(cd "./${home}/config" && sed -i -e "s/breatheBlockInterval = 0/breatheBlockInterval = 5/g" app.toml)
 #	$(cd "./${home}/config" && sed -i -e "s/publishStaking = false/publishStaking = true/g" app.toml)
 #	$(cd "./${home}/config" && sed -i -e "s/publishKafka = false/publishKafka = true/g" app.toml)


### PR DESCRIPTION
### Description
The BEP159 hard fork still needs more discussion with the community, this PR removes it from the code first.

### Rationale
The BSC validator set maintainers need more time discussion about BEP159, especially the reward ratio. The team decide to delay the upgrade of BEP159

### Example
None

### Changes

Notable changes: 
None

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

