### PR TITLE
release: release v0.10.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.10.24
+This is the release for the Final Sunset of BNB Beacon Chain Mainnet.
+
 ## v0.10.23
 This is the release for the Final Sunset of BNB Beacon Chain testnet.
 

--- a/asset/mainnet/app.toml
+++ b/asset/mainnet/app.toml
@@ -73,6 +73,8 @@ BEP255Height = 328088888
 FirstSunsetHeight = 373526985
 # Block height of BEP333 upgrade
 SecondSunsetHeight = 378062790
+# Block height of BEP333 upgrade
+FinalSunsetHeight = 384544850
 
 [addr]
 # Bech32PrefixAccAddr defines the Bech32 prefix of an account's address

--- a/version/version.go
+++ b/version/version.go
@@ -12,7 +12,7 @@ var (
 	Version string
 )
 
-const NodeVersion = "v0.10.23"
+const NodeVersion = "v0.10.24"
 
 func init() {
 	Version = fmt.Sprintf("BNB Beacon Chain Release: %s;", NodeVersion)


### PR DESCRIPTION
### Description

Release for the Final Sunset Fork of Beacon Chain Mainnet.

The final sunset hardfork of Beacon Chain will happen at Nov 19 14:00 UTC+8 time.

### Rationale

Oct 16 14:00 UTC+8 height: https://explorer.bnbchain.org/block/382821952
Oct 17 14:00 UTC+8 height: https://explorer.bnbchain.org/block/382872625

Nov 19 14:00 expected height: 382872625 + (382872625 - 382821952) * 33  ‎ = 384,544,834 

Then take 384,544,850 as the hardfork height.

### Example

NA

### Changes

Notable changes: 
* app.toml