### PR TITLE
doc: add change log and testnet upgrade hight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.10.17
+This is the release for the sunset of BNB Beacon Chain.
+
+FEATURES
+* [\#977](https://github.com/bnb-chain/node/pull/1003) [BEP] feat: implement BEP-333(BNB Chain Fusion)
+
+
 ## v0.10.16
 FEATURES
 * [\#977](https://github.com/bnb-chain/node/pull/977) [BEP] asset: add bep255 upgrade height for mainnet

--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -76,6 +76,7 @@ BEP171Height = 37691120
 BEP126Height = 38931600
 # Block height of BEP255 upgrade
 BEP255Height = 41650000
+FirstSunsetHeight = 50121232
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]


### PR DESCRIPTION
### Description

this PR prepare for the v0.10.17 release.

### Rationale

1. change the upgrade height for testnet, target at 4th March UTC 6:00.
2. Add change logs

### Example
None

### Changes
This is a hardfork upgrade on testnet, every client is suggested to upgrade

### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

