### PR TITLE
feat: enable bep171 upgrade on mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.10
+FEATURES
+* [\#936](https://github.com/bnb-chain/node/pull/936) [BEP]: enable bep171 upgrade on mainnet #936
+
 ## v0.10.9
 
 BUG FIX

--- a/asset/mainnet/app.toml
+++ b/asset/mainnet/app.toml
@@ -63,6 +63,8 @@ BEP153Height = 284376000
 #Block height of BEP173 upgrade
 BEP173Height = 284376000
 FixDoubleSignChainIdHeight = 9223372036854775807
+# Block height of BEP171 upgrade
+BEP171Height = 309782000
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address

--- a/asset/mainnet/app.toml
+++ b/asset/mainnet/app.toml
@@ -64,7 +64,7 @@ BEP153Height = 284376000
 BEP173Height = 284376000
 FixDoubleSignChainIdHeight = 9223372036854775807
 # Block height of BEP171 upgrade
-BEP171Height = 309782000
+BEP171Height = 310182000
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.9"
+const NodeVersion = "v0.10.10"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This pr will enable the upgrade of [BEP171](https://github.com/bnb-chain/BEPs/pull/171) on mainnet. 
The forecasted upgrade time is 21th Apr. at 7:00 (UTC).

### Rationale

Enable BEP171.

### Example

NA

### Changes

Notable changes: 
* `app.toml`