### PR TITLE
feat: add gen-consensus-key command in bnbcli

### DIFF
--- a/cmd/bnbcli/main.go
+++ b/cmd/bnbcli/main.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"github.com/bnb-chain/node/cmd/bnbcli/utils"
-	"github.com/spf13/cobra"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
@@ -12,16 +9,16 @@ import (
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	bankcmd "github.com/cosmos/cosmos-sdk/x/bank/client/cli"
 	govcmd "github.com/cosmos/cosmos-sdk/x/gov/client/cli"
-	sidecmd "github.com/cosmos/cosmos-sdk/x/sidechain/client/cli"
-
 	paramcmd "github.com/cosmos/cosmos-sdk/x/paramHub/client/cli"
+	sidecmd "github.com/cosmos/cosmos-sdk/x/sidechain/client/cli"
 	slashingcmd "github.com/cosmos/cosmos-sdk/x/slashing/client/cli"
 	stakecmd "github.com/cosmos/cosmos-sdk/x/stake/client/cli"
-
+	"github.com/spf13/cobra"
 	"github.com/tendermint/tendermint/libs/cli"
 
 	"github.com/bnb-chain/node/admin"
 	"github.com/bnb-chain/node/app"
+	"github.com/bnb-chain/node/cmd/bnbcli/utils"
 	"github.com/bnb-chain/node/common"
 	"github.com/bnb-chain/node/common/types"
 	accountcmd "github.com/bnb-chain/node/plugins/account/client/cli"

--- a/cmd/bnbcli/main.go
+++ b/cmd/bnbcli/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/bnb-chain/node/cmd/bnbcli/utils"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -84,6 +85,7 @@ func main() {
 		client.LineBreak,
 		apiserv.ServeCommand(cdc),
 		keys.Commands(),
+		utils.Commands(),
 		client.LineBreak,
 		version.VersionCmd,
 	)

--- a/cmd/bnbcli/utils/consensus_key.go
+++ b/cmd/bnbcli/utils/consensus_key.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/privval"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	outputPathFlag = "output-path"
+)
+
+func genConsensusKeyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gen-consensus-key",
+		Short: "generate the JSON file containing the private key to use as a validator in the consensus protocol",
+		RunE:  runGenConsensusKeyCmd,
+	}
+	cmd.Flags().String(outputPathFlag, "./priv_validator_key.json", "The target path of the output file")
+	return cmd
+}
+
+func runGenConsensusKeyCmd(cmd *cobra.Command, args []string) error {
+	flags := cmd.Flags()
+
+	outputPath, _ := flags.GetString(outputPathFlag)
+
+	filePv := privval.GenFilePV(outputPath, "")
+	filePv.Key.Save()
+	fmt.Printf("The consensus key has been generated and saved to %s successfully\n", outputPath)
+	pubkey := types.MustBech32ifyConsPub(filePv.Key.PubKey)
+	fmt.Printf("The consensus pubkey is %s\n", pubkey)
+	return nil
+}

--- a/cmd/bnbcli/utils/consensus_key.go
+++ b/cmd/bnbcli/utils/consensus_key.go
@@ -2,10 +2,10 @@ package utils
 
 import (
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/types"
-	"github.com/tendermint/tendermint/privval"
 
+	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
+	"github.com/tendermint/tendermint/privval"
 )
 
 const (

--- a/cmd/bnbcli/utils/root.go
+++ b/cmd/bnbcli/utils/root.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func Commands() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "utils",
+		Short: "Utilities for interacting with BNB Beacon Chain",
+	}
+	cmd.AddCommand(
+		genConsensusKeyCommand(),
+	)
+	return cmd
+}


### PR DESCRIPTION
### Description

Add a command to generate the JSON file containing the private key to use as a validator in the consensus protocol.

The generated file can be used as the `priv_validator_key_file` in `config.toml`. And the output consensus pubkey in bech32 format can be used as the parameter `pubkey` in `bnbcli staking create-validator-open` command.

```toml
# Path to the JSON file containing the private key to use as a validator in the consensus protocol
priv_validator_key_file = "config/priv_validator_key.json"
```

### Rationale

Currently, the consensus key is generated in the command `bnbchaind init`.

Generate the consensus key separately can be used when:
1. Users want to `create-validator` first and then init the full node.
2. Users want to update the consensus key.

### Example

```bash
$ ./build/bnbcli utils gen-consensus-key -h
generate the JSON file containing the private key to use as a validator in the consensus protocol

Usage:
  bnbcli utils gen-consensus-key [flags]

Flags:
  -h, --help                 help for gen-consensus-key
      --output-path string   The target path of the output file (default "./priv_validator_key.json")

Global Flags:
  -e, --encoding string   Binary encoding (hex|b64|btc) (default "hex")
      --home string       directory for config and data (default "/Users/xxx/.bnbcli")
  -o, --output string     Output format (text|json) (default "text")
      --trace             print out full stack trace on errors

$ ./build/bnbcli utils gen-consensus-key
The consensus key has been generated and saved to ./priv_validator_key.json successfully
The consensus pubkey is bcap1zcjduepqg6glk780f4ynvjjk82drnycty7zjl0uz79a6h2depnhavshvg39sm0c5tl

```

### Changes

* add a new command in bnbcli