### PR TITLE
fix: change BreatheBlockInterval config to time period

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -898,7 +898,7 @@ func (app *BNBBeaconChain) isBreatheBlock(height int64, lastBlockTime time.Time,
 	// lastBlockTime is zero if this blockTime is for the first block (first block doesn't mean height = 1, because after
 	// state sync from breathe block, the height is breathe block + 1)
 	if app.baseConfig.BreatheBlockInterval > 0 {
-		return height%int64(app.baseConfig.BreatheBlockInterval) == 0
+		return !lastBlockTime.IsZero() && !utils.SamePeriodInUTC(lastBlockTime, blockTime, int64(app.baseConfig.BreatheBlockInterval))
 	} else {
 		return !lastBlockTime.IsZero() && !utils.SameDayInUTC(lastBlockTime, blockTime)
 	}

--- a/common/utils/times.go
+++ b/common/utils/times.go
@@ -12,3 +12,7 @@ func Now() time.Time {
 func SameDayInUTC(first, second time.Time) bool {
 	return first.Unix()/SecondsPerDay == second.Unix()/SecondsPerDay
 }
+
+func SamePeriodInUTC(first, second time.Time, period int64) bool {
+	return first.Unix()/period == second.Unix()/period
+}


### PR DESCRIPTION
### Description

fix: change BreatheBlockInterval config to time period

### Rationale

In order to match the breathing block judgment of BSC, it is necessary to change the original judgment based on block height to time judgment.

### Example

n/a

### Changes

Notable changes: 
* config

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

n/a

### Related issues

n/a
