### PR TITLE
feat: implement cmd to sign validator ownership

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -55,6 +55,7 @@ import (
 	"github.com/bnb-chain/node/plugins/dex/list"
 	"github.com/bnb-chain/node/plugins/dex/order"
 	dextypes "github.com/bnb-chain/node/plugins/dex/types"
+	migrate "github.com/bnb-chain/node/plugins/migrate"
 	tokenRecover "github.com/bnb-chain/node/plugins/recover"
 	"github.com/bnb-chain/node/plugins/tokens"
 	"github.com/bnb-chain/node/plugins/tokens/issue"
@@ -1178,6 +1179,7 @@ func MakeCodec() *wire.Codec {
 	oracle.RegisterWire(cdc)
 	ibc.RegisterWire(cdc)
 	tokenRecover.RegisterWire(cdc)
+	migrate.RegisterWire(cdc)
 	return cdc
 }
 

--- a/cmd/bnbcli/main.go
+++ b/cmd/bnbcli/main.go
@@ -26,6 +26,7 @@ import (
 	apiserv "github.com/bnb-chain/node/plugins/api"
 	bridgecmd "github.com/bnb-chain/node/plugins/bridge/client/cli"
 	dexcmd "github.com/bnb-chain/node/plugins/dex/client/cli"
+	migratecmd "github.com/bnb-chain/node/plugins/migrate/client/cli"
 	recovercmd "github.com/bnb-chain/node/plugins/recover/client/cli"
 	tokencmd "github.com/bnb-chain/node/plugins/tokens/client/cli"
 	"github.com/bnb-chain/node/version"
@@ -101,6 +102,7 @@ func main() {
 	bridgecmd.AddCommands(rootCmd, cdc)
 	sidecmd.AddCommands(rootCmd, cdc)
 	recovercmd.AddCommands(rootCmd, cdc)
+	migratecmd.AddCommands(rootCmd, cdc)
 
 	// prepare and add flags
 	executor := cli.PrepareMainCmd(rootCmd, "BC", app.DefaultCLIHome)

--- a/plugins/migrate/client/cli/commands.go
+++ b/plugins/migrate/client/cli/commands.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/spf13/cobra"
+)
+
+func AddCommands(cmd *cobra.Command, cdc *codec.Codec) {
+	ownerShipCmd := &cobra.Command{
+		Use:   "validator-ownership",
+		Short: "validator-ownership commands",
+	}
+
+	ownerShipCmd.AddCommand(
+		client.PostCommands(
+			SignValidatorOwnerShipCmd(cdc),
+		)...,
+	)
+
+	cmd.AddCommand(ownerShipCmd)
+}

--- a/plugins/migrate/client/cli/tx.go
+++ b/plugins/migrate/client/cli/tx.go
@@ -81,14 +81,14 @@ func SignAndPrint(ctx context.CLIContext, builder authtxb.TxBuilder, bscOperator
 
 	fmt.Printf("TX JSON: %s\n", json)
 	fmt.Println("Sign Message: ", string(stdMsg.Bytes()))
-	fmt.Println("Sign Message Hash: ", hex.EncodeToString(crypto.Sha256(stdMsg.Bytes())))
+	fmt.Println("Sign Message Hash: ", "0x"+hex.EncodeToString(crypto.Sha256(stdMsg.Bytes())))
 	sig := tx.GetSignatures()[0]
-	fmt.Printf("Signature: %s\n", hex.EncodeToString(sig.Signature))
+	fmt.Printf("Signature: %s\n", "0x"+hex.EncodeToString(sig.Signature))
 	var originPubKey secp256k1.PubKeySecp256k1
 	err = builder.Codec.UnmarshalBinaryBare(sig.PubKey.Bytes(), &originPubKey)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("PubKey: %s\n", hex.EncodeToString(originPubKey))
+	fmt.Printf("PubKey: %s\n", "0x"+hex.EncodeToString(originPubKey))
 	return nil
 }

--- a/plugins/migrate/client/cli/tx.go
+++ b/plugins/migrate/client/cli/tx.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/keys"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
+	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
+
+	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+
+	"github.com/bnb-chain/node/plugins/migrate"
+)
+
+const (
+	flagBSCOperatorAddress = "bsc-operator-address"
+)
+
+func SignValidatorOwnerShipCmd(cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sign-validator-ownership",
+		Short: "get validator ownership sign data",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().
+				WithCodec(cdc).
+				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
+			bscOperator := viper.GetString(flagBSCOperatorAddress)
+
+			return SignAndPrint(cliCtx, txBldr, common.HexToAddress(bscOperator))
+		},
+	}
+
+	cmd.Flags().String(flagBSCOperatorAddress, "", "bsc operator address")
+
+	return cmd
+}
+
+func SignAndPrint(ctx context.CLIContext, builder authtxb.TxBuilder, bscOperator common.Address) error {
+	name, err := ctx.GetFromName()
+	if err != nil {
+		return err
+	}
+
+	passphrase, err := keys.GetPassphrase(name)
+	if err != nil {
+		return err
+	}
+
+	msg := migrate.NewValidatorOwnerShipMsg(bscOperator)
+
+	// build and sign the transaction
+	stdMsg, err := builder.Build([]sdk.Msg{msg})
+	if err != nil {
+		return err
+	}
+	txBytes, err := builder.Sign(name, passphrase, stdMsg)
+	if err != nil {
+		return err
+	}
+
+	var tx auth.StdTx
+	err = builder.Codec.UnmarshalBinaryLengthPrefixed(txBytes, &tx)
+	if err != nil {
+		return err
+	}
+	json, err := builder.Codec.MarshalJSON(tx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("TX JSON: %s\n", json)
+	fmt.Println("Sign Message: ", string(stdMsg.Bytes()))
+	fmt.Println("Sign Message Hash: ", hex.EncodeToString(crypto.Sha256(stdMsg.Bytes())))
+	sig := tx.GetSignatures()[0]
+	fmt.Printf("Signature: %s\n", hex.EncodeToString(sig.Signature))
+	var originPubKey secp256k1.PubKeySecp256k1
+	err = builder.Codec.UnmarshalBinaryBare(sig.PubKey.Bytes(), &originPubKey)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("PubKey: %s\n", hex.EncodeToString(originPubKey))
+	return nil
+}

--- a/plugins/migrate/msg.go
+++ b/plugins/migrate/msg.go
@@ -1,0 +1,75 @@
+package migrate
+
+import (
+	"encoding/json"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	Route   = "recover"
+	MsgType = "validator_ownership"
+)
+
+var _ sdk.Msg = ValidatorOwnerShip{}
+
+func NewValidatorOwnerShipMsg(
+	bscOperatorAddress common.Address,
+) ValidatorOwnerShip {
+	return ValidatorOwnerShip{
+		BSCOperatorAddress: bscOperatorAddress,
+	}
+}
+
+func newValidatorOwnerShipSignData(
+	bscOperatorAddress common.Address) ValidatorOwnerShipSignData {
+	return ValidatorOwnerShipSignData{
+		BSCOperatorAddress: strings.ToLower(bscOperatorAddress.Hex()),
+	}
+}
+
+type ValidatorOwnerShipSignData struct {
+	BSCOperatorAddress string `json:"bsc_operator_address"`
+}
+
+type ValidatorOwnerShip struct {
+	BSCOperatorAddress common.Address `json:"bsc_operator_address"`
+}
+
+// GetInvolvedAddresses implements types.Msg.
+func (msg ValidatorOwnerShip) GetInvolvedAddresses() []sdk.AccAddress {
+	return msg.GetSigners()
+}
+
+// GetSignBytes implements types.Msg.
+func (msg ValidatorOwnerShip) GetSignBytes() []byte {
+	b, err := json.Marshal(newValidatorOwnerShipSignData(msg.BSCOperatorAddress))
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// GetSigners implements types.Msg.
+func (m ValidatorOwnerShip) GetSigners() []sdk.AccAddress {
+	// This is not a real on-chain transaction
+	// We can get signer from the public key.
+	return []sdk.AccAddress{}
+}
+
+// Route implements types.Msg.
+func (ValidatorOwnerShip) Route() string {
+	return Route
+}
+
+// Type implements types.Msg.
+func (ValidatorOwnerShip) Type() string {
+	return MsgType
+}
+
+// ValidateBasic implements types.Msg.
+func (msg ValidatorOwnerShip) ValidateBasic() sdk.Error {
+	return nil
+}

--- a/plugins/migrate/wire.go
+++ b/plugins/migrate/wire.go
@@ -1,0 +1,10 @@
+package migrate
+
+import (
+	"github.com/bnb-chain/node/wire"
+)
+
+// Register concrete types on wire codec
+func RegisterWire(cdc *wire.Codec) {
+	cdc.RegisterConcrete(ValidatorOwnerShip{}, "migrate/ValidatorOwnerShip", nil)
+}

--- a/plugins/recover/client/cli/tx.go
+++ b/plugins/recover/client/cli/tx.go
@@ -92,14 +92,14 @@ func SignAndPrint(ctx context.CLIContext, builder authtxb.TxBuilder, msg sdk.Msg
 
 	fmt.Printf("TX JSON: %s\n", json)
 	fmt.Println("Sign Message: ", string(stdMsg.Bytes()))
-	fmt.Println("Sign Message Hash: ", hex.EncodeToString(crypto.Sha256(stdMsg.Bytes())))
+	fmt.Println("Sign Message Hash: ", "0x"+hex.EncodeToString(crypto.Sha256(stdMsg.Bytes())))
 	sig := tx.GetSignatures()[0]
-	fmt.Printf("Signature: %s\n", hex.EncodeToString(sig.Signature))
+	fmt.Printf("Signature: %s\n", "0x"+hex.EncodeToString(sig.Signature))
 	var originPubKey secp256k1.PubKeySecp256k1
 	err = builder.Codec.UnmarshalBinaryBare(sig.PubKey.Bytes(), &originPubKey)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("PubKey: %s\n", hex.EncodeToString(originPubKey))
+	fmt.Printf("PubKey: %s\n", "0x"+hex.EncodeToString(originPubKey))
 	return nil
 }


### PR DESCRIPTION
### Description

feat: implement cmd to sign validator ownership

### Rationale

bsc validator on bc can sign their sigs to prove the ownership to the new operator address on bsc after bc-fusion

### Example

```bash
./build/tbnbcli validator-ownership sign-validator-ownership --bsc-operator-address 0x45737bAf95D995a963ab3a7c9AC66fC7A63ad76E --from test1 --chain-id Binance-Chain-Ganges
```

### Changes

Notable changes: 
* cmd

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

n/a

### Related issues

n/a

