### PR TITLE
release: release v0.10.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.10.23
+This is the release for the Final Sunset of BNB Beacon Chain testnet.
+
 ## v0.10.22
 This is the release for the Second Sunset of BNB Beacon Chain Mainnet.
 

--- a/asset/testnet/app.toml
+++ b/asset/testnet/app.toml
@@ -76,8 +76,10 @@ BEP171Height = 37691120
 BEP126Height = 38931600
 # Block height of BEP255 upgrade
 BEP255Height = 41650000
+# Block height of BEP333 upgrade
 FirstSunsetHeight = 50121232
 SecondSunsetHeight = 54554742
+FinalSunsetHeight = 56218686
 
 [query]
 # ABCI query interface black list, suggested value: ["custom/gov/proposals", "custom/timelock/timelocks", "custom/atomicSwap/swapcreator", "custom/atomicSwap/swaprecipient"]

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.22"
+const NodeVersion = "v0.10.23"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

Release for the Final Sunset Fork of Beacon Chain testnet.

### Rationale

Jul 16 14:00 height: 55569662 https://testnet-explorer.bnbchain.org/block/55569662
Ju1 15 14:00 height: 55529098 https://testnet-explorer.bnbchain.org/block/55529098

Aug 1 14:00 expected height: 55569662 + (55569662 - 55529098) * 16  = 56,218,686

### Example

NA

### Changes

Notable changes: 
* app.toml