### PR TITLE
release: release v0.10.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## v0.10.22
+This is the release for the Second Sunset of BNB Beacon Chain Mainnet.
+
 ## v0.10.21
 This is the release for the Second Sunset of BNB Beacon Chain testnet.
 

--- a/asset/mainnet/app.toml
+++ b/asset/mainnet/app.toml
@@ -71,6 +71,8 @@ BEP126Height = 321213000
 BEP255Height = 328088888
 # Block height of BEP333 upgrade
 FirstSunsetHeight = 373526985
+# Block height of BEP333 upgrade
+SecondSunsetHeight = 378062790
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.21"
+const NodeVersion = "v0.10.22"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

This is release pr to enable `Second Sunset Hardfork` on BC mainnet.

### Rationale

June 26, 14:00 height: 377148750 
June 25, 14:00 height: 377097970

July 14, 14:00 expect height: 377148750 + (377148750 - 377097970) * 18 = 378,062,790

### Example

NA

### Changes

Notable changes: 
* hardfork height