### PR TITLE
release: update change log and version for release v0.10.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## v0.10.15
+FEATURES
+* [\#956](https://github.com/bnb-chain/node/pull/956) [BEP] feat: implement bep255
+* [\#964](https://github.com/bnb-chain/node/pull/964) [fix] fix: clear side vote addresses
+
 ## v0.10.14
 FEATURES
-* [\#953](https://github.com/bnb-chain/node/pull/953) [cli] feat:support setting acc prefix when collecting gentxs
+* [\#953](https://github.com/bnb-chain/node/pull/953) [cli] feat: support setting acc prefix when collecting gentxs
 * [\#957](https://github.com/bnb-chain/node/pull/957) [deps] deps: bump cosmos-sdk to v0.26.5
 
 ## v0.10.13

--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -74,6 +74,8 @@ LimitConsAddrUpdateIntervalHeight = 37691120
 BEP171Height = 37691120
 # Block height of BEP126 upgrade
 BEP126Height = 38931600
+# Block height of BEP255 upgrade
+BEP255Height = 41650000
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]

--- a/go.mod
+++ b/go.mod
@@ -165,7 +165,7 @@ require (
 
 replace (
 	github.com/Shopify/sarama v1.26.1 => github.com/Shopify/sarama v1.21.0
-	github.com/cosmos/cosmos-sdk => github.com/NathanBSC/bnc-cosmos-sdk v0.0.0-20230706112451-a0c34d72f14b
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/bnc-cosmos-sdk v0.26.6
 	github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/prysmaticlabs/grpc-gateway/v2 v2.3.1-0.20210702154020-550e1cd83ec1
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/go-amino => github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,6 @@ github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go
 github.com/MariusVanDerWijden/FuzzyVM v0.0.0-20221202121132-bd37e8fb1d0d/go.mod h1:BSKhCg8phwi9taTm849mjagbJqs5fpFFXCc6uH4qaT4=
 github.com/MariusVanDerWijden/tx-fuzz v1.0.2/go.mod h1:jrK+Lr2mr1+6Pm3LlQ6rGHgK3WRQ9VMTiX+2mPMe6ys=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
-github.com/NathanBSC/bnc-cosmos-sdk v0.0.0-20230706112451-a0c34d72f14b h1:3ksZjBkwPU9EntuLpcqnMbP3BI6RmGFOlL1nTglAvsg=
-github.com/NathanBSC/bnc-cosmos-sdk v0.0.0-20230706112451-a0c34d72f14b/go.mod h1:OjdXpDHofs6gcPLM9oGD+mm8DPc6Lsevz0Kia53zt3Q=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -180,6 +178,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
+github.com/bnb-chain/bnc-cosmos-sdk v0.26.6 h1:5NrdUXplI2cqWZlLOovSqm+xO5ja03ZPCPT4bQqCD1Y=
+github.com/bnb-chain/bnc-cosmos-sdk v0.26.6/go.mod h1:OjdXpDHofs6gcPLM9oGD+mm8DPc6Lsevz0Kia53zt3Q=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2 h1:iAlp9gqG0f2LGAauf3ZiijWlT6NI+W2r9y70HH9LI3k=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2/go.mod h1:LiCO7jev+3HwLGAiN9gpD0z+jTz95RqgSavbse55XOY=
 github.com/bnb-chain/bnc-tendermint v0.32.3-bc.10 h1:E4iSwEbJCLYchHiHE1gnOM3jjmJXLBxARhy/RCl8CpI=

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.14"
+const NodeVersion = "v0.10.15"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This pr prepares the release v0.10.15, with new features and bug fixes. 

The BNB Beacon Chain *testnet* is expected to have a scheduled hard fork upgrade at block height 41650000. Based on the current block generation speed, the hard fork is forecasted to occur on 11th Jul. at 6:00 (UTC). The full node runners on *testnet* must switch their software version to [v0.10.15](https://github.com/bnb-echain/node/releases/tag/v0.10.15) before the height.

Be noted: [BEP255](https://github.com/bnb-chain/BEPs/blob/master/BEP255.md) will be enabled for *testnet* in this release.

### Rationale

Release

### Example

NA

### Changes

Notable changes: 
* change log
* testnet asset