### PR TITLE
release: draft release for v0.10.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.16
+FEATURES
+* [\#977](https://github.com/bnb-chain/node/pull/977) [BEP] asset: add bep255 upgrade height for mainnet
+
 ## v0.10.15
 FEATURES
 * [\#956](https://github.com/bnb-chain/node/pull/956) [BEP] feat: implement bep255

--- a/asset/mainnet/app.toml
+++ b/asset/mainnet/app.toml
@@ -67,6 +67,8 @@ FixDoubleSignChainIdHeight = 9223372036854775807
 BEP171Height = 310182000
 #Block height of BEP126 upgrade
 BEP126Height = 321213000
+# Block height of BEP255 upgrade
+BEP255Height = 328088888
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.15"
+const NodeVersion = "v0.10.16"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This pr drafts the release v0.10.16, which will enable BEP255 upgrade on mainnet. For more information, please refer to [BEP255](https://github.com/bnb-chain/BEPs/blob/master/BEP255.md).

The BNB Beacon Chain *mainnet* is expected to have a scheduled hard fork upgrade at block height 328088888. Based on the current block generation speed, the hard fork is forecasted to occur on 19th Jul. at 6:00 (UTC). The full node runners on *mainnet* must switch their software version to [v0.10.16](https://github.com/bnb-echain/node/releases/tag/v0.10.16) before the height.


### Rationale

Release

### Example

NA

### Changes

Notable changes: 
* change log
* mainnet asset