### PR TITLE
fix: publish completed UnbondingDelegation events to kafka in EndBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+## v0.10.18
+This is the buf-fix release for the sunset of BNB Beacon Chain.
+
+FEATURES
+* [\#1004](https://github.com/bnb-chain/node/pull/1004) [fix] fix: publish completed UnbondingDelegation events to kafka in EndBlock
+
+
 ## v0.10.17
 This is the release for the sunset of BNB Beacon Chain.
 
 FEATURES
-* [\#977](https://github.com/bnb-chain/node/pull/1003) [BEP] feat: implement BEP-333(BNB Chain Fusion)
+* [\#1003](https://github.com/bnb-chain/node/pull/1003) [BEP] feat: implement BEP-333(BNB Chain Fusion)
 
 
 ## v0.10.16

--- a/go.mod
+++ b/go.mod
@@ -165,7 +165,7 @@ require (
 
 replace (
 	github.com/Shopify/sarama v1.26.1 => github.com/Shopify/sarama v1.21.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240229092307-8d663caeea0a
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/bnc-cosmos-sdk v0.26.8
 	github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/prysmaticlabs/grpc-gateway/v2 v2.3.1-0.20210702154020-550e1cd83ec1
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/go-amino => github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2

--- a/go.mod
+++ b/go.mod
@@ -165,7 +165,7 @@ require (
 
 replace (
 	github.com/Shopify/sarama v1.26.1 => github.com/Shopify/sarama v1.21.0
-	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/bnc-cosmos-sdk v0.26.7
+	github.com/cosmos/cosmos-sdk => github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240229092307-8d663caeea0a
 	github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/prysmaticlabs/grpc-gateway/v2 v2.3.1-0.20210702154020-550e1cd83ec1
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/go-amino => github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240229092307-8d663caeea0a h1:kn4nGo8dOr9YahtvxaYClYYCxGhC+5qk6dZT07aB0pg=
-github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240229092307-8d663caeea0a/go.mod h1:OjdXpDHofs6gcPLM9oGD+mm8DPc6Lsevz0Kia53zt3Q=
+github.com/bnb-chain/bnc-cosmos-sdk v0.26.8 h1:YmkqrGKzzWzd5uV46Yem1+docY4hi3aNeCsxGUORzbg=
+github.com/bnb-chain/bnc-cosmos-sdk v0.26.8/go.mod h1:OjdXpDHofs6gcPLM9oGD+mm8DPc6Lsevz0Kia53zt3Q=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2 h1:iAlp9gqG0f2LGAauf3ZiijWlT6NI+W2r9y70HH9LI3k=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2/go.mod h1:LiCO7jev+3HwLGAiN9gpD0z+jTz95RqgSavbse55XOY=
 github.com/bnb-chain/bnc-tendermint v0.32.3-bc.10 h1:E4iSwEbJCLYchHiHE1gnOM3jjmJXLBxARhy/RCl8CpI=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/bnc-cosmos-sdk v0.26.7 h1:6dnRDvX5Q31+uJSvw3OhK8zb5kUeEX+dWvw9XbR4IEg=
-github.com/bnb-chain/bnc-cosmos-sdk v0.26.7/go.mod h1:OjdXpDHofs6gcPLM9oGD+mm8DPc6Lsevz0Kia53zt3Q=
+github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240229092307-8d663caeea0a h1:kn4nGo8dOr9YahtvxaYClYYCxGhC+5qk6dZT07aB0pg=
+github.com/bnb-chain/bnc-cosmos-sdk v0.26.5-0.20240229092307-8d663caeea0a/go.mod h1:OjdXpDHofs6gcPLM9oGD+mm8DPc6Lsevz0Kia53zt3Q=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2 h1:iAlp9gqG0f2LGAauf3ZiijWlT6NI+W2r9y70HH9LI3k=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2/go.mod h1:LiCO7jev+3HwLGAiN9gpD0z+jTz95RqgSavbse55XOY=
 github.com/bnb-chain/bnc-tendermint v0.32.3-bc.10 h1:E4iSwEbJCLYchHiHE1gnOM3jjmJXLBxARhy/RCl8CpI=


### PR DESCRIPTION
### Description

fix: publish completed UnbondingDelegation events to kafka in EndBlock

### Rationale

related to: https://github.com/bnb-chain/bnc-cosmos-sdk/pull/388

### Example
n/a

### Changes

Notable changes: 
* go.mod

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

n/a

### Related issues

n/a

