### PR TITLE
docs: update change log to release v0.10.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.13
+BUG FIX
+* [\#950](https://github.com/bnb-chain/node/pull/950) [deps] fix: bump cosmos sdk to fix validator unmarshal issue
+
 ## v0.10.12
 FEATURES
 * [\#935](https://github.com/bnb-chain/node/pull/935) [BEP] feat: implement bep126

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.12"
+const NodeVersion = "v0.10.13"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This pr prepares the release of v0.10.13.

#### Change Log

[\#950](https://github.com/bnb-chain/node/pull/950) [deps] fix: bump cosmos sdk to fix validator unmarshal issue

### Rationale

Release

### Example

NA

### Changes

Notable changes: 
* change log
