### PR TITLE
fix: refund swap, timelock failed

### DIFF
--- a/plugins/tokens/plugin.go
+++ b/plugins/tokens/plugin.go
@@ -92,6 +92,13 @@ func EndBlocker(ctx sdk.Context, timelockKeeper timelock.Keeper, swapKeeper swap
 		var automaticSwap swap.AtomicSwap
 		swapKeeper.CDC().MustUnmarshalBinaryBare(swapIterator.Value(), &automaticSwap)
 		swapID := swapIterator.Key()[len(swap.HashKey):]
+		swapItem := swapKeeper.GetSwap(ctx, swapID)
+		if swapItem == nil {
+			continue
+		}
+		if swapItem.Status != swap.Open {
+			continue
+		}
 		result := swap.HandleRefundHashTimerLockedTransferAfterBCFusion(ctx, swapKeeper, swap.RefundHTLTMsg{
 			From:   automaticSwap.From,
 			SwapID: swapID,

--- a/plugins/tokens/plugin.go
+++ b/plugins/tokens/plugin.go
@@ -104,7 +104,7 @@ func EndBlocker(ctx sdk.Context, timelockKeeper timelock.Keeper, swapKeeper swap
 			SwapID: swapID,
 		})
 		if !result.IsOK() {
-			logger.Error("Refund error", "swapId", swapID, "result", fmt.Sprintf("%s", result))
+			logger.Error("Refund error", "swapId", swapID, "result", fmt.Sprintf("%+v", result))
 			continue
 		}
 		i++

--- a/plugins/tokens/plugin.go
+++ b/plugins/tokens/plugin.go
@@ -74,7 +74,7 @@ func EndBlocker(ctx sdk.Context, timelockKeeper timelock.Keeper, swapKeeper swap
 			logger.Error("ParseKeyRecord error", "error", err)
 			continue
 		}
-		err = timelockKeeper.TimeUnlock(ctx, addr, id)
+		err = timelockKeeper.TimeUnlock(ctx, addr, id, true)
 		if err != nil {
 			logger.Error("TimeUnlock error", "error", err)
 			continue
@@ -104,7 +104,7 @@ func EndBlocker(ctx sdk.Context, timelockKeeper timelock.Keeper, swapKeeper swap
 			SwapID: swapID,
 		})
 		if !result.IsOK() {
-			logger.Error("Refund error", "swapId", swapID)
+			logger.Error("Refund error", "swapId", swapID, result.Tags)
 			continue
 		}
 		i++

--- a/plugins/tokens/plugin.go
+++ b/plugins/tokens/plugin.go
@@ -104,7 +104,7 @@ func EndBlocker(ctx sdk.Context, timelockKeeper timelock.Keeper, swapKeeper swap
 			SwapID: swapID,
 		})
 		if !result.IsOK() {
-			logger.Error("Refund error", "swapId", swapID, result.Tags)
+			logger.Error("Refund error", "swapId", swapID, "result", fmt.Sprintf("%s", result))
 			continue
 		}
 		i++

--- a/plugins/tokens/timelock/handler.go
+++ b/plugins/tokens/timelock/handler.go
@@ -60,7 +60,7 @@ func handleTimeRelock(ctx sdk.Context, keeper Keeper, msg TimeRelockMsg) sdk.Res
 }
 
 func handleTimeUnlock(ctx sdk.Context, keeper Keeper, msg TimeUnlockMsg) sdk.Result {
-	err := keeper.TimeUnlock(ctx, msg.From, msg.Id)
+	err := keeper.TimeUnlock(ctx, msg.From, msg.Id, false)
 	if err != nil {
 		return err.Result()
 	}

--- a/plugins/tokens/timelock/keeper.go
+++ b/plugins/tokens/timelock/keeper.go
@@ -127,13 +127,13 @@ func (keeper Keeper) TimeLock(ctx sdk.Context, from sdk.AccAddress, description 
 	return record, nil
 }
 
-func (keeper Keeper) TimeUnlock(ctx sdk.Context, from sdk.AccAddress, recordId int64) sdk.Error {
+func (keeper Keeper) TimeUnlock(ctx sdk.Context, from sdk.AccAddress, recordId int64, isBCFusionRefund bool) sdk.Error {
 	record, found := keeper.GetTimeLockRecord(ctx, from, recordId)
 	if !found {
 		return ErrTimeLockRecordDoesNotExist(DefaultCodespace, from, recordId)
 	}
 
-	if ctx.BlockHeader().Time.Before(record.LockTime) {
+	if !isBCFusionRefund && ctx.BlockHeader().Time.Before(record.LockTime) {
 		return ErrCanNotUnlock(DefaultCodespace, fmt.Sprintf("lock time(%s) is after now(%s)",
 			record.LockTime.UTC().String(), ctx.BlockHeader().Time.UTC().String()))
 	}

--- a/plugins/tokens/timelock/keeper_test.go
+++ b/plugins/tokens/timelock/keeper_test.go
@@ -142,7 +142,7 @@ func TestKeeper_TimeUnlock_RecordNotExist(t *testing.T) {
 
 	_, acc := testutils.NewAccount(ctx, accKeeper, 0)
 
-	err := keeper.TimeUnlock(ctx, acc.GetAddress(), 1)
+	err := keeper.TimeUnlock(ctx, acc.GetAddress(), 1, false)
 	require.NotNil(t, err)
 	require.Equal(t, err.Code(), CodeTimeLockRecordDoesNotExist)
 }
@@ -169,7 +169,7 @@ func TestKeeper_TimeUnlock_ErrLockTime(t *testing.T) {
 	record, err := keeper.TimeLock(ctx, acc.GetAddress(), "Test", lockCoins, time.Now().Add(1000*time.Second))
 	require.Nil(t, err)
 
-	err = keeper.TimeUnlock(ctx, acc.GetAddress(), record.Id)
+	err = keeper.TimeUnlock(ctx, acc.GetAddress(), record.Id, false)
 	require.NotNil(t, err)
 	require.Equal(t, err.Code(), CodeCanNotUnlock)
 }
@@ -197,7 +197,7 @@ func TestKeeper_TimeUnlock_Success(t *testing.T) {
 	require.Nil(t, err)
 
 	ctx = ctx.WithBlockTime(time.Now().Add(2000 * time.Second))
-	err = keeper.TimeUnlock(ctx, acc.GetAddress(), record.Id)
+	err = keeper.TimeUnlock(ctx, acc.GetAddress(), record.Id, false)
 	require.Nil(t, err)
 }
 


### PR DESCRIPTION
### Description

this pr include 2 fix for refund:
1. [only refund opened swap](https://github.com/bnb-chain/node/commit/dad1e235f7e016765ed4ac6de2b4236f9e150f4d)
2. [do not check timelock time if isBCFusionRefund](https://github.com/bnb-chain/node/commit/587060ad41f19e88f717a970ec1d49c59228ceec)
### Rationale

n/a

### Example

n/a

### Changes

Notable changes: 
* refund

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [ x manual transaction test passed (cli invoke)

### Already reviewed by

n/a

### Related issues

n/a
