### PR TITLE
release: prepare for release v0.10.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## v0.10.10
 FEATURES
-* [\#936](https://github.com/bnb-chain/node/pull/936) [BEP]: enable bep171 upgrade on mainnet #936
+* [\#936](https://github.com/bnb-chain/node/pull/936) [BEP]: enable bep171 upgrade on mainnet
+
+BUG FIX
+* [\#934](https://github.com/bnb-chain/node/pull/934) [fix] fix channel not registered error
+
 
 ## v0.10.9
-
 BUG FIX
 * [\#930](https://github.com/bnb-chain/node/pull/930) [deps] deps: bump cosmos-sdk to v0.26.1
 


### PR DESCRIPTION
### Description

This pr prepares for the release v0.10.10.

Change Log:

FEATURES
* [\#936](https://github.com/bnb-chain/node/pull/936)  feat: enable bep171 upgrade on mainnet

Bug Fix
* [\#934](https://github.com/bnb-chain/node/pull/934)  fix: channel not registered error


### Rationale

Prepare for release.

### Example

NA

### Changes

Notable changes: 
* change log


