### PR TITLE
release: draft release v0.10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
+## v0.10.11
+BUG FIX
+* [\#942](https://github.com/bnb-chain/node/pull/942) [deps] deps: bump cosmos-sdk to v0.26.2
+
 ## v0.10.10
 FEATURES
 * [\#936](https://github.com/bnb-chain/node/pull/936) [BEP]: enable bep171 upgrade on mainnet #936
 
 ## v0.10.9
-
 BUG FIX
 * [\#930](https://github.com/bnb-chain/node/pull/930) [deps] deps: bump cosmos-sdk to v0.26.1
 

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.10"
+const NodeVersion = "v0.10.11"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This drafts the release of v0.10.11, which is a bug fix release.

#### Changes
BUG FIX
* [\#942](https://github.com/bnb-chain/node/pull/942) [deps] deps: bump cosmos-sdk to v0.26.2


### Rationale

Bug fix of cli client

### Example

#### Before fix

```
/tbnbcli token info --symbol TCO-FC2 --chain-id=Binance-Chain-Ganges --node=data-seed-pre-0-s3.binance.org:80
ERROR: failed to prove merkle absence proof: Calculated root hash is invalid: expected [161 49 185 8 105 55 181 121 32 243 235 71 68 181 82 167 160 27 12 241 144 19 162 158 46 98 194 202 246 243 49 169] but got [39 141 219 74 147 43 56 167 105 71 172 202 68 173 171 108 109 124 101 138 17 151 247 201 119 103 250 236 190 16 28 228]
```

#### After fix

```
❯ ./tbnbcli token info --symbol BUSD-BAF --chain-id=Binance-Chain-Ganges --node=data-seed-pre-0-s3.binance.org:80
{
  "type": "bnbchain/Token",
  "value": {
    "name": "BUSD token",
    "symbol": "BUSD-BAF",
    "original_symbol": "BUSD",
    "total_supply": "16000000.00000000",
    "owner": "tbnb15yqj8s26vvf4l62954pr9wh8ltypwuzkmqwre4",
    "mintable": false,
    "contract_address": "0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee",
    "contract_decimals": 18
  }
}

```

### Changes

Notable changes: 
* go.mod

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)
