### PR TITLE
chore: remove slashIndicator address from operator

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -502,12 +502,6 @@ func (app *BinanceChain) initSideChain() {
 		if sdkErr != nil {
 			panic(sdkErr.Error())
 		}
-
-		slashIndicatorAddr, _ := sdk.NewSmartChainAddress(slashIndicatorContractAddr)
-		_, sdkErr = app.scKeeper.AddSystemRewardOperator(ctx, chainId, slashIndicatorAddr)
-		if sdkErr != nil {
-			panic(sdkErr.Error())
-		}
 	})
 }
 


### PR DESCRIPTION
### Description

This pr is to remove slashIndicator address from operator when BEP126 upgrade happens.

### Rationale

SlashIndicator doesn't need operator permission anymore

### Changes

Notable changes: 
* remove slashIndicator address from operator
