### PR TITLE
support setting acc prefix when collecting gentxs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.13
+BUG FIX
+* [\#950](https://github.com/bnb-chain/node/pull/950) [deps] fix: bump cosmos sdk to fix validator unmarshal issue
+
 ## v0.10.12
 FEATURES
 * [\#935](https://github.com/bnb-chain/node/pull/935) [BEP] feat: implement bep126

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.12"
+const NodeVersion = "v0.10.13"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

support setting acc prefix when collecting gentxs

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

