### PR TITLE
release: prepare change log for release v0.10.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.10.14
+FEATURES
+* [\#953](https://github.com/bnb-chain/node/pull/953) [cli] feat:support setting acc prefix when collecting gentxs
+* [\#957](https://github.com/bnb-chain/node/pull/957) [deps] deps: bump cosmos-sdk to v0.26.5
+
 ## v0.10.13
 BUG FIX
 * [\#950](https://github.com/bnb-chain/node/pull/950) [deps] fix: bump cosmos sdk to fix validator unmarshal issue

--- a/asset/mainnet/app.toml
+++ b/asset/mainnet/app.toml
@@ -66,7 +66,7 @@ FixDoubleSignChainIdHeight = 9223372036854775807
 # Block height of BEP171 upgrade
 BEP171Height = 310182000
 #Block height of BEP126 upgrade
-BEP126Height = 9223372036854775807
+BEP126Height = 321213000
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.13"
+const NodeVersion = "v0.10.14"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This pr prepares the release v0.10.14, with new features and bug fixes. 

The BNB Beacon Chain mainnet is expected to have a scheduled hard fork upgrade at block height 321213000. Based on the current block generation speed, the hard fork is forecasted to occur on 15th Jun. at 6:00 (UTC). The full node runners on mainnet must switch their software version to [v0.10.14](https://github.com/bnb-echain/node/releases/tag/v0.10.14) by 15th Jun.

Be noted: [BEP126](https://github.com/bnb-chain/BEPs/blob/master/BEP126.md) will be enabled for mainnet in this release.

#### Change Log
* [\#953](https://github.com/bnb-chain/node/pull/953) [cli] feat:support setting acc prefix when collecting gentxs
* [\#957](https://github.com/bnb-chain/node/pull/957) [deps] deps: bump cosmos-sdk to v0.26.5

### Rationale

Release

### Example

NA

### Changes

Notable changes: 
* NA