### PR TITLE
Support setting acc prefix  when collecting gentxs

### DIFF
--- a/cmd/bnbchaind/init/collect_gentxs.go
+++ b/cmd/bnbchaind/init/collect_gentxs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/bnb-chain/node/app"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -49,6 +50,8 @@ func CollectGenTxsCmd(cdc *codec.Codec, appInit server.AppInit) *cobra.Command {
 	cmd.Flags().StringP(flagGenTxDir, "i", "",
 		"override default \"gentx\" directory from which collect and execute "+
 			"genesis transactions; default [--home]/config/gentx/")
+	cmd.Flags().StringVar(&app.ServerContext.Bech32PrefixAccAddr, flagAccPrefix, "bnb", "bech32 prefix for AccAddress")
+	_ = app.ServerContext.BindPFlag("addr.bech32PrefixAccAddr", cmd.Flags().Lookup(flagAccPrefix))
 	return cmd
 }
 


### PR DESCRIPTION
### Description

support setting acc prefix  when collecting gentxs

### Rationale

useful to deploy test network.

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

