### PR TITLE
chore: update cosmos-sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 replace (
 	github.com/Shopify/sarama v1.26.1 => github.com/Shopify/sarama v1.21.0
 	// TODO: bump to official release
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240104113054-9e0aa252ecc4
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240105082215-555f52701c56
 	github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/prysmaticlabs/grpc-gateway/v2 v2.3.1-0.20210702154020-550e1cd83ec1
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/go-amino => github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240104113054-9e0aa252ecc4 h1:g3gYJ/nrm3P1GcRLQBmQErDHA6JNjtk5tsnLUiu+Dnc=
-github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240104113054-9e0aa252ecc4/go.mod h1:OjdXpDHofs6gcPLM9oGD+mm8DPc6Lsevz0Kia53zt3Q=
+github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240105082215-555f52701c56 h1:eXJqo4tNqgRsuytJNh67u75+lqz5AoVFGFD2eqiEnDY=
+github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240105082215-555f52701c56/go.mod h1:OjdXpDHofs6gcPLM9oGD+mm8DPc6Lsevz0Kia53zt3Q=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2 h1:iAlp9gqG0f2LGAauf3ZiijWlT6NI+W2r9y70HH9LI3k=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2/go.mod h1:LiCO7jev+3HwLGAiN9gpD0z+jTz95RqgSavbse55XOY=
 github.com/bnb-chain/bnc-tendermint v0.32.3-bc.10 h1:E4iSwEbJCLYchHiHE1gnOM3jjmJXLBxARhy/RCl8CpI=


### PR DESCRIPTION
### Description

chore: update cosmos-sdk

### Rationale

disable ClaimMsg after FinalSunsetFork

### Example

n/a
### Changes

Notable changes: 
* n/a

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

n/a

### Related issues

... reference related issue #'s here ...

