### PR TITLE
chore: update testnet second sunset hardfork height

### DIFF
--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -77,7 +77,7 @@ BEP126Height = 38931600
 # Block height of BEP255 upgrade
 BEP255Height = 41650000
 FirstSunsetHeight = 50121232
-SecondSunsetHeight = 53251229
+SecondSunsetHeight = 54554742
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]


### PR DESCRIPTION
### Description

Update testnet second sunset hardfork height:
2024-06-12 14:00:00 height: 54188856 https://testnet-explorer.bnbchain.org/block/54188856
2024-06-11 14:00:00 height: 54148202 https://testnet-explorer.bnbchain.org/block/54148202

2024-06-21 14:00:00 height: 54188856 + 9 * (54188856 - 54148202) = 54554742

### Rationale

update second sunset hardfork height for testnet

### Example

NA

### Changes

Notable changes: 
* app.toml