### PR TITLE
fix: add sunsethardfork config and fix panic issue

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -950,6 +950,9 @@ func (app *BNBBeaconChain) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock)
 	} else if ctx.RouterCallRecord()["stake"] || sdk.IsUpgrade(upgrade.BEP128) {
 		validatorUpdates, completedUbd = stake.EndBlocker(ctx, app.stakeKeeper)
 	}
+
+	// That is no deep copy when New IBC Keeper. need to set it again.
+	app.ibcKeeper.SetSideChainKeeper(app.scKeeper)
 	ibc.EndBlocker(ctx, app.ibcKeeper)
 	if len(validatorUpdates) != 0 {
 		app.ValAddrCache.ClearCache()

--- a/app/app.go
+++ b/app/app.go
@@ -360,6 +360,9 @@ func SetUpgradeConfig(upgradeConfig *config.UpgradeConfig) {
 	upgrade.Mgr.AddUpgradeHeight(upgrade.FixDoubleSignChainId, upgradeConfig.FixDoubleSignChainIdHeight)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP126, upgradeConfig.BEP126Height)
 	upgrade.Mgr.AddUpgradeHeight(upgrade.BEP255, upgradeConfig.BEP255Height)
+	upgrade.Mgr.AddUpgradeHeight(upgrade.FirstSunset, upgradeConfig.FirstSunsetHeight)
+	upgrade.Mgr.AddUpgradeHeight(upgrade.SecondSunset, upgradeConfig.SecondSunsetHeight)
+	upgrade.Mgr.AddUpgradeHeight(upgrade.FinalSunset, upgradeConfig.FinalSunsetHeight)
 
 	// register store keys of upgrade
 	upgrade.Mgr.RegisterStoreKeys(upgrade.BEP9, common.TimeLockStoreKey.Name())

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -103,6 +103,12 @@ FixDoubleSignChainIdHeight = {{ .UpgradeConfig.FixDoubleSignChainIdHeight }}
 BEP126Height = {{ .UpgradeConfig.BEP126Height }}
 # Block height of BEP255 upgrade
 BEP255Height = {{ .UpgradeConfig.BEP255Height }}
+# Block height of FirstSunset upgrade
+FirstSunsetHeight = {{ .UpgradeConfig.FirstSunsetHeight }}
+# Block height of SecondSunset upgrade
+SecondSunsetHeight = {{ .UpgradeConfig.SecondSunsetHeight }}
+# Block height of FinalSunset upgrade
+FinalSunsetHeight = {{ .UpgradeConfig.FinalSunsetHeight }}
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]
@@ -552,6 +558,9 @@ type UpgradeConfig struct {
 	FixDoubleSignChainIdHeight                      int64 `mapstructure:"FixDoubleSignChainIdHeight"`
 	BEP126Height                                    int64 `mapstructure:"BEP126Height"`
 	BEP255Height                                    int64 `mapstructure:"BEP255Height"`
+	FirstSunsetHeight                               int64 `mapstructure:"FirstSunsetHeight"`
+	SecondSunsetHeight                              int64 `mapstructure:"SecondSunsetHeight"`
+	FinalSunsetHeight                               int64 `mapstructure:"FinalSunsetHeight"`
 }
 
 func defaultUpgradeConfig() *UpgradeConfig {
@@ -586,7 +595,10 @@ func defaultUpgradeConfig() *UpgradeConfig {
 		BEP171Height:                      math.MaxInt64,
 		FixFailAckPackageHeight:           math.MaxInt64,
 		EnableAccountScriptsForCrossChainTransferHeight: math.MaxInt64,
-		BEP255Height: math.MaxInt64,
+		BEP255Height:       math.MaxInt64,
+		FirstSunsetHeight:  math.MaxInt64,
+		SecondSunsetHeight: math.MaxInt64,
+		FinalSunsetHeight:  math.MaxInt64,
 	}
 }
 

--- a/common/upgrade/upgrade.go
+++ b/common/upgrade/upgrade.go
@@ -49,7 +49,10 @@ const (
 	BEP171                      = sdk.BEP171 // https://github.com/bnb-chain/BEPs/pull/171 Security Enhancement for Cross-Chain Module
 	BEP173                      = sdk.BEP173 // https://github.com/bnb-chain/BEPs/pull/173 Text Proposal
 	FixDoubleSignChainId        = sdk.FixDoubleSignChainId
-	BEP255                      = sdk.BEP255 // https://github.com/bnb-chain/BEPs/pull/255 Asset Reconciliation for Security Enhancement
+	BEP255                      = sdk.BEP255           // https://github.com/bnb-chain/BEPs/pull/255 Asset Reconciliation for Security Enhancement
+	FirstSunset                 = sdk.FirstSunsetFork  // https://github.com/bnb-chain/BEPs/pull/333 BNB Chain Fusion
+	SecondSunset                = sdk.SecondSunsetFork // https://github.com/bnb-chain/BEPs/pull/333 BNB Chain Fusion
+	FinalSunset                 = sdk.FinalSunsetFork  // https://github.com/bnb-chain/BEPs/pull/333 BNB Chain Fusion
 )
 
 func UpgradeBEP10(before func(), after func()) {

--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 replace (
 	github.com/Shopify/sarama v1.26.1 => github.com/Shopify/sarama v1.21.0
 	// TODO: bump to official release
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20231129092047-065b54761eab
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20231214014755-d940f55f667c
 	github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/prysmaticlabs/grpc-gateway/v2 v2.3.1-0.20210702154020-550e1cd83ec1
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/go-amino => github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20231129092047-065b54761eab h1:Wr52A136l+sjd79w3zv6cRaSz9IYNWgoeE9tW9SGwxU=
-github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20231129092047-065b54761eab/go.mod h1:OjdXpDHofs6gcPLM9oGD+mm8DPc6Lsevz0Kia53zt3Q=
+github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20231214014755-d940f55f667c h1:8R2s5MCR8ZYn5ChktnXmuwC1z5l0Ldrfpt8WdMqmOQE=
+github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20231214014755-d940f55f667c/go.mod h1:OjdXpDHofs6gcPLM9oGD+mm8DPc6Lsevz0Kia53zt3Q=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2 h1:iAlp9gqG0f2LGAauf3ZiijWlT6NI+W2r9y70HH9LI3k=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2/go.mod h1:LiCO7jev+3HwLGAiN9gpD0z+jTz95RqgSavbse55XOY=
 github.com/bnb-chain/bnc-tendermint v0.32.3-bc.10 h1:E4iSwEbJCLYchHiHE1gnOM3jjmJXLBxARhy/RCl8CpI=


### PR DESCRIPTION
### Description
1. add sunsethardfork config
2. ibc keeper did not set it correctly

### Rationale
`scKeeper` is not copied when the app init stage. and it will panic in `EndBlock` to call the ibc.scKeeper

### Example
n/a

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

