### PR TITLE
release: release v0.10.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## v0.10.21
+This is the release for the Second Sunset of BNB Beacon Chain testnet.
 
 ## v0.10.20
 This is the release for the First Sunset of BNB Beacon Chain Mainnet.

--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -77,6 +77,7 @@ BEP126Height = 38931600
 # Block height of BEP255 upgrade
 BEP255Height = 41650000
 FirstSunsetHeight = 50121232
+SecondSunsetHeight = 53251229
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]


### PR DESCRIPTION
### Description
This just enable the upgrade height for Second Sunset of BNB Beacon Chain testnet.

### Rationale
prepare for release v0.10.21

### Example
No

### Changes
None

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

