### PR TITLE
release: prepare for release v0.10.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.10.9
 
 BUG FIX
-* [\#914](https://github.com/bnb-chain/node/pull/930) [deps] deps: bump cosmos-sdk to v0.26.1
+* [\#930](https://github.com/bnb-chain/node/pull/930) [deps] deps: bump cosmos-sdk to v0.26.1
 
 ## v0.10.8
 FEATURES

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
-//nolint
+// nolint
 package version
 
 import "fmt"
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.8"
+const NodeVersion = "v0.10.9"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This pr will prepare for the release v0.10.9 to change the version of node.

### Rationale

Change the version of node.

### Example

N/A

### Changes

Notable changes: 
* change the version of node

