### PR TITLE
feat: enable FirstSunset on mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.10.20
+This is the release for the First Sunset of BNB Beacon Chain Mainnet.
+
+FEATURES
+* [\#1016](https://github.com/bnb-chain/node/pull/1016) [BEP] feat: enable FirstSunset on mainnet
+
 ## v0.10.19
 This is the bug-fix release for the sunset of BNB Beacon Chain.
 

--- a/asset/mainnet/app.toml
+++ b/asset/mainnet/app.toml
@@ -69,6 +69,8 @@ BEP171Height = 310182000
 BEP126Height = 321213000
 # Block height of BEP255 upgrade
 BEP255Height = 328088888
+# Block height of BEP333 upgrade
+FirstSunsetHeight = 373526985
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.19"
+const NodeVersion = "v0.10.20"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This PR add the FirstSunset height to mainnet config.

### Rationale

The target fork time is `2024/4/15/ 06:00:00 UTC+0`(1713160800)
Current Block time: `2024/4/1 03:25:38 UTC+0`(1711941938) -> https://explorer.bnbchain.org/block/372822440
Avg Block Time: 19s/11 ~= 1.73s

Target Fork Block Height: (1713160800 - 1711941938)/1.73 + 372822440 ~= `373526985`

### Example

n/a

### Changes

Notable changes: 
n/a

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

n/a

### Related issues

n/a
